### PR TITLE
Set default strides for outputs

### DIFF
--- a/src/kernel/output.cc
+++ b/src/kernel/output.cc
@@ -20,14 +20,22 @@
 namespace mirage {
 namespace kernel {
 
+std::vector<size_t> get_default_strides(DTensor const &A) {
+  std::vector<size_t> strides(A.num_dims);
+  size_t stride = 1;
+  for (int i = A.num_dims - 1; i >= 0; --i) {
+    strides[i] = stride;
+    stride *= A.dim[i];
+  }
+  return strides;
+}
+
 void Graph::mark_output(DTensor const &A) {
-  std::vector<size_t> strides;
-  return mark_output(A);
+  return mark_output(A, get_default_strides(A));
 }
 
 void Graph::mark_output(DTensor const *A) {
-  std::vector<size_t> strides;
-  return mark_output(A);
+  return mark_output(A, get_default_strides(*A));
 }
 
 void Graph::mark_output(DTensor const &A, std::vector<size_t> const &strides) {


### PR DESCRIPTION
**Description of changes:**
It seems `mark_output(DTensor const &)` and `mark_output(DTensor const *A)` were incomplete. This PR fixes that by setting a default value for strides.


**Related Issues:**

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #


