### PR TITLE
[Triton] Move Triton runtime under triton_transpiler/ instead of transpiler/

### DIFF
--- a/demo/triton_rms_norm.py
+++ b/demo/triton_rms_norm.py
@@ -10,7 +10,7 @@ if __name__ == "__main__":
     O = graph.matmul(D, W)
     graph.mark_output(O)
     optimized_graph = graph.superoptimize(config="mlp", backend="triton", 
-            warmup_iters=2, profile_iters=6, previous_checkpoint="../benchmark/saved_mugraphs/rmsnorm_bs1.json")
+            warmup_iters=2, profile_iters=6)
 
     with open("triton_rms_generated.py", "w") as f:
         f.write(mi.generate_triton_program(optimized_graph.cygraph, target_cc=10)["code"])

--- a/include/mirage/triton_transpiler/runtime/triton_kernels.py
+++ b/include/mirage/triton_transpiler/runtime/triton_kernels.py
@@ -1,0 +1,67 @@
+import triton
+import triton.language as tl
+
+@triton.jit
+def elementwise_binary_kernel(X_ptr, Y_ptr, Out_ptr, M: tl.constexpr, N: tl.constexpr, OP: tl.constexpr):
+    row_idx = tl.program_id(0)
+    col_idx = tl.program_id(1) * 128 + tl.arange(0, 128)  #TODO: 128 is hardcoded
+    mask = col_idx < N
+
+    X_offset = row_idx * N + col_idx
+    Y_offset = row_idx * N + col_idx
+    Out_offset = row_idx * N + col_idx
+
+    x = tl.load(X_ptr + X_offset, mask=mask)
+    y = tl.load(Y_ptr + Y_offset, mask=mask)
+
+    if OP == 1200:
+        out = x + y 
+    elif OP == 1201:
+        out = x * y 
+    elif OP == 1202:
+        out = x / y
+    else:
+        tl.device_print("Unsupported OP code in elementwise_binary_kernel")
+
+    tl.store(Out_ptr + Out_offset, out, mask=mask)
+
+@triton.jit
+def elementwise_unary_kernel(X_ptr, Out_ptr, M: tl.constexpr, N: tl.constexpr, OP: tl.constexpr):
+    row_idx = tl.program_id(0)
+    col_idx = tl.program_id(1) * 128 + tl.arange(0, 128) #TODO: 128 is hardcoded
+    mask = col_idx < N
+
+    X_offset = row_idx * N + col_idx
+    Out_offset = row_idx * N + col_idx
+
+    x = tl.load(X_ptr + X_offset, mask=mask)
+
+    if OP == 1100:
+        out = tl.exp(x)
+    elif OP == 1102:
+        out = tl.sqrt(x)
+    elif OP == 1101:
+        out = x * x
+    else:
+        tl.device_print("Unsupported OP code in elementwise_unary_kernel")
+
+    tl.store(Out_ptr + Out_offset, out, mask=mask)
+
+@triton.jit
+def reduce_sum_kernel(X_ptr, Out_ptr, M: tl.constexpr, N: tl.constexpr, dim: tl.constexpr):
+    row_idx = tl.program_id(0)
+    col_idx = tl.program_id(1) * 128 + tl.arange(0, 128) #TODO: 128 is hardcoded
+    mask = col_idx < N
+
+    if dim == 1:
+        sum_val = tl.zeros([N], dtype=tl.float32)
+        for i in range(M):
+            sum_val += tl.load(X_ptr + i * N + col_idx, mask=mask)
+        if row_idx == 0:
+            tl.store(Out_ptr + col_idx, sum_val, mask=mask)
+
+    elif dim == 0:
+        sum_val = tl.sum(tl.load(X_ptr + row_idx * N + col_idx, mask=mask))
+        if col_idx[0] == 0:
+            tl.store(Out_ptr + row_idx, sum_val)
+

--- a/python/mirage/kernel.py
+++ b/python/mirage/kernel.py
@@ -587,7 +587,7 @@ class KNGraph:
             return all_graphs
         elif backend == "triton":
             MIRAGE_ROOT, INCLUDE_PATH, _ = get_key_paths()
-            os.environ["KERNELS_PATH"] = os.path.join(INCLUDE_PATH, "mirage/transpiler/runtime") # for triton
+            os.environ["KERNELS_PATH"] = os.path.join(INCLUDE_PATH, "mirage/triton_transpiler/runtime") # for triton
             best_graph, best_file_path, best_output_shapes = profile_and_select_best_graph(all_graphs, 
                                                  target_cc=torch.cuda.get_device_properties(0).major * 10 
                                                  + torch.cuda.get_device_properties(0).minor,

--- a/setup.py
+++ b/setup.py
@@ -121,9 +121,12 @@ def copy_include():
         # copy mirage/transpiler/runtime/* 
         # to python/mirage/include/mirage/transpiler/runtime/*
         # instead of python/mirage/include/include/mirage/transpiler/runtime/*
-        include_mirage_dir = "include/mirage/transpiler/runtime"
-        include_mirage_dst = path.join(INCLUDE_BASE, "mirage/transpiler/runtime")
-        shutil.copytree(include_mirage_dir, include_mirage_dst)
+        include_mirage_dirs = ["include/mirage/transpiler/runtime", 
+                               "include/mirage/triton_transpiler/runtime"]
+        include_mirage_dsts = [path.join(INCLUDE_BASE, "mirage/transpiler/runtime"), 
+                               path.join(INCLUDE_BASE, "mirage/triton_transpiler/runtime")]
+        for include_mirage_dir, include_mirage_dst in zip(include_mirage_dirs, include_mirage_dsts):
+            shutil.copytree(include_mirage_dir, include_mirage_dst)
 
         config_h_src = path.join(mirage_path, "include/mirage/config.h") # Needed by transpiler/runtime/threadblock/utils.h
         config_h_dst = path.join(INCLUDE_BASE, "mirage/config.h")


### PR DESCRIPTION
**Description of changes:**
1. Move Triton runtime under triton_transpiler/ instead of transpiler/ as once talked about
2. Update triton example to current version


**Related Issues:**

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #


