### PR TITLE
[Transpiler] Allow the transpiler to return errors for untranspilable muGraphs

### DIFF
--- a/include/mirage/search/verification/output_match.h
+++ b/include/mirage/search/verification/output_match.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <vector>
 #include <cstddef>
+#include <vector>
 
 namespace mirage {
 namespace search {

--- a/include/mirage/search/verification/output_match.h
+++ b/include/mirage/search/verification/output_match.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vector>
+#include <cstddef>
 
 namespace mirage {
 namespace search {

--- a/include/mirage/transpiler/error_types.h
+++ b/include/mirage/transpiler/error_types.h
@@ -1,0 +1,29 @@
+/* Copyright 2023-2024 CMU
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+namespace mirage {
+namespace transpiler {
+
+enum TranspileErrorType {
+  CUDA_T_SUCCESS = 0,
+  CUDA_T_INSUFFICIENT_SMEM = 1,
+  CUDA_T_LAYOUT_ERROR = 2,
+  CUDA_T_UNKOWN_ERRORS = 999,
+};
+
+} // namespace transpiler
+} // namespace mirage

--- a/include/mirage/transpiler/structs.h
+++ b/include/mirage/transpiler/structs.h
@@ -50,6 +50,16 @@ struct OutputTensorDirective {
 
 // Result returned by the transpiler
 struct TranspileResult {
+  enum State {
+    SUCCESS = 0,
+    INSUFFICIENT_SHARED_MEMORY = 1,
+    UNKNOWN_ERRORS = 999,
+  };
+
+  // A state indicating whether the transpile kernel is
+  // valid or not
+  State state;
+
   // The generated CUDA code
   std::string code;
 
@@ -65,6 +75,14 @@ struct TranspileResult {
 
 // Transpile a custom KN operator (a custom block graph)
 struct CustomOPTranspileResult {
+  enum State {
+    SUCCESS = 0,
+    INSUFFICIENT_SHARED_MEMORY = 1,
+    UNKNOWN_ERRORS = 999,
+  };
+  // A state indicating whether the transpile kernel is
+  // valid or not
+  State state;
   // The name of the generated kernel function
   std::string func_name;
   // The size of the shared memory, in bytes

--- a/include/mirage/transpiler/structs.h
+++ b/include/mirage/transpiler/structs.h
@@ -22,6 +22,7 @@
 #include "mirage/kernel/device_tensor.h"
 #include "mirage/threadblock/smem_tensor.h"
 #include "mirage/transpiler/common.h"
+#include "mirage/transpiler/error_types.h"
 
 namespace mirage {
 namespace transpiler {
@@ -50,15 +51,9 @@ struct OutputTensorDirective {
 
 // Result returned by the transpiler
 struct TranspileResult {
-  enum State {
-    SUCCESS = 0,
-    INSUFFICIENT_SHARED_MEMORY = 1,
-    UNKNOWN_ERRORS = 999,
-  };
-
   // A state indicating whether the transpile kernel is
   // valid or not
-  State state;
+  TranspileErrorType error_type;
 
   // The generated CUDA code
   std::string code;
@@ -75,14 +70,10 @@ struct TranspileResult {
 
 // Transpile a custom KN operator (a custom block graph)
 struct CustomOPTranspileResult {
-  enum State {
-    SUCCESS = 0,
-    INSUFFICIENT_SHARED_MEMORY = 1,
-    UNKNOWN_ERRORS = 999,
-  };
   // A state indicating whether the transpile kernel is
   // valid or not
-  State state;
+  TranspileErrorType error_type;
+
   // The name of the generated kernel function
   std::string func_name;
   // The size of the shared memory, in bytes

--- a/src/transpiler/resolve_tensor_layout.cc
+++ b/src/transpiler/resolve_tensor_layout.cc
@@ -195,6 +195,12 @@ void Transpiler::resolve_tensor_layout() {
     }
     opt.add(z3::atmost(innermost_exprs, 1));
     opt.add(z3::atleast(innermost_exprs, 1));
+    // Every STensor can have at most 1 swizzle dim
+    z3::expr_vector swizzled_exprs(ctx);
+    for (int i = 0; i < num_dims; ++i) {
+      swizzled_exprs.push_back(s_is_swizzled[stensor.guid][i]);
+    }
+    opt.add(z3::atmost(swizzled_exprs, 1));
     // The innermost dim of a STensor cannot be swizzled
     for (int i = 0; i < num_dims; ++i) {
       opt.add(!s_is_swizzled[stensor.guid][i] ||

--- a/src/transpiler/sched_tb_graph.cc
+++ b/src/transpiler/sched_tb_graph.cc
@@ -42,7 +42,9 @@ static pair<bool, int>
         return i;
       }
     }
-    return -1;
+    // In the case where all dimensions are of size 1
+    // return the last dim as the inner most dim
+    return num_dims - 1;
   };
   int real_innermost_dtensor = find_real_innermost_dim(
       dtensor.num_dims, dtensor.dim, dtensor_meta.strides);

--- a/src/transpiler/transpiler_kn.cc
+++ b/src/transpiler/transpiler_kn.cc
@@ -409,6 +409,18 @@ TranspileResult Transpiler::transpile_ugraph() {
         }
         // Transpile
         CustomOPTranspileResult result = transpile_kn_custom_op(cur_op);
+        if (result.state != CustomOPTranspileResult::SUCCESS) {
+          vector<OutputTensorDirective> output_directives;
+          TranspileResult::State state;
+          switch (result.state) {
+            case CustomOPTranspileResult::INSUFFICIENT_SHARED_MEMORY:
+              state = TranspileResult::INSUFFICIENT_SHARED_MEMORY;
+              break;
+            default:
+              state = TranspileResult::UNKNOWN_ERRORS;
+          }
+          return TranspileResult{state, "", 0, 0, output_directives};
+        }
         if (result.smem_size > max_smem_size) {
           max_smem_size = result.smem_size;
         }
@@ -479,8 +491,11 @@ TranspileResult Transpiler::transpile_ugraph() {
         vector<int>(dtensor.dim, dtensor.dim + dtensor.num_dims),
         vector<size_t>(meta.strides, meta.strides + dtensor.num_dims)});
   }
-  return TranspileResult{
-      code, this->d_buf_size, max_smem_size, output_directives};
+  return TranspileResult{TranspileResult::SUCCESS,
+                         code,
+                         this->d_buf_size,
+                         max_smem_size,
+                         output_directives};
 }
 
 } // namespace transpiler

--- a/src/transpiler/transpiler_kn.cc
+++ b/src/transpiler/transpiler_kn.cc
@@ -409,17 +409,10 @@ TranspileResult Transpiler::transpile_ugraph() {
         }
         // Transpile
         CustomOPTranspileResult result = transpile_kn_custom_op(cur_op);
-        if (result.state != CustomOPTranspileResult::SUCCESS) {
+        if (result.error_type != CUDA_T_SUCCESS) {
           vector<OutputTensorDirective> output_directives;
-          TranspileResult::State state;
-          switch (result.state) {
-            case CustomOPTranspileResult::INSUFFICIENT_SHARED_MEMORY:
-              state = TranspileResult::INSUFFICIENT_SHARED_MEMORY;
-              break;
-            default:
-              state = TranspileResult::UNKNOWN_ERRORS;
-          }
-          return TranspileResult{state, "", 0, 0, output_directives};
+          return TranspileResult{
+              result.error_type, "", 0, 0, output_directives};
         }
         if (result.smem_size > max_smem_size) {
           max_smem_size = result.smem_size;
@@ -491,11 +484,8 @@ TranspileResult Transpiler::transpile_ugraph() {
         vector<int>(dtensor.dim, dtensor.dim + dtensor.num_dims),
         vector<size_t>(meta.strides, meta.strides + dtensor.num_dims)});
   }
-  return TranspileResult{TranspileResult::SUCCESS,
-                         code,
-                         this->d_buf_size,
-                         max_smem_size,
-                         output_directives};
+  return TranspileResult{
+      CUDA_T_SUCCESS, code, this->d_buf_size, max_smem_size, output_directives};
 }
 
 } // namespace transpiler

--- a/src/transpiler/transpiler_tb.cc
+++ b/src/transpiler/transpiler_tb.cc
@@ -1078,8 +1078,10 @@ CustomOPTranspileResult
 
   code.e("}"); // kernel
 
-  return CustomOPTranspileResult{
-      func_name, mem_plan.smem_size, code.to_string()};
+  return CustomOPTranspileResult{CustomOPTranspileResult::SUCCESS,
+                                 func_name,
+                                 mem_plan.smem_size,
+                                 code.to_string()};
 }
 
 } // namespace transpiler

--- a/src/transpiler/transpiler_tb.cc
+++ b/src/transpiler/transpiler_tb.cc
@@ -779,6 +779,8 @@ CustomOPTranspileResult
               break;
             }
           }
+          assert(iter_dim != -1);
+#ifdef DEADCODE
           if (iter_dim == -1) {
             // We cannot find a dim that satisfies our assumption:
             // dim i in input&output tensor == meta.innermost_dim or
@@ -786,7 +788,7 @@ CustomOPTranspileResult
             // We return a CUDA_T_LAYOUT_ERROR
             return CUDA_T_LAYOUT_ERROR;
           }
-          assert(iter_dim != -1);
+#endif
           // Define layouts
           string in_layout = mov_last_get_stensor_layout(
               input, stensor_metas.at(input.guid), iter_dim);

--- a/src/transpiler/transpiler_tb.cc
+++ b/src/transpiler/transpiler_tb.cc
@@ -651,8 +651,8 @@ CustomOPTranspileResult
 
   // A lambda function that transpiles an TBSchedNode
   auto transpile_tb_sched_node = [&](TBSchedNode const &sched_node,
+                                     CodeKeeper &code,
                                      bool is_in_loop) {
-    CodeKeeper code;
     if (sched_node.type == tb_sched_node_t::SYNCTHREADS) {
       code.e("__syncthreads();");
     } else {
@@ -778,6 +778,13 @@ CustomOPTranspileResult
               iter_dim = i;
               break;
             }
+          }
+          if (iter_dim == -1) {
+            // We cannot find a dim that satisfies our assumption:
+            // dim i in input&output tensor == meta.innermost_dim or
+            // meta.swizzled_dim
+            // We return a CUDA_T_LAYOUT_ERROR
+            return CUDA_T_LAYOUT_ERROR;
           }
           assert(iter_dim != -1);
           // Define layouts
@@ -980,7 +987,7 @@ CustomOPTranspileResult
       }
       code.e("}");
     }
-    return code;
+    return CUDA_T_SUCCESS;
   };
 
   // Declare the for loop
@@ -1031,8 +1038,12 @@ CustomOPTranspileResult
             dynamic_cast<tb::TBInputOp const *>(sched_node.ops[0].first))) {
       continue;
     }
-    CodeKeeper res = transpile_tb_sched_node(sched_node, true);
+    CodeKeeper res;
+    TranspileErrorType err = transpile_tb_sched_node(sched_node, res, true);
     code << res;
+    if (err != CUDA_T_SUCCESS) {
+      return CustomOPTranspileResult{err, func_name, 0, ""};
+    }
   }
 
   code.e("}"); // For loop
@@ -1071,17 +1082,19 @@ CustomOPTranspileResult
     code.e("// The epilogue (kernels outside the loop)");
     code.e("__syncthreads();");
     for (TBSchedNode const &sched_node : sched.post_loop_nodes) {
-      CodeKeeper res = transpile_tb_sched_node(sched_node, false);
+      CodeKeeper res;
+      TranspileErrorType err = transpile_tb_sched_node(sched_node, res, false);
       code << res;
+      if (err != CUDA_T_SUCCESS) {
+        return CustomOPTranspileResult{err, func_name, 0, ""};
+      }
     }
   }
 
   code.e("}"); // kernel
 
-  return CustomOPTranspileResult{CustomOPTranspileResult::SUCCESS,
-                                 func_name,
-                                 mem_plan.smem_size,
-                                 code.to_string()};
+  return CustomOPTranspileResult{
+      CUDA_T_SUCCESS, func_name, mem_plan.smem_size, code.to_string()};
 }
 
 } // namespace transpiler


### PR DESCRIPTION
**Description of changes:**

This change introduces a `state` field in `TranspileResult`, which allows the transpiler to label some mugraphs as invalid when generating CUDA code.

**Related Issues:**

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #


