### PR TITLE
[fix] Use `constexpr` instead of `define` to define MAX_TENSOR_DIMS

### DIFF
--- a/include/mirage/cpu/cmem_tensor.h
+++ b/include/mirage/cpu/cmem_tensor.h
@@ -23,7 +23,7 @@
 namespace mirage {
 namespace cpu {
 
-#define MAX_TENSOR_DIMS 4
+constexpr int MAX_TENSOR_DIMS = 4;
 
 struct CTensor {
   CTensor(void) {

--- a/include/mirage/kernel/device_tensor.h
+++ b/include/mirage/kernel/device_tensor.h
@@ -26,7 +26,7 @@
 namespace mirage {
 namespace kernel {
 
-#define MAX_TENSOR_DIMS 4
+constexpr int MAX_TENSOR_DIMS = 4;
 
 class KNOperator;
 

--- a/include/mirage/threadblock/smem_tensor.h
+++ b/include/mirage/threadblock/smem_tensor.h
@@ -26,7 +26,7 @@
 namespace mirage {
 namespace threadblock {
 
-#define MAX_TENSOR_DIMS 4
+constexpr int MAX_TENSOR_DIMS = 4;
 
 class TBOperator;
 

--- a/src/kernel/cuda/customized_kernel.cu
+++ b/src/kernel/cuda/customized_kernel.cu
@@ -657,7 +657,7 @@ void KNCustomizedOp::run() {
 }
 
 bool KNCustomizedOp::profile(ProfileResult &result) {
-  printf("smem_offset = %d\n", bgraph.smem_offset);
+  printf("smem_offset = %ld\n", bgraph.smem_offset);
   int max_smem_size = mirage::config::MAX_SMEM_SIZE;
   assert(bgraph.smem_offset <= max_smem_size);
   if (bgraph.smem_offset > 48 * 1024) {


### PR DESCRIPTION
Previously we use `#define` to define `MAX_TENSOR_DIMS` in `cmem_tensor.h`, `device_tensor.h`, and `smem_tensor.h`. This may cause unexpected behaviour when we include two or more these files, since `#define` is not controlled by namespace. This may cause potential bug when `MAX_TENSOR_DIMS` are not the same among those files.

In this commit I use `constexpr` to define `MAX_TENSOR_DIMS`, which won't cause this problem.