### PR TITLE
Fp8

### DIFF
--- a/demo/demo_mma_hopper.py
+++ b/demo/demo_mma_hopper.py
@@ -1,0 +1,61 @@
+import mirage as mi
+import argparse
+import os
+import torch
+
+datatype = {
+  "e4m3": (mi.float8_e4m3, torch.float8_e4m3fn),
+  "e5m2": (mi.float8_e5m2, torch.float8_e5m2),
+}
+
+config = {
+  "M":  16  ,
+  "N":  4096,
+  "K":  4096,
+}
+
+def matmul_hopper_fp8(mode):
+  M, N, K = config["M"], config["N"], config["K"]
+
+  mirage_fp8, _ = datatype[mode]
+
+  kn_graph = mi.new_kernel_graph()
+  X = kn_graph.new_input(dims=(M, K), dtype=mirage_fp8)
+  W = kn_graph.new_input(dims=(K, N), dtype=mirage_fp8)
+
+  # launch 64x1x1 blocks, each running a warp group (128 threads)
+  tb_graph = mi.new_threadblock_graph(grid_dim=(64,1,1), block_dim=(128,1,1), forloop_range=64, reduction_dimx=64)
+  tX = tb_graph.new_input(dtensor=X, input_map=(-1,-1,-1), forloop_dim=1)
+  tW = tb_graph.new_input(dtensor=W, input_map=( 1,-1,-1), forloop_dim=0)
+  tM = tb_graph.matmul(tX, tW)
+  tO = tb_graph.forloop_accum(tM)
+  tb_graph.new_output(stensor=tO, output_map=(1, -1, -1))
+
+  O = kn_graph.customized([X, W], tb_graph)
+
+  kn_graph.mark_output(O)
+  return graph
+
+if __name__ == "__main__":
+  M, N, K = config["M"], config["N"], config["K"]
+
+  for mode in ["e4m3", "e5m2"]:
+    print(f"sm90 arch matmul with datatype fp8_{mode}...")
+    mm = matmul_hopper_fp8(mode=mode)
+    
+    # real inputs
+    _, torch_fp8 = datatype[mode]
+    input_tensors = [
+        torch.randn(M, K, dtype=torch_fp8, device='cuda:0'),
+        torch.randn(K, N, dtype=torch_fp8, device='cuda:0'),
+    ]
+    
+    # debug: view transpiled CUDA code
+    input_strides = [tensor.stride() for tensor in input_tensors]
+    p = mi.generate_cuda_program(mm.cygraph, target_cc=86, input_strides=input_strides)
+    
+    # run kernel graph
+    output = mm(inputs=input_tensors)[0]
+
+    print(output.shape)
+    print(output.stride(0), output.stride(1))

--- a/include/mirage/transpiler/runtime/kernel/element_unary.h
+++ b/include/mirage/transpiler/runtime/kernel/element_unary.h
@@ -15,7 +15,10 @@ template <typename T, ElementUnaryOpType OP>
 static __device__ __forceinline__ T perform_element_unary_op(T a) {
   if constexpr (!(std::is_same_v<T, cutlass::half_t> ||
                   std::is_same_v<T, cutlass::bfloat16_t> ||
-                  std::is_same_v<T, float> || std::is_same_v<T, __half>)) {
+                  std::is_same_v<T, float> || 
+                  std::is_same_v<T, __half> ||
+                  std::is_same_v<T, cutlass::float_e4m3_t> ||
+                  std::is_same_v<T, cutlass::float_e5m2_t>)) {
     assert(0 && "unsupport datatype in kn elementunary");
   }
   if constexpr (OP == ElementUnaryOpType::EXP) {

--- a/include/mirage/transpiler/runtime/threadblock/element_unary.h
+++ b/include/mirage/transpiler/runtime/threadblock/element_unary.h
@@ -27,7 +27,10 @@ static __device__ __forceinline__ T
     perform_element_unary_op(T a, float scalar = 0.0f) {
   if constexpr (!(std::is_same_v<T, cutlass::half_t> ||
                   std::is_same_v<T, cutlass::bfloat16_t> ||
-                  std::is_same_v<T, float> || std::is_same_v<T, __half>)) {
+                  std::is_same_v<T, float> || 
+                  std::is_same_v<T, __half> || 
+                  std::is_same_v<T, cutlass::float_e4m3_t> ||
+                  std::is_same_v<T, cutlass::float_e5m2_t>)) {
     assert(0 && "unsupport datatype in tb elementunary");
   }
   if constexpr (OP == ElementUnaryOpType::EXP) {

--- a/include/mirage/type.h
+++ b/include/mirage/type.h
@@ -42,7 +42,9 @@ enum DataType {
   // 8-bit types
   // range(float types): 930-934
   // range(int types): 935-939
-  DT_FLOAT8 = 930,
+  // DT_FLOAT8 = 930,
+  DT_FLOAT8_E4M3 = 930,
+  DT_FLOAT8_E5M2 = 931,
   DT_INT8 = 935,
   // 16-bit types
   // range(float types): 940-944

--- a/python/mirage/kernel.py
+++ b/python/mirage/kernel.py
@@ -91,6 +91,8 @@ dtype_map = {
     'int32':   torch.int32,
     'int64':   torch.int64,
     'uint8':   torch.uint8, 
+    'e4m3':    torch.float8_e4m3fn,
+    'e5m2':    torch.float8_e5m2,
     'fp16':    torch.float16,
     'bf16':    torch.bfloat16,
     'fp32':    torch.float32,

--- a/src/base/data_type.cc
+++ b/src/base/data_type.cc
@@ -47,9 +47,9 @@ std::string get_datatype_str(DataType dtype) {
     // case DT_FLOAT8:
     //   return "float8";
     case DT_FLOAT8_E4M3:
-      return "e4m3";
+      return "float_e4m3_t";
     case DT_FLOAT8_E5M2:
-      return "e5m2";
+      return "float_e5m2_t";
     case DT_INT8:
       return "int8";
     case DT_BFLOAT16:

--- a/src/base/data_type.cc
+++ b/src/base/data_type.cc
@@ -21,7 +21,11 @@ namespace type {
 size_t get_datatype_size(DataType type) {
   switch (type) {
     case DT_INT8:
-    case DT_FLOAT8:
+    // case DT_FLOAT8:
+    //   return 1;
+    case DT_FLOAT8_E4M3:
+      return 1;
+    case DT_FLOAT8_E5M2: 
       return 1;
     case DT_BFLOAT16:
     case DT_FLOAT16:
@@ -40,8 +44,12 @@ std::string get_datatype_str(DataType dtype) {
   switch (dtype) {
     case DT_INT4:
       return "int4";
-    case DT_FLOAT8:
-      return "float8";
+    // case DT_FLOAT8:
+    //   return "float8";
+    case DT_FLOAT8_E4M3:
+      return "e4m3";
+    case DT_FLOAT8_E5M2:
+      return "e5m2";
     case DT_INT8:
       return "int8";
     case DT_BFLOAT16:


### PR DESCRIPTION
**Description of changes:**
Plans: 
- add fp8_e4m3, fp8_e5m2 datatype in mirage kernel, threadblock level
- testing using sm90 gpu
- overload Hopper_Matmul::run with A and B scaling. This is to support block-level scaling inspired by DeepGemm
- demo_mma_hopper.py demonstrating use


**Related Issues:** Hopper support for FP8

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #


