### PR TITLE
Exposed json functionalities to Python interface

### DIFF
--- a/include/mirage/search/search_c.h
+++ b/include/mirage/search/search_c.h
@@ -26,7 +26,8 @@ int cython_search(mirage::kernel::Graph const *input_graph,
                   bool verbose,
                   char const *default_config);
 
-void cython_to_json(mirage::kernel::Graph const *input_graph, char const *filename);
+void cython_to_json(mirage::kernel::Graph const *input_graph,
+                    char const *filename);
 mirage::kernel::Graph *cython_from_json(char const *filename);
 } // namespace search_c
 } // namespace mirage

--- a/include/mirage/search/search_c.h
+++ b/include/mirage/search/search_c.h
@@ -25,5 +25,8 @@ int cython_search(mirage::kernel::Graph const *input_graph,
                   char const *filename,
                   bool verbose,
                   char const *default_config);
+
+void cython_to_json(mirage::kernel::Graph const *input_graph, char const *filename);
+mirage::kernel::Graph *cython_from_json(char const *filename);
 } // namespace search_c
 } // namespace mirage

--- a/python/mirage/_cython/CCore.pxd
+++ b/python/mirage/_cython/CCore.pxd
@@ -301,6 +301,10 @@ cdef extern from "mirage/search/search_c.h" namespace "mirage::search_c":
                            const char * filename,
                            bool verbose,
                            const char * default_config)
+    
+    cdef void cython_to_json(const CppKNGraph *input_graph,
+                             const char *filename)
+    cdef CppKNGraph *cython_from_json(const char *filename)
 
 cdef extern from "mirage/transpiler/transpile.h" namespace "mirage::transpiler":
     ctypedef struct TranspilerConfig:

--- a/python/mirage/_cython/core.pyx
+++ b/python/mirage/_cython/core.pyx
@@ -1141,3 +1141,13 @@ def generate_triton_program(CyKNGraph input_graph, *, int target_cc) -> dict:
 
 def set_gpu_device_id(gpu_id: int):
     cython_set_gpu_device_id(gpu_id)
+
+def cy_to_json(CyKNGraph input_graph, str filename):
+    cfilename = filename.encode('UTF-8')
+    cython_to_json(input_graph.p_kgraph, cfilename)
+
+def cy_from_json(str filename):
+    cfilename = filename.encode('UTF-8')
+    ptr = cython_from_json(cfilename)
+    graph = ctypes.cast(<unsigned long long>ptr, ctypes.c_void_p)
+    return CyKNGraph(graph)

--- a/python/mirage/kernel.py
+++ b/python/mirage/kernel.py
@@ -636,3 +636,9 @@ class KNGraph:
         operators = self.cygraph.get_graph_structure()
         self.visualizer = visualizer(file_name)
         self.visualizer.draw_graphs(operators)
+    
+    def to_json(self, filename):
+        cy_to_json(self.cygraph, filename)
+    
+    def from_json(self, filename):
+        self.cygraph = cy_from_json(filename)

--- a/src/search/search_c.cc
+++ b/src/search/search_c.cc
@@ -1,5 +1,6 @@
 #include "mirage/search/search_c.h"
 #include "mirage/kernel/customized.h"
+#include "mirage/kernel/graph.h"
 #include "mirage/search/dim_strategy.h"
 #include "mirage/search/op_utils.h"
 #include "mirage/search/search.h"
@@ -107,6 +108,22 @@ int cython_search(mirage::kernel::Graph const *input_graph,
     }
     return num;
   }
+}
+
+void cython_to_json(mirage::kernel::Graph const *input_graph, char const *filename) {
+  json j;
+  to_json(j, *input_graph);
+  std::ofstream ofs(filename);
+  ofs << j;
+}
+
+mirage::kernel::Graph *cython_from_json(char const *filename) {
+  std::ifstream graph_file(filename, std::ifstream::binary);
+  json j;
+  graph_file >> j;
+  mirage::kernel::Graph *new_graph = new mirage::kernel::Graph();
+  from_json(j, *new_graph);
+  return new_graph;
 }
 
 } // namespace search_c

--- a/src/search/search_c.cc
+++ b/src/search/search_c.cc
@@ -110,7 +110,8 @@ int cython_search(mirage::kernel::Graph const *input_graph,
   }
 }
 
-void cython_to_json(mirage::kernel::Graph const *input_graph, char const *filename) {
+void cython_to_json(mirage::kernel::Graph const *input_graph,
+                    char const *filename) {
   json j;
   to_json(j, *input_graph);
   std::ofstream ofs(filename);


### PR DESCRIPTION
**Description of changes:**
This PR exposes the json functionalities in the C++ search side so that user's can call to_json and from_json to convert KNGraph objects into a json file.


**Related Issues:**

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #


