### PR TITLE
optimize `linear` and `silu_mul_linear` tasks

### DIFF
--- a/demo/qwen3/models/modeling_qwen3.py
+++ b/demo/qwen3/models/modeling_qwen3.py
@@ -191,18 +191,18 @@ class Qwen3Attention(nn.Module):
         assert kv_cache[0].shape == (
             config.num_hidden_layers,
             1,
-            config.max_position_embeddings,
+            4096,
             self.num_key_value_heads // world_size,
             self.head_dim,
         )
         assert kv_cache[1].shape == (
             config.num_hidden_layers,
             1,
-            config.max_position_embeddings,
+            4096,
             self.num_key_value_heads // world_size,
             self.head_dim,
         )
-        self.max_position_embeddings = config.max_position_embeddings
+        self.max_position_embeddings = 4096
         self.rope_theta = config.rope_theta
         self.is_causal = True
         self.attention_dropout = config.attention_dropout
@@ -393,7 +393,7 @@ class Qwen3Model(Qwen3PreTrainedModel):
             (
                 config.num_hidden_layers,
                 1,
-                config.max_position_embeddings,
+                4096,
                 config.num_key_value_heads // world_size,
                 config.hidden_size // config.num_attention_heads,
             ),
@@ -404,7 +404,7 @@ class Qwen3Model(Qwen3PreTrainedModel):
             (
                 config.num_hidden_layers,
                 1,
-                config.max_position_embeddings,
+                4096,
                 config.num_key_value_heads // world_size,
                 config.hidden_size // config.num_attention_heads,
             ),

