### PR TITLE
Argmax Modification

### DIFF
--- a/include/mirage/persistent_kernel/persistent_kernel.cuh
+++ b/include/mirage/persistent_kernel/persistent_kernel.cuh
@@ -500,11 +500,8 @@ __global__ void persistent_kernel(RuntimeConfig config) {
             break;
           }
           case TASK_ARGMAX_PARTIAL: {
-            // We need to determine the block index for this partial task.
-            // This should be encoded in the task graph. A simple way is
-            // to assume partial tasks are numbered consecutively.
-            // The logic to get the base_task_id depends on your graph generation.
-            // Here, we assume the triggering event's first_task_id is the base.
+            // TODO: We need to determine the block index for this partial task. 
+            // Make sure it's compatible with graph generation.
             EventId trigger_event_id = task_desc.trigger_event;
             size_t event_idx = get_event_position_index(trigger_event_id);
             EventDesc event_desc = config.all_events[event_idx];

--- a/include/mirage/persistent_kernel/persistent_kernel.cuh
+++ b/include/mirage/persistent_kernel/persistent_kernel.cuh
@@ -511,8 +511,7 @@ __global__ void persistent_kernel(RuntimeConfig config) {
             size_t base_task_id = event_desc.first_task_id;
             int partial_task_idx = get_task_position_index(cur_task_id) - base_task_id;
             
-            // NOTE: The number of blocks (e.g., 64) is an example.
-            // This should match the number of partial tasks you create in the graph.
+            // TODO: This should match the real number
             kernel::argmax_partial_kernel<bfloat16, 153600, 64>(
                 task_desc.inputs[0].base_ptr,   // full vocab tensor
                 task_desc.outputs[0].base_ptr,  // intermediate buffer
@@ -520,8 +519,7 @@ __global__ void persistent_kernel(RuntimeConfig config) {
             break;
           }
           case TASK_ARGMAX_REDUCE: {
-            // NOTE: The number of blocks (e.g., 64) is an example.
-            // This should match the number of partial tasks you create in the graph.
+            // TODO: This should match the real number
             kernel::argmax_reduce_kernel<bfloat16, 64>(
                 task_desc.inputs[0].base_ptr,   // intermediate buffer
                 task_desc.outputs[0].base_ptr); // final output tensor

--- a/include/mirage/persistent_kernel/tasks/argmax.cuh
+++ b/include/mirage/persistent_kernel/tasks/argmax.cuh
@@ -92,10 +92,19 @@ __device__ __forceinline__ void argmax_partial_kernel(
   T local_max = T(-inf);
   int local_idx = -1;
 
-  int part_size = (VOCAB_SIZE + NUM_BLOCKS - 1) / NUM_BLOCKS;
-  int start_offset = block_idx * part_size;
-  int end_offset = min((block_idx + 1) * part_size, VOCAB_SIZE);
+  int bigger_part_size = (VOCAB_SIZE + NUM_BLOCKS - 1) / NUM_BLOCKS;
+  int bigger_part_num = VOCAB_SIZE % NUM_BLOCKS;
+  int start_offset = 0;
+  int end_offset = 0;
+  if (block_idx >= bigger_part_num){
+    start_offset = block_idx * (bigger_part_size - 1) + bigger_part_num;
+    end_offset = start_offset + bigger_part_size - 1;
+  } else {
+    start_offset = block_idx * bigger_part_size;
+    end_offset = (block_idx + 1) * bigger_part_size;
+  }
 
+  // TODO: try vectorize
   for (int i = start_offset + tidx; i < end_offset; i += blockDim.x) {
     T val = input[i];
     if (val > local_max) {

--- a/include/mirage/persistent_kernel/tasks/argmax.cuh
+++ b/include/mirage/persistent_kernel/tasks/argmax.cuh
@@ -18,8 +18,7 @@
 namespace kernel {
 
 template <typename T>
-__device__ __forceinline__ void
-    warp_argmax(T val, int idx, T &warp_max_val, int &warp_max_idx) {
+__device__ __forceinline__ void warp_reduce_max_idx(T &val, int &idx) {
 #pragma unroll
   for (int offset = 16; offset > 0; offset /= 2) {
     float tmp = __shfl_down_sync(0xffffffff, (float)val, offset);
@@ -30,56 +29,112 @@ __device__ __forceinline__ void
       idx = other_idx;
     }
   }
-  warp_max_val = val;
-  warp_max_idx = idx;
 }
 
-template <typename T, int BATCH_SIZE, int VOCAB_SIZE>
-__device__ __forceinline__ void
-    argmax_kernel(void const *__restrict__ input_ptr,
-                  void *__restrict__ output_ptr) {
-  T const *__restrict__ input = static_cast<T const *>(input_ptr);
-  int *__restrict__ output = static_cast<int *>(output_ptr);
+template <typename T>
+__device__ __forceinline__ void block_reduce_max_idx(T &val, int &idx) {
+  __shared__ T smem_vals[32]; // max 32 warps
+  __shared__ int smem_idxs[32];
 
-  // assume batch size is 1 for a single task
+  warp_reduce_max_idx(val, idx);
+
+  int lane_id = threadIdx.x % 32;
+  int warp_id = threadIdx.x / 32;
+
+  if (lane_id == 0) {
+    smem_vals[warp_id] = val;
+    smem_idxs[warp_id] = idx;
+  }
+
+  __syncthreads();
+
+  T block_max_val = T(-inf);
+  int block_max_idx = -1;
+
+  if (warp_id == 0) {
+    int num_warps = (blockDim.x + 31) / 32;
+    if (lane_id < num_warps) {
+      block_max_val = smem_vals[lane_id];
+      block_max_idx = smem_idxs[lane_id];
+    }
+    warp_reduce_max_idx(block_max_val, block_max_idx);
+  }
+
+  __syncthreads();
+
+  if (warp_id == 0 && lane_id == 0) {
+    smem_vals[0] = block_max_val;
+    smem_idxs[0] = block_max_idx;
+  }
+
+  __syncthreads();
+
+  val = smem_vals[0];
+  idx = smem_idxs[0];
+}
+
+template <typename T>
+struct PartialMax {
+  T val;
+  int idx;
+};
+
+template <typename T, int VOCAB_SIZE, int NUM_BLOCKS>
+__device__ __forceinline__ void argmax_partial_kernel(
+    void const *__restrict__ input_ptr,
+    void *__restrict__ partial_output_ptr,
+    int block_idx) {
+  T const *__restrict__ input = static_cast<T const *>(input_ptr);
+  PartialMax<T> *__restrict__ partial_output =
+      static_cast<PartialMax<T> *>(partial_output_ptr);
+
   int tidx = threadIdx.x;
-  int warp_idx = warp_id();
   T local_max = T(-inf);
   int local_idx = -1;
-  __shared__ T warp_max_vals[4];
-  __shared__ int warp_max_idxs[4];
 
-  for (int i = tidx; i < VOCAB_SIZE; i += blockDim.x) {
+  int part_size = (VOCAB_SIZE + NUM_BLOCKS - 1) / NUM_BLOCKS;
+  int start_offset = block_idx * part_size;
+  int end_offset = min((block_idx + 1) * part_size, VOCAB_SIZE);
+
+  for (int i = start_offset + tidx; i < end_offset; i += blockDim.x) {
     T val = input[i];
     if (val > local_max) {
       local_max = val;
       local_idx = i;
     }
   }
-  T warp_max_val;
-  int warp_max_idx;
-  warp_argmax(local_max, local_idx, warp_max_val, warp_max_idx);
 
-  __syncthreads();
+  block_reduce_max_idx(local_max, local_idx);
 
-  if ((tidx % 32) == 0) {
-    warp_max_vals[warp_idx] = warp_max_val;
-    warp_max_idxs[warp_idx] = warp_max_idx;
+  if (tidx == 0) {
+    partial_output[block_idx].val = local_max;
+    partial_output[block_idx].idx = local_idx;
+  }
+}
+
+template <typename T, int NUM_BLOCKS>
+__device__ __forceinline__ void
+argmax_reduce_kernel(void const *__restrict__ partial_input_ptr,
+                     void *__restrict__ final_output_ptr) {
+  PartialMax<T> const *__restrict__ partial_input =
+      static_cast<PartialMax<T> const *>(partial_input_ptr);
+  int *__restrict__ final_output = static_cast<int *>(final_output_ptr);
+
+  int tidx = threadIdx.x;
+  T local_max = T(-inf);
+  int local_idx = -1;
+
+  for (int i = tidx; i < NUM_BLOCKS; i += blockDim.x) {
+    if (partial_input[i].val > local_max) {
+      local_max = partial_input[i].val;
+      local_idx = partial_input[i].idx;
+    }
   }
 
-  T final_max_val = T(-inf);
-  int final_max_idx = -1;
+  block_reduce_max_idx(local_max, local_idx);
 
-  if (warp_idx == 0 && tidx < 32) {
-    if (tidx < 4) {
-      final_max_val = warp_max_vals[tidx];
-      final_max_idx = warp_max_idxs[tidx];
-    }
-    warp_argmax(final_max_val, final_max_idx, warp_max_val, warp_max_idx);
-
-    if (tidx == 0) {
-      output[0] = warp_max_idx;
-    }
+  if (tidx == 0) {
+    final_output[0] = local_idx;
   }
 }
 


### PR DESCRIPTION
**Description of changes:**
Current argmax only use one block's capability. Aim to change it to 2 step argmax leveraging multiple blocks.
This involves both runtime and task generation change. This PR only includes the runtime part.

For `argmax_partial` task:
* input: a matrix of `bfloat16` with shape [1, vocab_size // num_tasks]
* output1: a matrix of `bfloat16` with shape [1, 1]
* output2: a matrix of `int64_t` with shape [1,1]
* partial_vocab_size
* index_offset

For `argmax_reduction` task:
* input1: a matrix of `bfloat16` with shape [1, num_tasks]
* input2: a matrix of `int64_t` with shape [1, num_tasks]
* output: a matrix of `int64_t` with shape [1,1]
* num_partial_tasks

**Related Issues:**

Linked Issues:
- Issue #281 

Issues closed by this PR:
- Closes #


