### PR TITLE
Added support for all Qwen operators

### DIFF
--- a/scripts/op.py
+++ b/scripts/op.py
@@ -1,8 +1,10 @@
 class Operator:
-    def __init__(self, name=None, fn=None, input_ops=[], output_ops=[], input_tensor_shapes=[], output_tensor_shapes=[]):
+    def __init__(self, name=None, fn=None, input_ops=[], output_ops=[], input_tensor_shapes=[], output_tensor_shapes=[], additional_params=[], kwargs={}):
         self.name = name
         self.fn = fn
         self.input_ops = input_ops
         self.output_ops = output_ops
+        self.additional_params = additional_params
+        self.kwargs = kwargs
         self.input_tensor_shapes = input_tensor_shapes
         self.output_tensor_shapes = output_tensor_shapes


### PR DESCRIPTION
This pull request adds support for the operators needed for Qwen to be properly partitioned, as well as some missing operators that were not previously supported.

**Description of changes:**
- Adds support for Sigmoid, Softmax, Neg, Rec, Square, RMSNorm, and ReduceSum operators
- Sigmoid, Softmax, Neg, and Rec all require constants, so support is added for constant-value matrices to the conversion to kernel graph and timing code
- Added support for additional arguments (i.e. axis) and kwargs to operator class to support above additions
