### PR TITLE
Fix: mitigate randomness of gpu performance test

### DIFF
--- a/tests/ci-tests/qwen2.5/demo.py
+++ b/tests/ci-tests/qwen2.5/demo.py
@@ -53,8 +53,8 @@ if __name__ == "__main__":
     g = torch.cuda.CUDAGraph()
     stream = torch.cuda.Stream()
     step = torch.tensor([0], dtype=torch.int32, device="cuda")
-    warmup = 16
-    output_len = 512
+    warmup = 128
+    output_len = 2048
     for cur_pos in range(prompt_len, prompt_len + output_len):
         step.fill_(cur_pos-1)
         # prefilling phase

--- a/tests/ci-tests/qwen2.5/models/modeling_qwen2.py
+++ b/tests/ci-tests/qwen2.5/models/modeling_qwen2.py
@@ -143,7 +143,7 @@ class Qwen2MLP(nn.Module):
         D = graph.mul(D, G)
         O = graph.matmul(D, W)
         graph.mark_output(O)
-        self.kernel1 = graph.superoptimize(config="mlp")
+        self.kernel1 = graph.superoptimize(config="mlp", warmup_iters=100, profile_iters=5000)
 
         graph = mi.new_kernel_graph()
         X = graph.new_input(dims=(1, self.intermediate_size), dtype=mi.bfloat16)
@@ -152,7 +152,7 @@ class Qwen2MLP(nn.Module):
         D = graph.mul(graph.silu(X), Y)
         O = graph.matmul(D, W)
         graph.mark_output(O)
-        self.kernel2 = graph.superoptimize(config="mlp")
+        self.kernel2 = graph.superoptimize(config="mlp", warmup_iters=100, profile_iters=5000)
 
     def forward(self, input_layernorm, hidden_state, stream: torch.cuda.Stream = None):
         if hidden_state.shape[-2] == 1 and self.enable_mirage:
@@ -211,7 +211,7 @@ class Qwen2Attention(nn.Module):
         D = graph.mul(D, G)
         O = graph.matmul(D, W)
         graph.mark_output(O)
-        self.kernel = graph.superoptimize(config="mlp")
+        self.kernel = graph.superoptimize(config="mlp", warmup_iters=100, profile_iters=5000)
 
     def forward(
         self,


### PR DESCRIPTION
**Description of changes:**
The mirage-generated **self-attention kernel** in the qwen2.5 demo was selected from 88 mugraphs, where many cuda kernels show very close performance and differ in just several milliseconds. Some external factors like overhead could easily affect the profiled performance and result in randomness which causes performance degradation.
This pr adds longer generated context, more warmup iterations and profiling iterations in ```demo.py``` to reduce the possibility of choosing poor kernels.


**Related Issues:**

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #


