### PR TITLE
[Deprecate ExecutionPlan] Initial attempt to make ExecutionPlan deprecated

### DIFF
--- a/include/mirage/kernel/customized.h
+++ b/include/mirage/kernel/customized.h
@@ -27,9 +27,9 @@ namespace kernel {
 
 class KNCustomizedOp : public mirage::kernel::KNOperator {
 public:
-  KNCustomizedOp(Graph *_kgraph,
-                 std::vector<DTensor> const &inputs,
-                 mirage::threadblock::ExecutionPlan const &plan);
+  //KNCustomizedOp(Graph *_kgraph,
+  //               std::vector<DTensor> const &inputs,
+  //               mirage::threadblock::ExecutionPlan const &plan);
   KNCustomizedOp(Graph *_kgraph,
                  std::vector<DTensor> const &inputs,
                  mirage::threadblock::Graph const &_graph);
@@ -41,7 +41,7 @@ public:
   operator json() const override;
 
 public:
-  mirage::threadblock::ExecutionPlan plan;
+  // mirage::threadblock::ExecutionPlan plan;
   mirage::threadblock::Graph bgraph;
 };
 

--- a/include/mirage/kernel/graph.h
+++ b/include/mirage/kernel/graph.h
@@ -96,12 +96,12 @@ public:
   DTensor *all_reduce(DTensor const *input, bool inplace = true);
   KNOperator *create_all_reduce_op(DTensor const &input, bool inplace);
   // customized operator
-  std::vector<DTensor>
-      customized(std::vector<DTensor> const &inputs,
-                 mirage::threadblock::ExecutionPlan const &plan);
-  KNOperator *
-      create_customized_op(std::vector<DTensor> const &inputs,
-                           mirage::threadblock::ExecutionPlan const &plan);
+  //std::vector<DTensor>
+  //    customized(std::vector<DTensor> const &inputs,
+  //               mirage::threadblock::ExecutionPlan const &plan);
+  //KNOperator *
+  //    create_customized_op(std::vector<DTensor> const &inputs,
+  //                         mirage::threadblock::ExecutionPlan const &plan);
   std::vector<DTensor> customized(std::vector<DTensor> const &inputs,
                                   mirage::threadblock::Graph const &_graph);
   KNOperator *create_customized_op(std::vector<DTensor> const &inputs,

--- a/src/kernel/customized.cc
+++ b/src/kernel/customized.cc
@@ -29,19 +29,27 @@ namespace kernel {
 using mirage::threadblock::ExecutionPlan;
 using mirage::threadblock::STensor;
 
+//std::vector<DTensor> Graph::customized(std::vector<DTensor> const &inputs,
+//                                       ExecutionPlan const &plan) {
+//  KNOperator *op = create_customized_op(inputs, plan);
+//  assert(op != nullptr);
+//  operators.push_back(op);
+//  return op->output_tensors;
+//}
+
 std::vector<DTensor> Graph::customized(std::vector<DTensor> const &inputs,
-                                       ExecutionPlan const &plan) {
-  KNOperator *op = create_customized_op(inputs, plan);
+                                       threadblock::Graph const &bgraph) {
+  KNOperator *op = create_customized_op(inputs, bgraph);
   assert(op != nullptr);
   operators.push_back(op);
   return op->output_tensors;
 }
 
-KNOperator *Graph::create_customized_op(std::vector<DTensor> const &inputs,
-                                        ExecutionPlan const &plan) {
-  KNCustomizedOp *op = new KNCustomizedOp(this, inputs, plan);
-  return op;
-}
+// KNOperator *Graph::create_customized_op(std::vector<DTensor> const &inputs,
+//                                         ExecutionPlan const &plan) {
+//   KNCustomizedOp *op = new KNCustomizedOp(this, inputs, plan);
+//   return op;
+// }
 
 KNOperator *Graph::create_customized_op(std::vector<DTensor> const &inputs,
                                         threadblock::Graph const &_graph) {
@@ -63,6 +71,7 @@ KNOperator *Graph::create_customized_op(std::vector<DTensor> const &inputs,
   return op;
 }
 
+#ifdef DEADCODE
 KNCustomizedOp::KNCustomizedOp(Graph *_kgraph,
                                std::vector<DTensor> const &_inputs,
                                ExecutionPlan const &_plan)
@@ -200,6 +209,7 @@ KNCustomizedOp::KNCustomizedOp(Graph *_kgraph,
     }
   }
 }
+#endif
 
 KNCustomizedOp::KNCustomizedOp(mirage::kernel::Graph *_kgraph,
                                std::vector<DTensor> const &_inputs,
@@ -209,10 +219,10 @@ KNCustomizedOp::KNCustomizedOp(mirage::kernel::Graph *_kgraph,
              _graph.block_dim,
              _graph.forloop_range,
              _graph.reduction_dimx) {
-  plan.grid_dim = _graph.grid_dim;
-  plan.block_dim = _graph.block_dim;
-  plan.forloop_range = _graph.forloop_range;
-  plan.reduction_dimx = _graph.reduction_dimx;
+  //plan.grid_dim = _graph.grid_dim;
+  //plan.block_dim = _graph.block_dim;
+  //plan.forloop_range = _graph.forloop_range;
+  //plan.reduction_dimx = _graph.reduction_dimx;
 
   for (auto const &op : _graph.operators) {
     std::vector<STensor> my_inputs;
@@ -231,7 +241,7 @@ KNCustomizedOp::KNCustomizedOp(mirage::kernel::Graph *_kgraph,
     }
     if (op->op_type != mirage::type::TB_INPUT_OP &&
         op->op_type != mirage::type::TB_OUTPUT_OP) {
-      plan.ops.push_back({op->op_type, indices});
+      //plan.ops.push_back({op->op_type, indices});
     }
     switch (op->op_type) {
       case mirage::type::TB_INPUT_OP: {
@@ -242,9 +252,9 @@ KNCustomizedOp::KNCustomizedOp(mirage::kernel::Graph *_kgraph,
                          input_op->input_map,
                          input_op->forloop_dim,
                          input_op->output_tensors[0].layout);
-        plan.input_map.push_back(input_op->input_map);
-        plan.input_forloop_dim.push_back(input_op->forloop_dim);
-        plan.input_smem_layouts.push_back(input_op->output_tensors[0].layout);
+        //plan.input_map.push_back(input_op->input_map);
+        //plan.input_forloop_dim.push_back(input_op->forloop_dim);
+        //plan.input_smem_layouts.push_back(input_op->output_tensors[0].layout);
         break;
       }
       case mirage::type::TB_OUTPUT_OP: {
@@ -271,7 +281,7 @@ KNCustomizedOp::KNCustomizedOp(mirage::kernel::Graph *_kgraph,
           output->dtensor = dtensor;
         }
         output_tensors.push_back(dtensor);
-        plan.output_map = output_op->output_map;
+        //plan.output_map = output_op->output_map;
         break;
       }
       case mirage::type::TB_MATMUL_OP: {
@@ -287,14 +297,11 @@ KNCustomizedOp::KNCustomizedOp(mirage::kernel::Graph *_kgraph,
         bgraph.elementunary(my_inputs[0], op->op_type);
         break;
       }
-      case mirage::type::TB_ADD_OP: {
-        assert(my_inputs.size() == 2);
-        bgraph.add(my_inputs[0], my_inputs[1]);
-        break;
-      }
+      case mirage::type::TB_ADD_OP:
+      case mirage::type::TB_MUL_OP:
       case mirage::type::TB_DIV_OP: {
         assert(my_inputs.size() == 2);
-        bgraph.div(my_inputs[0], my_inputs[1]);
+        bgraph.elementbinary(my_inputs[0], my_inputs[1], op->op_type);
         break;
       }
       case mirage::type::TB_REDUCTION_0_OP:
@@ -321,6 +328,14 @@ KNCustomizedOp::KNCustomizedOp(mirage::kernel::Graph *_kgraph,
         bgraph.concat(my_inputs[0], my_inputs[1], concat_dim);
         break;
       }
+      case mirage::type::TB_FORLOOP_ACCUM_NO_RED_OP:
+      case mirage::type::TB_FORLOOP_ACCUM_RED_LD_SUM_OP:
+      case mirage::type::TB_FORLOOP_ACCUM_RED_LD_MEAN_OP:
+      case mirage::type::TB_FORLOOP_ACCUM_RED_LD_RMS_OP: {
+        assert(my_inputs.size() == 1);
+        bgraph.forloop_accum(my_inputs[0], op->op_type);
+        break;
+      }
       default: {
         assert(false && "Unsupported kernel operator");
       }
@@ -343,8 +358,7 @@ KNCustomizedOp::operator json() const {
   return json{{"op_type", op_type},
               {"input_tensors", input_tensors},
               {"output_tensors", output_tensors},
-              {"bgraph", bgraph},
-              {"plan", plan}};
+              {"bgraph", bgraph}};
 }
 
 } // namespace kernel

--- a/src/kernel/graph.cc
+++ b/src/kernel/graph.cc
@@ -220,7 +220,8 @@ void from_json(json const &j, Graph &g) {
         }
         threadblock::ExecutionPlan plan;
         jop.at("plan").get_to(plan);
-        std::vector<DTensor> outputs = g.customized(inputs, plan);
+        threadblock::Graph bgraph(inputs, plan);
+        std::vector<DTensor> outputs = g.customized(inputs, bgraph);
         for (size_t i = 0; i < outputs.size(); ++i) {
           size_t guidO;
           jop.at("output_tensors")[i].at("guid").get_to(guidO);


### PR DESCRIPTION
This PR aims to remove all usage of ExecutionPlan in Mirage. ExecutionPlan are functionally equivalent to threadblock::Graph.