### PR TITLE
 Split matmul along contraction axis on transpose

### DIFF
--- a/include/mirage/nki_transpiler/transpile.h
+++ b/include/mirage/nki_transpiler/transpile.h
@@ -47,6 +47,18 @@ struct NKITranspilerConfig {
   int target_cc;
 };
 
+struct NeuronArch {
+  NeuronArch() = delete;
+  NeuronArch(NeuronArch const &) = delete;
+  NeuronArch(NeuronArch &&) = delete;
+  static constexpr char const *pmax = "nki.language.tile_size.pmax";
+  static constexpr char const *psum_fmax = "nki.language.tile_size.psum_fmax";
+  static constexpr char const *gemm_mov_fmax =
+      "nki.language.tile_size.gemm_moving_fmax";
+  static constexpr char const *gemm_sta_fmax =
+      "nki.language.tile_size.gemm_stationary_fmax";
+};
+
 // Descriptive transpiler errors.
 // Currently, only layout errors are reported, further descriptive
 // errors can be added to provide info to users.

--- a/src/nki_transpiler/transpile.cc
+++ b/src/nki_transpiler/transpile.cc
@@ -540,6 +540,7 @@ std::optional<NKIErrorInfo> NKITranspiler::resolve_tensor_layout() {
 NKITranspileResult NKITranspiler::transpile_ugraph() {
   // Generate header
   CodeKeeper header;
+  header.e("import neuronxcc.nki as nki");
   header.e("import neuronxcc.nki.language as nl");
   header.e("import neuronxcc.nki.isa as nisa");
   header.e("from torch_neuronx import nki_jit");


### PR DESCRIPTION
**Description of changes:**

When both inputs parallel axis is mapped to physical partition dimension, it is possible to have their contraction axis sizes greater than 128, this requires us to do a transpose before performing matmul, In NKI transpose operation the partition dimension of resulting tile after transpose should be <= 128, hence we should split along the contraction dimension before doing transpose.
This is a special case, only happens when both inputs parallel axis is mapped to partition dimension, all other cases shall be correct.

- [x] Code Cleanup
- [x] Numerical accuracy testing

Possible next step is making the accumulation stensors as psum tiles explicitly.
@jiazhihao It would be helpful if you could take a look at this commit for correctness issues if any. thanks

**Related Issues:**

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #


