### PR TITLE
Include header files for JIT compilation. MIRAGE_ROOT is no longer required.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -46,7 +46,7 @@ All dependenices will be automatically installed.
 ### Install the Mirage python package from Pypi
 We also provide the latest version of Mirage on Pypi. Install by running:
 ```bash
-pip install mirage
+pip install mirage-project
 ```
 
 ### Check your installation

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,6 +8,7 @@ recursive-include cmake *
 recursive-include src *
 
 recursive-include python/mirage/_cython *.pyx *.pxd
+recursive-include python/mirage/include *
 
 recursive-include deps/cutlass *
 recursive-include deps/json *

--- a/python/mirage/kernel.py
+++ b/python/mirage/kernel.py
@@ -155,7 +155,8 @@ class KNGraph:
                                        output_tensors=kwargs.get("outputs", []))
         # print(result)
         
-        MIRAGE_ROOT = os.environ.get('MIRAGE_ROOT', './')
+        MIRAGE_ROOT = os.environ.get('MIRAGE_ROOT', 
+                                     os.path.join(os.path.dirname(__file__), 'include'))
         
         # if True:
         #     tempdir = './test/'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 cmake>=3.24
 cython>=0.28
 z3-solver
+# torch>=2.0
 numpy


### PR DESCRIPTION
If env `MIRAGE_ROOT` is not set, it will search header files in the mirage package directory, where all necessary runtime headers are already included. 

Test:
Install mirage in a new python environment, and run `demo/demo_jit.py`. May also need torch.