### PR TITLE
Wrap up device memory manager to avoid unnecessary memory allocation

### DIFF
--- a/include/mirage/kernel/device_memory_manager.h
+++ b/include/mirage/kernel/device_memory_manager.h
@@ -30,8 +30,11 @@ public:
   static DeviceMemoryManager *singleton;
   DeviceMemoryManager(void);
   ~DeviceMemoryManager(void);
-  bool allocate(DTensor &tensor, bool allocate_fingerprint = true);
-  bool free(DTensor &tensor);
+  // bool allocate(DTensor &tensor, bool allocate_fingerprint = true);
+  // bool free(DTensor &tensor);
+
+  bool allocate(size_t tensor_size, void *&data_ptr);
+  bool free(void *data_ptr);
 
 public:
   static DeviceMemoryManager *get_instance();
@@ -50,6 +53,27 @@ public:
 public:
   cublasHandle_t blas;
   // cudnnHandle_t cudnn;
+};
+
+class DeviceMemoryManagerWrapper {
+public:
+  DeviceMemoryManagerWrapper();
+  ~DeviceMemoryManagerWrapper();
+
+  bool allocate(DTensor const &tensor, bool allocate_fingerprint = true);
+  bool free(DTensor const &tensor);
+  bool free_physical_memory(DTensor const &tensor);
+
+  void *get_data_ptr(size_t guid);
+  type::FPType *get_fp_ptr(size_t guid);
+
+  std::unordered_map<size_t, void *> guid2data_ptr;
+  std::unordered_map<size_t, type::FPType *> guid2fp_ptr;
+  std::unordered_map<size_t, size_t> guid2data_size;
+  std::unordered_map<size_t, size_t> guid2fp_size;
+
+  size_t offset;
+  size_t total_size;
 };
 
 } // namespace kernel