--- a/include/mirage/persistent_kernel/tasks/linear.cuh
+++ b/include/mirage/persistent_kernel/tasks/linear.cuh
@@ -39,9 +39,9 @@ __device__ __forceinline__ void linear_kernel(void const *input_ptr,
                                               bool bias,
                                               void const *bias_ptr) {
   constexpr int CHUNK_SIZE = 16 / sizeof(T);
-  constexpr int TILE_SIZE = 64;
-  constexpr int OUTPUT_ATOM_SIZE = OUTPUT_SIZE <= 64 ? OUTPUT_SIZE : 64;
+  constexpr int OUTPUT_ATOM_SIZE = OUTPUT_SIZE <= 128 ? OUTPUT_SIZE : 128;
   constexpr int NUM_OUTPUT_ATOMS = OUTPUT_SIZE / OUTPUT_ATOM_SIZE;
+  constexpr int TILE_SIZE = 128;
   constexpr int FORLOOP_RANGE = REDUCTION_SIZE / TILE_SIZE;
 
   constexpr int NUM_CHUNKS_A = BATCH_SIZE * TILE_SIZE / CHUNK_SIZE;
@@ -58,14 +58,16 @@ __device__ __forceinline__ void linear_kernel(void const *input_ptr,
   constexpr int log2_CHUNKS_PER_ROW_C = log2_constexpr(CHUNKS_PER_ROW_C);
 
   // using SM80_16x8x16_F16F16F16F16_TNX2 = 16X16X16
-  constexpr int NUM_WARPS_N = OUTPUT_ATOM_SIZE / 16; // 1, 2, 4
-  constexpr int NUM_WARPS_K = 4 / NUM_WARPS_N;       // 4, 2, 1
+  constexpr int NUM_WARPS_N =
+      OUTPUT_ATOM_SIZE / 16 <= 4 ? OUTPUT_ATOM_SIZE / 16 : 4;
+  constexpr int NUM_WARPS_K = 4 / NUM_WARPS_N;
 
   constexpr int NUM_ITERS_M = 1;
-  constexpr int NUM_ITERS_N = 1;
-  constexpr int NUM_ITERS_K = 4 / NUM_WARPS_K; // 1, 2, 4
+  constexpr int NUM_ITERS_N = OUTPUT_ATOM_SIZE / NUM_WARPS_N / 16;
+  constexpr int NUM_ITERS_K = TILE_SIZE / NUM_WARPS_K / 16;
 
   constexpr int log2_NUM_WARPS_N = log2_constexpr(NUM_WARPS_N);
+  constexpr int log2_NUM_ITERS_K = log2_constexpr(NUM_ITERS_K);
 
   int warp_idx = warp_id();
   int warp_row = warp_idx >> log2_NUM_WARPS_N;
@@ -91,49 +93,60 @@ __device__ __forceinline__ void linear_kernel(void const *input_ptr,
 
   extern __shared__ char smem[];
 
+  // STensors' offsets
+  constexpr size_t ZERO_BUFFER_OFFSET = 0;
+  // sizeof(T) * 8
+
+  constexpr size_t SHARED_INPUT_OFFSET = ZERO_BUFFER_OFFSET + sizeof(T) * 8;
+  // sizeof(T) * BATCH_SIZE * TILE_SIZE
+
+  constexpr size_t SHARED_INPUT_BUFFER_OFFSET =
+      SHARED_INPUT_OFFSET + sizeof(T) * BATCH_SIZE * TILE_SIZE;
+  // sizeof(T) * BATCH_SIZE * TILE_SIZE
+
+  constexpr size_t SHARED_WEIGHT_OFFSET =
+      SHARED_INPUT_BUFFER_OFFSET + sizeof(T) * BATCH_SIZE * TILE_SIZE;
+  // sizeof(T) * TILE_SIZE * OUTPUT_ATOM_SIZE
+
+  constexpr size_t SHARED_WEIGHT_BUFFER_OFFSET =
+      SHARED_WEIGHT_OFFSET + sizeof(T) * TILE_SIZE * OUTPUT_ATOM_SIZE;
+  // sizeof(T) * TILE_SIZE * OUTPUT_ATOM_SIZE
+
+  constexpr size_t MM_INTERMEDIATE_OFFSET =
+      SHARED_WEIGHT_BUFFER_OFFSET + sizeof(T) * TILE_SIZE * OUTPUT_ATOM_SIZE;
+  // sizeof(T) * NUM_WARPS_K * BATCH_SIZE * OUTPUT_ATOM_SIZE
+
+  constexpr size_t SHARED_OUTPUT_OFFSET =
+      MM_INTERMEDIATE_OFFSET +
+      sizeof(T) * NUM_WARPS_K * BATCH_SIZE * OUTPUT_ATOM_SIZE;
+  // sizeof(T) * BATCH_SIZE * OUTPUT_ATOM_SIZE
+
+  constexpr size_t SHARED_BIAS_OFFSET =
+      SHARED_OUTPUT_OFFSET + sizeof(T) * BATCH_SIZE * OUTPUT_ATOM_SIZE;
+  // sizeof(T) * BATCH_SIZE * OUTPUT_ATOM_SIZE
+
   // zero buffer
-  T *zero_buf = (T *)(smem); // 128 bytes
-  *((__uint128_t *)smem) = 0ul;
+  T *zero_buf = (T *)(smem + ZERO_BUFFER_OFFSET);
+  *((__uint128_t *)zero_buf) = 0ul;
 
   // copy input
-  T *shared_input =
-      (T *)((char *)zero_buf + 128); // sizeof(T) * BATCH_SIZE * TILE_SIZE
-  T *shared_input_buffer =
-      (T *)((char *)shared_input +
-            sizeof(T) * BATCH_SIZE *
-                TILE_SIZE); // sizeof(T) * BATCH_SIZE * TILE_SIZE
+  T *shared_input = (T *)(smem + SHARED_INPUT_OFFSET);
+  T *shared_input_buffer = (T *)(smem + SHARED_INPUT_BUFFER_OFFSET);
 
   // copy weight
-  T *shared_weight =
-      (T *)((char *)shared_input_buffer +
-            sizeof(T) * BATCH_SIZE *
-                TILE_SIZE); // sizeof(T) * TILE_SIZE * OUTPUT_ATOM_SIZE
-  T *shared_weight_buffer =
-      (T *)((char *)shared_weight +
-            sizeof(T) * TILE_SIZE *
-                OUTPUT_ATOM_SIZE); // sizeof(T) * TILE_SIZE * OUTPUT_ATOM_SIZE
+  T *shared_weight = (T *)(smem + SHARED_WEIGHT_OFFSET);
+  T *shared_weight_buffer = (T *)(smem + SHARED_WEIGHT_BUFFER_OFFSET);
 
   // intermediate
-  T *mm_intermediate =
-      (T *)((char *)shared_weight_buffer +
-            sizeof(T) * TILE_SIZE *
-                OUTPUT_ATOM_SIZE); // sizeof(T) * BATCH_SIZE *
-                                   // OUTPUT_ATOM_SIZE * NUM_WARPS_K
+  T *mm_intermediate = (T *)(smem + MM_INTERMEDIATE_OFFSET);
 
-  // out
-  T *shared_output = (T *)((char *)mm_intermediate +
-                           sizeof(T) * BATCH_SIZE * OUTPUT_ATOM_SIZE *
-                               NUM_WARPS_K); // sizeof(T) * BATCH_SIZE *
-                                             // OUTPUT_ATOM_SIZE
+  // output
+  T *shared_output = (T *)(smem + SHARED_OUTPUT_OFFSET);
 
   // bias
-  T *shared_bias = (T *)((char *)shared_output +
-                         sizeof(T) * BATCH_SIZE *
-                             OUTPUT_ATOM_SIZE); // sizeof(T) * BATCH_SIZE *
-                                                // OUTPUT_ATOM_SIZE
+  T *shared_bias = bias ? (T *)(smem + SHARED_BIAS_OFFSET) : nullptr;
 
   // define the swizzle mode
-
   using ZeroBufferSmem = smem_row<T, 0, 0, 0, 1, 8, 8>;
   using InputSmem = smem_row<T, 0, 0, 0, BATCH_SIZE, TILE_SIZE, TILE_SIZE>;
   using WeightSmem =
@@ -147,7 +160,7 @@ __device__ __forceinline__ void linear_kernel(void const *input_ptr,
                                           BATCH_SIZE * NUM_WARPS_K,
                                           OUTPUT_ATOM_SIZE,
                                           OUTPUT_ATOM_SIZE>;
-  // zero buffer
+
   ZeroBufferSmem zero_buffer(zero_buf);
 
   InputSmem input_smem(shared_input);
@@ -166,12 +179,12 @@ __device__ __forceinline__ void linear_kernel(void const *input_ptr,
        output_atom_idx++,
            d_weight += OUTPUT_ATOM_SIZE * REDUCTION_SIZE,
            d_output += OUTPUT_ATOM_SIZE,
-           d_bias = bias ? d_bias + OUTPUT_ATOM_SIZE : d_bias) {
+           d_bias = bias ? d_bias + OUTPUT_ATOM_SIZE : nullptr) {
     weight_dmem.set_ptr(d_weight);
     output_dmem.set_ptr(d_output);
     bias_dmem.set_ptr(d_bias);
 
-// load input
+    // load input
 #pragma unroll
     for (int i = threadIdx.x; i < NUM_CHUNKS_A; i += NUM_THREADS) {
       // offset
@@ -180,7 +193,7 @@ __device__ __forceinline__ void linear_kernel(void const *input_ptr,
       load_smem(input_smem_buffer(row, col), input_dmem(row, col));
     }
 
-// load weight
+    // load weight
 #pragma unroll
     for (int i = threadIdx.x; i < NUM_CHUNKS_B; i += NUM_THREADS) {
       int row = (i & (CHUNKS_PER_COL_B - 1)) << log2_CHUNK_SIZE;
@@ -199,9 +212,10 @@ __device__ __forceinline__ void linear_kernel(void const *input_ptr,
     }
     cp_async_fence();
 
-    //  accumulator
+    // accumulator
     float s_frag[NUM_ITERS_M][NUM_ITERS_N][8];
     for (uint32_t m = 0; m < NUM_ITERS_M; m++) {
+#pragma unroll
       for (uint32_t n = 0; n < NUM_ITERS_N; n++) {
 #pragma unroll
         for (uint32_t i = 0; i < 8; i++) {
@@ -232,7 +246,8 @@ __device__ __forceinline__ void linear_kernel(void const *input_ptr,
         cp_async_fence();
         cp_async_wait<1>();
       }
-      // SWAP the double buffer
+
+      // swap the double buffer
       if ((for_idx & 1) == 0) {
         input_smem.set_ptr(shared_input_buffer);
         input_smem_buffer.set_ptr(shared_input);
@@ -250,14 +265,15 @@ __device__ __forceinline__ void linear_kernel(void const *input_ptr,
       for (uint32_t m = 0; m < NUM_ITERS_M; m++) {
         int m_row = (lane_idx & 0xF);
         bool is_valid = (m_row < BATCH_SIZE);
+#pragma unroll
         for (uint32_t n = 0; n < NUM_ITERS_N; n++) {
-          int n_col =
-              (warp_col << 4) + ((lane_idx >> 4) << 3) + (lane_idx & 0x7);
+          int n_col = (n << (4 + log2_NUM_WARPS_N)) + (warp_col << 4) +
+                      ((lane_idx >> 4) << 3) + (lane_idx & 0x7);
 #pragma unroll
           for (uint32_t k = 0; k < NUM_ITERS_K; k++) {
-            int m_col = (warp_row << (4 + log2_NUM_WARPS_N)) + (k << 4) +
+            int m_col = (warp_row << (4 + log2_NUM_ITERS_K)) + (k << 4) +
                         ((lane_idx >> 4) << 3);
-            int n_row = (warp_row << (4 + log2_NUM_WARPS_N)) + (k << 4) +
+            int n_row = (warp_row << (4 + log2_NUM_ITERS_K)) + (k << 4) +
                         (((lane_idx & 0xF) >> 3) << 3);
             T *src_ptr =
                 is_valid ? input_smem(m_row, m_col) : zero_buffer(0, 0);
@@ -271,15 +287,16 @@ __device__ __forceinline__ void linear_kernel(void const *input_ptr,
       __syncthreads();
     }
 
-    // reg write back to smem
+    // write back to shared memory
     for (uint32_t m = 0; m < NUM_ITERS_M; m++) {
+#pragma unroll
       for (uint32_t n = 0; n < NUM_ITERS_N; n++) {
 #pragma unroll
         for (uint32_t i = 0; i < 4; i++) {
           int row_in_warp = (lane_idx >> 2) + ((i & 0x1) << 3);
           if (row_in_warp < BATCH_SIZE) {
-            int col =
-                (warp_col << 4) + ((lane_idx & 0x3) << 1) + ((i >> 1) << 3);
+            int col = (n << (4 + log2_NUM_WARPS_N)) + (warp_col << 4) +
+                      ((lane_idx & 0x3) << 1) + ((i >> 1) << 3);
             mm_intermediate_smem.at(warp_row + row_in_warp, col) =
                 bfloat16(s_frag[m][n][(i << 1)]);
             mm_intermediate_smem.at(warp_row + row_in_warp, col + 1) =

--- a/include/mirage/persistent_kernel/tasks/silu_mul_linear.cuh
+++ b/include/mirage/persistent_kernel/tasks/silu_mul_linear.cuh
@@ -39,9 +39,9 @@ __device__ __forceinline__ void
                               void const *bias_ptr,
                               void *output_ptr) {
   constexpr int CHUNK_SIZE = 16 / sizeof(T);
-  constexpr int TILE_SIZE = 64;
-  constexpr int OUTPUT_ATOM_SIZE = OUTPUT_SIZE <= 64 ? OUTPUT_SIZE : 64;
+  constexpr int OUTPUT_ATOM_SIZE = OUTPUT_SIZE <= 128 ? OUTPUT_SIZE : 128;
   constexpr int NUM_OUTPUT_ATOMS = OUTPUT_SIZE / OUTPUT_ATOM_SIZE;
+  constexpr int TILE_SIZE = 128;
   constexpr int FORLOOP_RANGE = REDUCTION_SIZE / TILE_SIZE;
 
   constexpr int NUM_CHUNKS_A = BATCH_SIZE * TILE_SIZE / CHUNK_SIZE;
@@ -58,14 +58,16 @@ __device__ __forceinline__ void
   constexpr int log2_CHUNKS_PER_ROW_C = log2_constexpr(CHUNKS_PER_ROW_C);
 
   // using SM80_16x8x16_F16F16F16F16_TNX2 = 16X16X16
-  constexpr int NUM_WARPS_N = OUTPUT_ATOM_SIZE / 16; // 1, 2, 4
-  constexpr int NUM_WARPS_K = 4 / NUM_WARPS_N;       // 4, 2, 1
+  constexpr int NUM_WARPS_N =
+      OUTPUT_ATOM_SIZE / 16 <= 4 ? OUTPUT_ATOM_SIZE / 16 : 4;
+  constexpr int NUM_WARPS_K = 4 / NUM_WARPS_N;
 
   constexpr int NUM_ITERS_M = 1;
-  constexpr int NUM_ITERS_N = 1;
-  constexpr int NUM_ITERS_K = 4 / NUM_WARPS_K; // 1, 2, 4
+  constexpr int NUM_ITERS_N = OUTPUT_ATOM_SIZE / NUM_WARPS_N / 16;
+  constexpr int NUM_ITERS_K = TILE_SIZE / NUM_WARPS_K / 16;
 
   constexpr int log2_NUM_WARPS_N = log2_constexpr(NUM_WARPS_N);
+  constexpr int log2_NUM_ITERS_K = log2_constexpr(NUM_ITERS_K);
 
   int warp_idx = warp_id();
   int warp_row = warp_idx >> log2_NUM_WARPS_N;
@@ -94,59 +96,76 @@ __device__ __forceinline__ void
 
   extern __shared__ char smem[];
 
+  // STensors' offsets
+  constexpr size_t ZERO_BUFFER_OFFSET = 0;
+  // sizeof(T) * 8
+
+  constexpr size_t SHARED_INPUT_OFFSET = ZERO_BUFFER_OFFSET + sizeof(T) * 8;
+  // sizeof(T) * BATCH_SIZE * TILE_SIZE
+
+  constexpr size_t SHARED_INPUT_BUFFER_OFFSET =
+      SHARED_INPUT_OFFSET + sizeof(T) * BATCH_SIZE * TILE_SIZE;
+  // sizeof(T) * BATCH_SIZE * TILE_SIZE
+
+  constexpr size_t SHARED_MUL_OFFSET =
+      SHARED_INPUT_BUFFER_OFFSET + sizeof(T) * BATCH_SIZE * TILE_SIZE;
+  // sizeof(T) * BATCH_SIZE * TILE_SIZE
+
+  constexpr size_t SHARED_MUL_BUFFER_OFFSET =
+      SHARED_MUL_OFFSET + sizeof(T) * BATCH_SIZE * TILE_SIZE;
+  // sizeof(T) * BATCH_SIZE * TILE_SIZE
+
+  constexpr size_t SHARED_WEIGHT_OFFSET =
+      SHARED_MUL_BUFFER_OFFSET + sizeof(T) * BATCH_SIZE * TILE_SIZE;
+  // sizeof(T) * TILE_SIZE * OUTPUT_ATOM_SIZE
+
+  constexpr size_t SHARED_WEIGHT_BUFFER_OFFSET =
+      SHARED_WEIGHT_OFFSET + sizeof(T) * TILE_SIZE * OUTPUT_ATOM_SIZE;
+  // sizeof(T) * TILE_SIZE * OUTPUT_ATOM_SIZE
+
+  constexpr size_t SHARED_BIAS_OFFSET =
+      SHARED_WEIGHT_BUFFER_OFFSET + sizeof(T) * TILE_SIZE * OUTPUT_ATOM_SIZE;
+  // sizeof(T) * BATCH_SIZE * OUTPUT_ATOM_SIZE
+
+  constexpr size_t SILU_MUL_OUTPUT_OFFSET =
+      SHARED_BIAS_OFFSET + sizeof(T) * BATCH_SIZE * OUTPUT_ATOM_SIZE;
+  // sizeof(T) * BATCH_SIZE * TILE_SIZE
+
+  constexpr size_t MM_INTERMEDIATE_OFFSET =
+      SILU_MUL_OUTPUT_OFFSET + sizeof(T) * BATCH_SIZE * TILE_SIZE;
+  // sizeof(T) * NUM_WARPS_K * BATCH_SIZE * OUTPUT_ATOM_SIZE
+
+  constexpr size_t SHARED_OUTPUT_OFFSET =
+      MM_INTERMEDIATE_OFFSET +
+      sizeof(T) * NUM_WARPS_K * BATCH_SIZE * OUTPUT_ATOM_SIZE;
+  // sizeof(T) * BATCH_SIZE * OUTPUT_ATOM_SIZE
+
   // zero buffer
-  T *zero_buf = (T *)(smem); // 128 bytes
-  *((__uint128_t *)smem) = 0ul;
+  T *zero_buf = (T *)(smem + ZERO_BUFFER_OFFSET);
+  *((__uint128_t *)zero_buf) = 0ul;
 
   // copy input
-  T *shared_input =
-      (T *)((char *)zero_buf + 128); // sizeof(T) * BATCH_SIZE * TILE_SIZE
-  T *shared_input_buffer =
-      (T *)((char *)shared_input +
-            sizeof(T) * BATCH_SIZE *
-                TILE_SIZE); // sizeof(T) * BATCH_SIZE * TILE_SIZE
+  T *shared_input = (T *)(smem + SHARED_INPUT_OFFSET);
+  T *shared_input_buffer = (T *)(smem + SHARED_INPUT_BUFFER_OFFSET);
 
-  T *shared_mul = (T *)((char *)shared_input_buffer +
-                        sizeof(T) * BATCH_SIZE *
-                            TILE_SIZE); // sizeof(T) *BATCH_SIZE * TILE_SIZE
-  T *shared_mul_buffer =
-      (T *)((char *)shared_mul +
-            sizeof(T) * BATCH_SIZE *
-                TILE_SIZE); // sizeof(T) *BATCH_SIZE * TILE_SIZE
+  T *shared_mul = (T *)(smem + SHARED_MUL_OFFSET);
+  T *shared_mul_buffer = (T *)(smem + SHARED_MUL_BUFFER_OFFSET);
 
   // copy weight
-  T *shared_weight =
-      (T *)((char *)shared_mul_buffer +
-            sizeof(T) * BATCH_SIZE *
-                TILE_SIZE); // sizeof(T) * TILE_SIZE * OUTPUT_ATOM_SIZE
-  T *shared_weight_buffer =
-      (T *)((char *)shared_weight +
-            sizeof(T) * TILE_SIZE *
-                OUTPUT_ATOM_SIZE); // sizeof(T) * TILE_SIZE * OUTPUT_ATOM_SIZE
+  T *shared_weight = (T *)(smem + SHARED_WEIGHT_OFFSET);
+  T *shared_weight_buffer = (T *)(smem + SHARED_WEIGHT_BUFFER_OFFSET);
 
   // bias
-  T *shared_bias =
-      (T *)((char *)shared_weight_buffer +
-            sizeof(T) * TILE_SIZE *
-                OUTPUT_ATOM_SIZE); // sizeof(T) * BATCH_SIZE * OUTPUT_ATOM_SIZE
+  T *shared_bias = (T *)(smem + SHARED_BIAS_OFFSET);
 
   // intermidiate
-  T *silu_output =
-      (T *)((char *)shared_bias +
-            sizeof(T) * BATCH_SIZE *
-                OUTPUT_ATOM_SIZE); // sizeof(T) * BATCH_SIZE * TILE_SIZE
-  T *mul_output = (T *)((char *)silu_output +
-                        sizeof(T) * BATCH_SIZE *
-                            TILE_SIZE); // sizeof(T) * BATCH_SIZE * TILE_SIZE
-
-  T *mm_intermediate =
-      (T *)((char *)mul_output + sizeof(T) * BATCH_SIZE * TILE_SIZE);
+  T *silu_mul_output = (T *)(smem + SILU_MUL_OUTPUT_OFFSET);
+  T *mm_intermediate = (T *)(smem + MM_INTERMEDIATE_OFFSET);
 
   // out
-  T *shared_output = shared_input; // reuse shared_input
+  T *shared_output = (T *)(smem + SHARED_OUTPUT_OFFSET);
 
   // define the swizzle mode
-
   using ZeroBufferSmem = smem_row<T, 0, 0, 0, 1, 8, 8>;
   using InputSmem = smem_row<T, 0, 0, 0, BATCH_SIZE, TILE_SIZE, TILE_SIZE>;
   using WeightSmem =
@@ -157,10 +176,10 @@ __device__ __forceinline__ void
                                           0,
                                           0,
                                           0,
-                                          BATCH_SIZE * NUM_WARPS_K,
+                                          NUM_WARPS_K * BATCH_SIZE,
                                           OUTPUT_ATOM_SIZE,
                                           OUTPUT_ATOM_SIZE>;
-  // zero buffer
+
   ZeroBufferSmem zero_buffer(zero_buf);
 
   InputSmem input_smem(shared_input);
@@ -174,10 +193,7 @@ __device__ __forceinline__ void
 
   OutputSmem bias_smem(shared_bias);
 
-  InputSmem silu_smem(silu_output);
-
-  InputSmem mul_output_smem(mul_output);
-
+  InputSmem silu_mul_output_smem(silu_mul_output);
   MatMulIntermediateSmem mm_intermediate_smem(mm_intermediate);
 
   OutputSmem output_smem(shared_output);
@@ -191,19 +207,12 @@ __device__ __forceinline__ void
     bias_dmem.set_ptr(d_bias);
     output_dmem.set_ptr(d_output);
 
-    // load input
+    // load input and mul
 #pragma unroll
     for (int i = threadIdx.x; i < NUM_CHUNKS_A; i += NUM_THREADS) {
       int row = i >> log2_CHUNKS_PER_ROW_A;
       int col = (i & (CHUNKS_PER_ROW_A - 1)) << log2_CHUNK_SIZE;
       load_smem(input_smem_buffer(row, col), input_dmem(row, col));
-    }
-
-    // load mul
-#pragma unroll
-    for (int i = threadIdx.x; i < NUM_CHUNKS_A; i += NUM_THREADS) {
-      int row = i >> log2_CHUNKS_PER_ROW_A;
-      int col = (i & (CHUNKS_PER_ROW_A - 1)) << log2_CHUNK_SIZE;
       load_smem(mul_smem_buffer(row, col), mul_dmem(row, col));
     }
 
@@ -224,9 +233,10 @@ __device__ __forceinline__ void
     }
     cp_async_fence();
 
-    //  accumulator
+    // accumulator
     float s_frag[NUM_ITERS_M][NUM_ITERS_N][8];
     for (uint32_t m = 0; m < NUM_ITERS_M; m++) {
+#pragma unroll
       for (uint32_t n = 0; n < NUM_ITERS_N; n++) {
 #pragma unroll
         for (uint32_t i = 0; i < 8; i++) {
@@ -247,12 +257,6 @@ __device__ __forceinline__ void
           int row = i >> log2_CHUNKS_PER_ROW_A;
           int col = (i & (CHUNKS_PER_ROW_A - 1)) << log2_CHUNK_SIZE;
           load_smem(input_smem(row, col), input_dmem_buffer(row, col));
-        }
-
-#pragma unroll
-        for (int i = threadIdx.x; i < NUM_CHUNKS_A; i += NUM_THREADS) {
-          int row = i >> log2_CHUNKS_PER_ROW_A;
-          int col = (i & (CHUNKS_PER_ROW_A - 1)) << log2_CHUNK_SIZE;
           load_smem(mul_smem(row, col), mul_dmem_buffer(row, col));
         }
 
@@ -265,7 +269,8 @@ __device__ __forceinline__ void
         cp_async_fence();
         cp_async_wait<1>();
       }
-      // SWAP the double buffer
+
+      // swap the double buffer
       if ((for_idx & 1) == 0) {
         input_smem.set_ptr(shared_input_buffer);
         input_smem_buffer.set_ptr(shared_input);
@@ -281,33 +286,34 @@ __device__ __forceinline__ void
         input_weight_smem.set_ptr(shared_weight);
         input_weight_smem_buffer.set_ptr(shared_weight_buffer);
       }
+      __syncthreads();
 
-      float const scalars[] = {0.0f};
-      perform_element_unary_chain_kernel<false,
-                                         decltype(silu_smem),
-                                         decltype(input_smem),
-                                         ElementUnaryOpType::SILU>(
-          silu_smem, input_smem, scalars);
-
-      mul<decltype(mul_output_smem), decltype(silu_smem), decltype(mul_smem)>(
-          mul_output_smem, silu_smem, mul_smem);
+      // fuse SiLU and mul
+#pragma unroll
+      for (int i = threadIdx.x; i < BATCH_SIZE * TILE_SIZE; i += NUM_THREADS) {
+        float input_val = float(input_smem.at(i));
+        T mul_val = mul_smem.at(i);
+        silu_mul_output_smem.at(i) =
+            T(input_val * (1.0f / (1.0f + expf(-input_val)))) * mul_val;
+      }
       __syncthreads();
 
       uint32_t a_frag[4], b_frag[4];
       for (uint32_t m = 0; m < NUM_ITERS_M; m++) {
         int m_row = (lane_idx & 0xF);
         bool is_valid = (m_row < BATCH_SIZE);
+#pragma unroll
         for (uint32_t n = 0; n < NUM_ITERS_N; n++) {
-          int n_col =
-              (warp_col << 4) + ((lane_idx >> 4) << 3) + (lane_idx & 0x7);
+          int n_col = (n << (4 + log2_NUM_WARPS_N)) + (warp_col << 4) +
+                      ((lane_idx >> 4) << 3) + (lane_idx & 0x7);
 #pragma unroll
           for (uint32_t k = 0; k < NUM_ITERS_K; k++) {
-            int m_col = (warp_row << (4 + log2_NUM_WARPS_N)) + (k << 4) +
+            int m_col = (warp_row << (4 + log2_NUM_ITERS_K)) + (k << 4) +
                         ((lane_idx >> 4) << 3);
-            int n_row = (warp_row << (4 + log2_NUM_WARPS_N)) + (k << 4) +
+            int n_row = (warp_row << (4 + log2_NUM_ITERS_K)) + (k << 4) +
                         (((lane_idx & 0xF) >> 3) << 3);
-            T *src_ptr =
-                is_valid ? mul_output_smem(m_row, m_col) : zero_buffer(0, 0);
+            T *src_ptr = is_valid ? silu_mul_output_smem(m_row, m_col)
+                                  : zero_buffer(0, 0);
             ldsm(src_ptr, a_frag);
             ldsm(input_weight_smem(n_row, n_col), b_frag);
             mma_m16n16k16_bf16bf16bf32(
@@ -318,15 +324,16 @@ __device__ __forceinline__ void
       __syncthreads();
     }
 
-    // reg write back to smem
+    // write back to shared memory
     for (uint32_t m = 0; m < NUM_ITERS_M; m++) {
+#pragma unroll
       for (uint32_t n = 0; n < NUM_ITERS_N; n++) {
 #pragma unroll
         for (uint32_t i = 0; i < 4; i++) {
           int row_in_warp = (lane_idx >> 2) + ((i & 0x1) << 3);
           if (row_in_warp < BATCH_SIZE) {
-            int col =
-                (warp_col << 4) + ((lane_idx & 0x3) << 1) + ((i >> 1) << 3);
+            int col = (n << (4 + log2_NUM_WARPS_N)) + (warp_col << 4) +
+                      ((lane_idx & 0x3) << 1) + ((i >> 1) << 3);
             mm_intermediate_smem.at(warp_row + row_in_warp, col) =
                 bfloat16(s_frag[m][n][(i << 1)]);
             mm_intermediate_smem.at(warp_row + row_in_warp, col + 1) =

--- a/tests/runtime_python/runtime_kernel_wrapper.cu
+++ b/tests/runtime_python/runtime_kernel_wrapper.cu
@@ -244,7 +244,7 @@ void launch_norm_linear(void const *input_ptr,
                         void *output_ptr) {
   dim3 grid_dim(1, 1, 1);
   dim3 block_dim(128, 1, 1);
-  size_t smem_size = 36666;
+  size_t smem_size = 96000;
 
   cudaFuncSetAttribute(
       norm_linear_kernel_wrapper<T, BATCH_SIZE, OUTPUT_SIZE, REDUCTION_SIZE>,


### PR DESCRIPTION
**Description of changes:**
- Compute the offsets of STensors in compiling stage
- Increase `TILE_SIZE` to 128
- Support more `OUTPUT_SIZE`
- Fuse `silu` and `mul`


**Related Issues:**

Linked Issues:
- Issue #305 