--- a/include/mirage/kernel/device_tensor.h
+++ b/include/mirage/kernel/device_tensor.h
@@ -27,62 +27,65 @@ namespace kernel {
 #define MAX_TENSOR_DIMS 4
 
 class KNOperator;
+class DeviceMemoryManagerWrapper;
 
 struct alignas(16) DTensor {
   DTensor(void);
   inline bool operator==(DTensor const &b) const {
-    if (data_type != b.data_type) {
-      return false;
-    }
-    if (layout != b.layout) {
-      return false;
-    }
-    if (num_dims != b.num_dims) {
-      return false;
-    }
-    for (int i = 0; i < num_dims; i++) {
-      if (dim[i] != b.dim[i]) {
-        return false;
-      }
-      // if (stride[i] != b.stride[i]) {
-      //   return false;
-      // }
-    }
-    if (owner_op != b.owner_op) {
-      return false;
-    }
-    if (owner_ts_idx != b.owner_ts_idx) {
-      return false;
-    }
-    assert(data_ptr == b.data_ptr);
-    return true;
+    return guid == b.guid;
+    // if (data_type != b.data_type) {
+    //   return false;
+    // }
+    // if (layout != b.layout) {
+    //   return false;
+    // }
+    // if (num_dims != b.num_dims) {
+    //   return false;
+    // }
+    // for (int i = 0; i < num_dims; i++) {
+    //   if (dim[i] != b.dim[i]) {
+    //     return false;
+    //   }
+    //   // if (stride[i] != b.stride[i]) {
+    //   //   return false;
+    //   // }
+    // }
+    // if (owner_op != b.owner_op) {
+    //   return false;
+    // }
+    // if (owner_ts_idx != b.owner_ts_idx) {
+    //   return false;
+    // }
+    // assert(data_ptr == b.data_ptr);
+    // return true;
   }
   inline bool operator!=(DTensor const &b) const {
-    if (data_type != b.data_type) {
-      return true;
-    }
-    if (layout != b.layout) {
-      return true;
-    }
-    if (num_dims != b.num_dims) {
-      return true;
-    }
-    for (int i = 0; i < num_dims; i++) {
-      if (dim[i] != b.dim[i]) {
-        return true;
-      }
-      // if (stride[i] != b.stride[i]) {
-      //   return true;
-      // }
-    }
-    if (owner_op != b.owner_op) {
-      return true;
-    }
-    if (owner_ts_idx != b.owner_ts_idx) {
-      return true;
-    }
-    assert(data_ptr == b.data_ptr);
-    return false;
+    return guid != b.guid;
+    // if (data_type != b.data_type) {
+    //   return true;
+    // }
+    // if (layout != b.layout) {
+    //   return true;
+    // }
+    // if (num_dims != b.num_dims) {
+    //   return true;
+    // }
+    // for (int i = 0; i < num_dims; i++) {
+    //   if (dim[i] != b.dim[i]) {
+    //     return true;
+    //   }
+    //   // if (stride[i] != b.stride[i]) {
+    //   //   return true;
+    //   // }
+    // }
+    // if (owner_op != b.owner_op) {
+    //   return true;
+    // }
+    // if (owner_ts_idx != b.owner_ts_idx) {
+    //   return true;
+    // }
+    // assert(data_ptr == b.data_ptr);
+    // return false;
   }
 
   inline size_t num_elements() const {
@@ -105,6 +108,9 @@ struct alignas(16) DTensor {
     return num_elements() * data_type_size;
   }
 
+  void get_data_ptr();
+  void get_fp_ptr();
+
   bool has_same_fingerprint(DTensor const &ref) const;
   mirage::type::DataType data_type;
   mirage::layout::DmemLayout layout;
@@ -119,6 +125,7 @@ struct alignas(16) DTensor {
   void *data_ptr;
   // pointer to fingerprint
   mirage::type::FPType *fp_ptr;
+  DeviceMemoryManagerWrapper *dmm;
 
   static int next_guid;
 };

--- a/include/mirage/kernel/device_tensor.h
+++ b/include/mirage/kernel/device_tensor.h
@@ -27,65 +27,39 @@ namespace kernel {
 #define MAX_TENSOR_DIMS 4
 
 class KNOperator;
-class DeviceMemoryManagerWrapper;
+class DeviceMemoryOffsetManager;
 
 struct alignas(16) DTensor {
   DTensor(void);
   inline bool operator==(DTensor const &b) const {
-    return guid == b.guid;
-    // if (data_type != b.data_type) {
-    //   return false;
-    // }
-    // if (layout != b.layout) {
-    //   return false;
-    // }
-    // if (num_dims != b.num_dims) {
-    //   return false;
-    // }
-    // for (int i = 0; i < num_dims; i++) {
-    //   if (dim[i] != b.dim[i]) {
-    //     return false;
-    //   }
-    //   // if (stride[i] != b.stride[i]) {
-    //   //   return false;
-    //   // }
-    // }
-    // if (owner_op != b.owner_op) {
-    //   return false;
-    // }
-    // if (owner_ts_idx != b.owner_ts_idx) {
-    //   return false;
-    // }
-    // assert(data_ptr == b.data_ptr);
-    // return true;
+    if (data_type != b.data_type) {
+      return false;
+    }
+    if (layout != b.layout) {
+      return false;
+    }
+    if (num_dims != b.num_dims) {
+      return false;
+    }
+    for (int i = 0; i < num_dims; i++) {
+      if (dim[i] != b.dim[i]) {
+        return false;
+      }
+      // if (stride[i] != b.stride[i]) {
+      //   return false;
+      // }
+    }
+    if (owner_op != b.owner_op) {
+      return false;
+    }
+    if (owner_ts_idx != b.owner_ts_idx) {
+      return false;
+    }
+    assert(data_offset == b.data_offset);
+    return true;
   }
   inline bool operator!=(DTensor const &b) const {
-    return guid != b.guid;
-    // if (data_type != b.data_type) {
-    //   return true;
-    // }
-    // if (layout != b.layout) {
-    //   return true;
-    // }
-    // if (num_dims != b.num_dims) {
-    //   return true;
-    // }
-    // for (int i = 0; i < num_dims; i++) {
-    //   if (dim[i] != b.dim[i]) {
-    //     return true;
-    //   }
-    //   // if (stride[i] != b.stride[i]) {
-    //   //   return true;
-    //   // }
-    // }
-    // if (owner_op != b.owner_op) {
-    //   return true;
-    // }
-    // if (owner_ts_idx != b.owner_ts_idx) {
-    //   return true;
-    // }
-    // assert(data_ptr == b.data_ptr);
-    // return false;
+    return !(*this == b);
   }
 
   inline size_t num_elements() const {
@@ -108,9 +82,6 @@ struct alignas(16) DTensor {
     return num_elements() * data_type_size;
   }
 
-  void get_data_ptr();
-  void get_fp_ptr();
-
   bool has_same_fingerprint(DTensor const &ref) const;
   mirage::type::DataType data_type;
   mirage::layout::DmemLayout layout;
@@ -121,11 +92,14 @@ struct alignas(16) DTensor {
   //  DTensor fields
   KNOperator *owner_op;
   int owner_ts_idx;
+  off_t data_offset;
+  off_t fp_offset;
   // pointer to data
   void *data_ptr;
   // pointer to fingerprint
   mirage::type::FPType *fp_ptr;
-  DeviceMemoryManagerWrapper *dmm;
+
+  DeviceMemoryOffsetManager *dmm;
 
   static int next_guid;
 };

--- a/include/mirage/kernel/graph.h
+++ b/include/mirage/kernel/graph.h
@@ -84,6 +84,7 @@ public:
   // std::unordered_map<std::pair<int, int>, std::pair<int, int>, pair_hash>
   // edges; std::vector<std::vector<SrcEdge>> edges;
   // mirage::kernel::OperatorFactory *operator_factory;
+  DeviceMemoryManagerWrapper *dmm;
 };
 
 void to_json(json &j, Graph const &g);

--- a/include/mirage/kernel/graph.h
+++ b/include/mirage/kernel/graph.h
@@ -33,6 +33,7 @@ private:
 
 public:
   Graph(void);
+  ~Graph();
   // input operator
   DTensor new_input(std::vector<int> const &dims,
                     mirage::type::DataType data_type,
@@ -77,6 +78,12 @@ public:
                                   mirage::threadblock::Graph const &_graph);
   KNOperator *create_customized_op(std::vector<DTensor> const &inputs,
                                    mirage::threadblock::Graph const &_graph);
+  // memory management
+  void allocate_all_tensors(bool allocate_fingerprint = true);
+  void free_all_tensors();
+  DeviceMemoryOffsetManager *dmm;
+  // profile
+  ProfileResult profile();
   // helper functions
   void generate_triton_program(char const *filepath);
   std::vector<mirage::kernel::KNOperator *> operators;
@@ -84,7 +91,6 @@ public:
   // std::unordered_map<std::pair<int, int>, std::pair<int, int>, pair_hash>
   // edges; std::vector<std::vector<SrcEdge>> edges;
   // mirage::kernel::OperatorFactory *operator_factory;
-  DeviceMemoryManagerWrapper *dmm;
 };
 
 void to_json(json &j, Graph const &g);

--- a/include/mirage/kernel/operator.h
+++ b/include/mirage/kernel/operator.h
@@ -47,7 +47,7 @@ public:
   KNInputOp(std::vector<int> const &dims,
             mirage::type::DataType data_type,
             mirage::layout::DmemLayout layout,
-            DeviceMemoryManagerWrapper *dmm);
+            DeviceMemoryOffsetManager *dmm);
   ~KNInputOp();
   bool profile(ProfileResult &profile);
   bool fingerprint(void);

--- a/include/mirage/kernel/operator.h
+++ b/include/mirage/kernel/operator.h
@@ -46,7 +46,8 @@ class KNInputOp : public KNOperator {
 public:
   KNInputOp(std::vector<int> const &dims,
             mirage::type::DataType data_type,
-            mirage::layout::DmemLayout layout);
+            mirage::layout::DmemLayout layout,
+            DeviceMemoryManagerWrapper *dmm);
   ~KNInputOp();
   bool profile(ProfileResult &profile);
   bool fingerprint(void);

--- a/include/mirage/search/search.h
+++ b/include/mirage/search/search.h
@@ -128,7 +128,7 @@ private:
   void fingerprint_eval();
   bool have_same_fingerprint(std::vector<DTensor> const &outputs,
                              std::vector<int> const &match) const;
-  bool verify(SearchContext<DTensor> &c, kernel::Graph const &g);
+  bool verify(SearchContext<DTensor> &c, kernel::Graph &g);
   void recovery_from_checkpoint(Checkpoint const &checkpoint);
 };
 

--- a/include/mirage/utils/containers.h
+++ b/include/mirage/utils/containers.h
@@ -41,3 +41,21 @@ std::vector<T> to_vector(int n, T *arr) {
   }
   return v;
 }
+
+template <typename T>
+struct _reversed {
+  T& iter;
+
+  auto begin() const {
+    return iter.rbegin();
+  }
+
+  auto end() const {
+    return iter.rend();
+  }
+};
+
+template <typename T>
+_reversed<T> reversed(T &&iter) {
+  return _reversed<T>{iter};
+}

--- a/src/kernel/customized.cc
+++ b/src/kernel/customized.cc
@@ -68,7 +68,7 @@ KNCustomizedOp::KNCustomizedOp(std::vector<DTensor> const &_inputs,
              _plan.block_dim,
              _plan.forloop_range,
              _plan.reduction_dimx) {
-  DeviceMemoryManagerWrapper *dmm = _inputs[0].dmm;
+  DeviceMemoryOffsetManager *dmm = _inputs[0].dmm;
   assert(_inputs.size() == plan.input_map.size());
   assert(plan.forloop_dim.size() == plan.input_map.size());
   assert(plan.input_smem_layouts.size() == plan.input_map.size());
@@ -201,7 +201,7 @@ KNCustomizedOp::KNCustomizedOp(std::vector<DTensor> const &_inputs,
   plan.forloop_range = _graph.forloop_range;
   plan.reduction_dimx = _graph.reduction_dimx;
 
-  DeviceMemoryManagerWrapper *dmm = _inputs[0].dmm;
+  DeviceMemoryOffsetManager *dmm = _inputs[0].dmm;
 
   for (auto const &op : _graph.operators) {
     std::vector<STensor> my_inputs;

--- a/src/kernel/device_memory_manager.cc
+++ b/src/kernel/device_memory_manager.cc
@@ -1,0 +1,119 @@
+/* Copyright 2023-2024 CMU
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mirage/kernel/device_memory_manager.h"
+#include "mirage/utils/containers.h"
+
+namespace mirage {
+namespace kernel {
+
+DeviceMemoryManagerWrapper::DeviceMemoryManagerWrapper() : offset(0) {
+  DeviceMemoryManager *dmm = DeviceMemoryManager::get_instance();
+  total_size = dmm->total_size;
+}
+DeviceMemoryManagerWrapper::~DeviceMemoryManagerWrapper() {}
+
+bool DeviceMemoryManagerWrapper::allocate(DTensor const &tensor,
+                                          bool allocate_fingerprint) {
+  assert(offset % 16 == 0);
+  size_t data_size = tensor.data_size();
+  data_size = (data_size + 15) / 16 * 16;
+  if (offset + data_size > total_size) {
+    return false;
+  }
+  offset += data_size;
+  guid2data_size[tensor.guid] = data_size;
+
+  if (allocate_fingerprint) {
+    assert(offset % 16 == 0);
+    size_t fingerprint_size = tensor.fingerprint_size();
+    fingerprint_size = (fingerprint_size + 15) / 16 * 16;
+    if (offset + fingerprint_size > total_size) {
+      return false;
+    }
+    offset += fingerprint_size;
+    guid2fp_size[tensor.guid] = fingerprint_size;
+  }
+
+  return true;
+}
+
+bool DeviceMemoryManagerWrapper::free(DTensor const &tensor) {
+  assert(offset % 16 == 0);
+  assert(contains_key(guid2data_size, tensor.guid));
+  size_t data_size = guid2data_size.at(tensor.guid);
+  assert(offset >= data_size);
+  offset -= data_size;
+  if (contains_key(guid2data_ptr, tensor.guid)) {
+    DeviceMemoryManager *dmm = DeviceMemoryManager::get_instance();
+    dmm->free(guid2data_ptr.at(tensor.guid));
+  }
+
+  if (contains_key(guid2fp_size, tensor.guid)) {
+    assert(offset % 16 == 0);
+    size_t fingerprint_size = guid2fp_size.at(tensor.guid);
+    assert(offset >= fingerprint_size);
+    offset -= fingerprint_size;
+    if (contains_key(guid2fp_ptr, tensor.guid)) {
+      DeviceMemoryManager *dmm = DeviceMemoryManager::get_instance();
+      dmm->free(guid2fp_ptr.at(tensor.guid));
+    }
+  }
+
+  return true;
+}
+
+bool DeviceMemoryManagerWrapper::free_physical_memory(DTensor const &tensor) {
+  DeviceMemoryManager *dmm = DeviceMemoryManager::get_instance();
+
+  if (contains_key(guid2fp_ptr, tensor.guid)) {
+    dmm->free(guid2fp_ptr.at(tensor.guid));
+  }
+
+  if (contains_key(guid2data_ptr, tensor.guid)) {
+    dmm->free(guid2data_ptr.at(tensor.guid));
+  }
+
+  return true;
+}
+
+void *DeviceMemoryManagerWrapper::get_data_ptr(size_t guid) {
+  if (contains_key(guid2data_ptr, guid)) {
+    return guid2data_ptr.at(guid);
+  }
+
+  assert(contains_key(guid2data_size, guid));
+  DeviceMemoryManager *dmm = DeviceMemoryManager::get_instance();
+  void *data_ptr = nullptr;
+  dmm->allocate(guid2data_size.at(guid), data_ptr);
+  guid2data_ptr[guid] = data_ptr;
+  return data_ptr;
+}
+
+type::FPType *DeviceMemoryManagerWrapper::get_fp_ptr(size_t guid) {
+  if (contains_key(guid2fp_ptr, guid)) {
+    return guid2fp_ptr.at(guid);
+  }
+
+  assert(contains_key(guid2fp_ptr, guid));
+  DeviceMemoryManager *dmm = DeviceMemoryManager::get_instance();
+  void *fp_ptr = nullptr;
+  dmm->allocate(guid2fp_size.at(guid), fp_ptr);
+  guid2fp_ptr[guid] = (type::FPType *)fp_ptr;
+  return (type::FPType *)fp_ptr;
+}
+
+} // namespace kernel
+} // namespace mirage

--- a/src/kernel/device_memory_manager.cu
+++ b/src/kernel/device_memory_manager.cu
@@ -95,43 +95,63 @@ DeviceMemoryManager::~DeviceMemoryManager() {
   checkCUDA(cublasDestroy(blas));
 }
 
-bool DeviceMemoryManager::allocate(DTensor &tensor, bool allocate_fingerprint) {
-  // assert that the start of the tensor is 16 bytes aligned
+// bool DeviceMemoryManager::allocate(DTensor &tensor, bool
+// allocate_fingerprint) {
+//   // assert that the start of the tensor is 16 bytes aligned
+//   assert(offset % 16 == 0);
+//   void *ret_ptr = base_ptr + offset;
+//   size_t tensor_size = tensor.data_size();
+//   // make tensor_size a multiplier of 16
+//   tensor_size = (tensor_size + 15) / 16 * 16;
+//   offset += tensor_size;
+//   tensor.data_ptr = ret_ptr;
+//   allocated_tensors.push_back(std::make_pair(ret_ptr, tensor_size));
+
+//   if (allocate_fingerprint) {
+//     assert(offset % 16 == 0);
+//     ret_ptr = base_ptr + offset;
+//     size_t tensor_size = tensor.fingerprint_size();
+//     tensor_size = (tensor_size + 15) / 16 * 16;
+//     offset += tensor_size;
+//     tensor.fp_ptr = (mirage::type::FPType *)ret_ptr;
+//     allocated_tensors.push_back(std::make_pair(ret_ptr, tensor_size));
+//   }
+//   // Assert that we haven't used more than what we pre-allocated
+//   assert(offset <= total_size);
+
+//   return true;
+// }
+
+bool DeviceMemoryManager::allocate(size_t tensor_size, void *&data_ptr) {
   assert(offset % 16 == 0);
   void *ret_ptr = base_ptr + offset;
-  size_t tensor_size = tensor.data_size();
-  // make tensor_size a multiplier of 16
   tensor_size = (tensor_size + 15) / 16 * 16;
   offset += tensor_size;
-  tensor.data_ptr = ret_ptr;
+  data_ptr = ret_ptr;
   allocated_tensors.push_back(std::make_pair(ret_ptr, tensor_size));
-
-  if (allocate_fingerprint) {
-    assert(offset % 16 == 0);
-    ret_ptr = base_ptr + offset;
-    size_t tensor_size = tensor.fingerprint_size();
-    tensor_size = (tensor_size + 15) / 16 * 16;
-    offset += tensor_size;
-    tensor.fp_ptr = (mirage::type::FPType *)ret_ptr;
-    allocated_tensors.push_back(std::make_pair(ret_ptr, tensor_size));
-  }
-  // Assert that we haven't used more than what we pre-allocated
-  assert(offset <= total_size);
 
   return true;
 }
 
-bool DeviceMemoryManager::free(DTensor &tensor) {
-  // Currently assume that tensors are freed in the reverse order
-  // so ptr must be the last tensor we have created
-  if (tensor.fp_ptr != nullptr) {
-    assert(allocated_tensors.size() > 0);
-    assert(allocated_tensors.back().first == tensor.fp_ptr);
-    offset -= allocated_tensors.back().second;
-    allocated_tensors.pop_back();
-  }
+// bool DeviceMemoryManager::free(DTensor &tensor) {
+//   // Currently assume that tensors are freed in the reverse order
+//   // so ptr must be the last tensor we have created
+//   if (tensor.fp_ptr != nullptr) {
+//     assert(allocated_tensors.size() > 0);
+//     assert(allocated_tensors.back().first == tensor.fp_ptr);
+//     offset -= allocated_tensors.back().second;
+//     allocated_tensors.pop_back();
+//   }
+//   assert(allocated_tensors.size() > 0);
+//   assert(allocated_tensors.back().first == tensor.data_ptr);
+//   offset -= allocated_tensors.back().second;
+//   allocated_tensors.pop_back();
+//   return true;
+// }
+
+bool DeviceMemoryManager::free(void *data_ptr) {
   assert(allocated_tensors.size() > 0);
-  assert(allocated_tensors.back().first == tensor.data_ptr);
+  assert(allocated_tensors.back().first == data_ptr);
   offset -= allocated_tensors.back().second;
   allocated_tensors.pop_back();
   return true;

--- a/src/kernel/device_tensor.cc
+++ b/src/kernel/device_tensor.cc
@@ -33,14 +33,8 @@ DTensor::DTensor() {
   owner_ts_idx = -1000;
   data_ptr = nullptr;
   fp_ptr = nullptr;
-}
-
-void DTensor::get_data_ptr() {
-  data_ptr = dmm->get_data_ptr(guid);
-}
-
-void DTensor::get_fp_ptr() {
-  fp_ptr = dmm->get_fp_ptr(guid);
+  data_offset = -1;
+  fp_offset = -1;
 }
 
 /*

--- a/src/kernel/device_tensor.cc
+++ b/src/kernel/device_tensor.cc
@@ -14,6 +14,7 @@
  */
 
 #include "mirage/kernel/device_tensor.h"
+#include "mirage/kernel/device_memory_manager.h"
 #include "mirage/utils/hash_utils.h"
 #include <functional>
 
@@ -31,6 +32,15 @@ DTensor::DTensor() {
   owner_op = nullptr;
   owner_ts_idx = -1000;
   data_ptr = nullptr;
+  fp_ptr = nullptr;
+}
+
+void DTensor::get_data_ptr() {
+  data_ptr = dmm->get_data_ptr(guid);
+}
+
+void DTensor::get_fp_ptr() {
+  fp_ptr = dmm->get_fp_ptr(guid);
 }
 
 /*
@@ -64,7 +74,7 @@ size_t hash<mirage::kernel::DTensor>::operator()(
   }
   hash_combine(ret, tensor.owner_op);
   hash_combine(ret, tensor.owner_ts_idx);
-  hash_combine(ret, tensor.data_ptr);
+  hash_combine(ret, tensor.guid);
   return ret;
 }
 

--- a/src/kernel/element_binary.cc
+++ b/src/kernel/element_binary.cc
@@ -71,7 +71,6 @@ DTensor *Graph::div(DTensor const *input1, DTensor const *input2) {
 KNOperator *Graph::create_elementbinary_op(DTensor const &input1,
                                            DTensor const &input2,
                                            mirage::type::KNOperatorType type) {
-  DeviceMemoryManager *dmm = DeviceMemoryManager::get_instance();
   if (input1.num_dims != input2.num_dims) {
     return nullptr;
   }
@@ -111,16 +110,15 @@ KNElementBinaryOp::KNElementBinaryOp(DTensor const &input1,
   output.owner_op = this;
   output.owner_ts_idx = 0;
   output.guid = DTensor::next_guid++;
-  DeviceMemoryManager *dmm = DeviceMemoryManager::get_instance();
-  dmm->allocate(output);
+  output.dmm = input1.dmm;
+  output.dmm->allocate(output);
   assert(output_tensors.size() == 0);
   output_tensors.push_back(output);
 }
 
 KNElementBinaryOp::~KNElementBinaryOp() {
-  DeviceMemoryManager *dmm = DeviceMemoryManager::get_instance();
   for (int i = output_tensors.size() - 1; i >= 0; i--) {
-    dmm->free(output_tensors[i]);
+    output_tensors[i].dmm->free(output_tensors[i]);
   }
 }
 

--- a/src/kernel/element_unary.cc
+++ b/src/kernel/element_unary.cc
@@ -42,7 +42,6 @@ DTensor *Graph::exp(DTensor const *input) {
 
 KNOperator *Graph::create_elementunary_op(DTensor const &input,
                                           mirage::type::KNOperatorType type) {
-  DeviceMemoryManager *dmm = DeviceMemoryManager::get_instance();
   if (dmm->offset + input.data_size() > dmm->total_size) {
     return nullptr;
   }
@@ -58,16 +57,15 @@ KNElementUnaryOp::KNElementUnaryOp(DTensor const &input,
   output.owner_op = this;
   output.owner_ts_idx = 0;
   output.guid = DTensor::next_guid++;
-  DeviceMemoryManager *dmm = DeviceMemoryManager::get_instance();
-  dmm->allocate(output);
+  output.dmm = input.dmm;
+  output.dmm->allocate(output);
   assert(output_tensors.size() == 0);
   output_tensors.push_back(output);
 }
 
 KNElementUnaryOp::~KNElementUnaryOp() {
-  DeviceMemoryManager *dmm = DeviceMemoryManager::get_instance();
   for (int i = output_tensors.size() - 1; i >= 0; i--) {
-    dmm->free(output_tensors[i]);
+    output_tensors[i].dmm->free(output_tensors[i]);
   }
 }
 

--- a/src/kernel/graph.cc
+++ b/src/kernel/graph.cc
@@ -14,6 +14,7 @@
  */
 
 #include "mirage/kernel/graph.h"
+#include "mirage/kernel/device_memory_manager.h"
 #include "mirage/utils/hash_utils.h"
 
 #include <iostream>
@@ -21,7 +22,9 @@
 namespace mirage {
 namespace kernel {
 
-Graph::Graph() {}
+Graph::Graph() {
+  dmm = new DeviceMemoryManagerWrapper();
+}
 
 size_t Graph::pair_hash::operator()(std::pair<int, int> const &p) const {
   size_t h1 = std::hash<int>{}(p.first);

--- a/src/kernel/matmul.cc
+++ b/src/kernel/matmul.cc
@@ -89,16 +89,15 @@ KNMatmulOp::KNMatmulOp(DTensor const &A, DTensor const &B)
   C.owner_op = this;
   C.owner_ts_idx = 0;
   C.guid = DTensor::next_guid++;
-  DeviceMemoryManager *dmm = DeviceMemoryManager::get_instance();
-  dmm->allocate(C);
+  C.dmm = A.dmm;
+  C.dmm->allocate(C);
   assert(output_tensors.size() == 0);
   output_tensors.push_back(C);
 }
 
 KNMatmulOp::~KNMatmulOp() {
-  DeviceMemoryManager *dmm = DeviceMemoryManager::get_instance();
   for (int i = output_tensors.size() - 1; i >= 0; i--) {
-    dmm->free(output_tensors[i]);
+    output_tensors[i].dmm->free(output_tensors[i]);
   }
 }
 

--- a/src/kernel/operator.cc
+++ b/src/kernel/operator.cc
@@ -84,7 +84,7 @@ KNOperator *Graph::create_input_op(std::vector<int> const &dims,
 KNInputOp::KNInputOp(std::vector<int> const &dims,
                      mirage::type::DataType data_type,
                      mirage::layout::DmemLayout layout,
-                     DeviceMemoryManagerWrapper *dmm)
+                     DeviceMemoryOffsetManager *dmm)
     : KNOperator(mirage::type::KN_INPUT_OP) {
   DTensor tensor;
   tensor.num_dims = dims.size();

--- a/src/kernel/reduction.cc
+++ b/src/kernel/reduction.cc
@@ -50,7 +50,6 @@ KNOperator *
   if (input.dim[dim] % size != 0) {
     return nullptr;
   }
-  DeviceMemoryManager *dmm = DeviceMemoryManager::get_instance();
   if (dmm->offset + input.data_size() > dmm->total_size) {
     return nullptr;
   }
@@ -69,16 +68,15 @@ KNReductionOp::KNReductionOp(DTensor const &input, int dim, int size)
   output.owner_op = this;
   output.owner_ts_idx = 0;
   output.guid = DTensor::next_guid++;
-  DeviceMemoryManager *dmm = DeviceMemoryManager::get_instance();
-  dmm->allocate(output);
+  output.dmm = input.dmm;
+  output.dmm->allocate(output);
   assert(output_tensors.size() == 0);
   output_tensors.push_back(output);
 }
 
 KNReductionOp::~KNReductionOp() {
-  DeviceMemoryManager *dmm = DeviceMemoryManager::get_instance();
   for (int i = output_tensors.size() - 1; i >= 0; i--) {
-    dmm->free(output_tensors[i]);
+    output_tensors[i].dmm->free(output_tensors[i]);
   }
 }
 


### PR DESCRIPTION
This PR closes #5. It implements a wrapper upon the device memory manager that only calculates the memory consumption when a tensor is created and allocates the actual physical memory only when necessary (i.e., profiling and fingerprint checking).

It also helps reduce side effects of graph operator generation, which is important for parallelizing the search procedure.

TODO:

- [ ] Free memory after profiling and fingerprint checking.
- [ ] Pass existing examples.