### PR TITLE
optimize `norm_linear` task

### DIFF
--- a/include/mirage/persistent_kernel/tasks/norm_linear.cuh
+++ b/include/mirage/persistent_kernel/tasks/norm_linear.cuh
@@ -29,8 +29,6 @@ namespace kernel {
 
 using bfloat16 = type::bfloat16_t;
 
-// kernel for [16, 64] and any BATCH_SIZE < 16 [x, 64]
-// OUTPUT_SIZE = 16, 32, 64, REDUCTION_SIZE = multiple of 64
 template <typename T,
           int BATCH_SIZE,
           int OUTPUT_SIZE,
@@ -42,11 +40,10 @@ __device__ __forceinline__ void
                           void const *weight_ptr,
                           float eps,
                           void *output_ptr) {
-  // Here we assume the type of T is bfloat16, so the sizeof(T) is 2
   constexpr int CHUNK_SIZE = 16 / sizeof(T);
-  constexpr int TILE_SIZE = 64;
-  constexpr int OUTPUT_ATOM_SIZE = OUTPUT_SIZE <= 64 ? OUTPUT_SIZE : 64;
+  constexpr int OUTPUT_ATOM_SIZE = OUTPUT_SIZE <= 128 ? OUTPUT_SIZE : 128;
   constexpr int NUM_OUTPUT_ATOMS = OUTPUT_SIZE / OUTPUT_ATOM_SIZE;
+  constexpr int TILE_SIZE = 128;
   constexpr int FORLOOP_RANGE = REDUCTION_SIZE / TILE_SIZE;
 
   constexpr int NUM_CHUNKS_A = BATCH_SIZE * TILE_SIZE / CHUNK_SIZE;
@@ -60,14 +57,16 @@ __device__ __forceinline__ void
   constexpr int log2_CHUNKS_PER_COL_B = log2_constexpr(CHUNKS_PER_COL_B);
 
   // using SM80_16x8x16_F16F16F16F16_TNX2 = 16X16X16
-  constexpr int NUM_WARPS_N = OUTPUT_ATOM_SIZE / 16; // 1, 2, 4
-  constexpr int NUM_WARPS_K = 4 / NUM_WARPS_N;       // 4, 2, 1
+  constexpr int NUM_WARPS_N =
+      OUTPUT_ATOM_SIZE / 16 <= 4 ? OUTPUT_ATOM_SIZE / 16 : 4;
+  constexpr int NUM_WARPS_K = 4 / NUM_WARPS_N;
 
   constexpr int NUM_ITERS_M = 1;
-  constexpr int NUM_ITERS_N = 1;
-  constexpr int NUM_ITERS_K = 4 / NUM_WARPS_K; // 1, 2, 4
+  constexpr int NUM_ITERS_N = OUTPUT_ATOM_SIZE / NUM_WARPS_N / 16;
+  constexpr int NUM_ITERS_K = TILE_SIZE / NUM_WARPS_K / 16;
 
   constexpr int log2_NUM_WARPS_N = log2_constexpr(NUM_WARPS_N);
+  constexpr int log2_NUM_ITERS_K = log2_constexpr(NUM_ITERS_K);
 
   int warp_idx = warp_id();
   int warp_row = warp_idx >> log2_NUM_WARPS_N;
@@ -91,72 +90,87 @@ __device__ __forceinline__ void
 
   extern __shared__ char smem[];
 
+  // STensors' offsets
+  constexpr size_t ZERO_BUFFER_OFFSET = 0;
+  // sizeof(T) * 8
+
+  constexpr size_t SHARED_INPUT_OFFSET = ZERO_BUFFER_OFFSET + sizeof(T) * 8;
+  // sizeof(T) * BATCH_SIZE * TILE_SIZE
+
+  constexpr size_t SHARED_INPUT_BUFFER_OFFSET =
+      SHARED_INPUT_OFFSET + sizeof(T) * BATCH_SIZE * TILE_SIZE;
+  // sizeof(T) * BATCH_SIZE * TILE_SIZE
+
+  constexpr size_t SHARED_NORM_WEIGHT_OFFSET =
+      SHARED_INPUT_BUFFER_OFFSET + sizeof(T) * BATCH_SIZE * TILE_SIZE;
+  // sizeof(T) * BATCH_SIZE * TILE_SIZE
+
+  constexpr size_t SHARED_NORM_WEIGHT_BUFFER_OFFSET =
+      SHARED_NORM_WEIGHT_OFFSET + sizeof(T) * BATCH_SIZE * TILE_SIZE;
+  // sizeof(T) * BATCH_SIZE * TILE_SIZE
+
+  constexpr size_t SHARED_WEIGHT_OFFSET =
+      SHARED_NORM_WEIGHT_BUFFER_OFFSET + sizeof(T) * BATCH_SIZE * TILE_SIZE;
+  // sizeof(T) * TILE_SIZE * OUTPUT_ATOM_SIZE
+
+  constexpr size_t SHARED_WEIGHT_BUFFER_OFFSET =
+      SHARED_WEIGHT_OFFSET + sizeof(T) * TILE_SIZE * OUTPUT_ATOM_SIZE;
+  // sizeof(T) * TILE_SIZE * OUTPUT_ATOM_SIZE
+
+  constexpr size_t MUL_OUTPUT_OFFSET =
+      SHARED_WEIGHT_BUFFER_OFFSET + sizeof(T) * TILE_SIZE * OUTPUT_ATOM_SIZE;
+  // sizeof(T) * BATCH_SIZE * TILE_SIZE
+
+  constexpr size_t ELEMENT_UNARY_OUTPUT_OFFSET =
+      MUL_OUTPUT_OFFSET + sizeof(T) * BATCH_SIZE * TILE_SIZE;
+  // sizeof(T) * BATCH_SIZE * TILE_SIZE
+
+  constexpr size_t MM_INTERMEDIATE_OFFSET =
+      ELEMENT_UNARY_OUTPUT_OFFSET + sizeof(T) * BATCH_SIZE * TILE_SIZE;
+  // sizeof(T) * NUM_WARPS_K * BATCH_SIZE * OUTPUT_ATOM_SIZE
+
+  constexpr size_t MM_OUTPUT_OFFSET =
+      MM_INTERMEDIATE_OFFSET +
+      sizeof(T) * NUM_WARPS_K * BATCH_SIZE * OUTPUT_ATOM_SIZE;
+  // sizeof(T) * BATCH_SIZE * OUTPUT_ATOM_SIZE
+
+  constexpr size_t REDUCTION_OUTPUT_OFFSET =
+      MM_OUTPUT_OFFSET + sizeof(T) * BATCH_SIZE * OUTPUT_ATOM_SIZE;
+  // sizeof(T) * BATCH_SIZE * 1
+
+  constexpr size_t SHARED_OUTPUT_OFFSET = MM_INTERMEDIATE_OFFSET;
+  // reuse mm_intermediate
+
   // zero buffer
-  T *zero_buf = (T *)(smem); // 128 bytes
-  *((__uint128_t *)smem) = 0ul;
+  T *zero_buf = (T *)(smem + ZERO_BUFFER_OFFSET);
+  *((__uint128_t *)zero_buf) = 0ul;
 
   // copy input
-  T *shared_input =
-      (T *)((char *)zero_buf + 128); // sizeof(T) * BATCH_SIZE * TILE_SIZE
-  T *shared_input_buffer =
-      (T *)((char *)shared_input +
-            sizeof(T) * BATCH_SIZE *
-                TILE_SIZE); // sizeof(T) * BATCH_SIZE * TILE_SIZE
+  T *shared_input = (T *)(smem + SHARED_INPUT_OFFSET);
+  T *shared_input_buffer = (T *)(smem + SHARED_INPUT_BUFFER_OFFSET);
 
   // copy norm weight
-  T *shared_norm_weight =
-      (T *)((char *)shared_input_buffer +
-            sizeof(T) * BATCH_SIZE *
-                TILE_SIZE); // sizeof(T) * BATCH_SIZE * TILE_SIZE
-  T *shared_norm_weight_buffer =
-      (T *)((char *)shared_norm_weight +
-            sizeof(T) * BATCH_SIZE *
-                TILE_SIZE); // sizeof(T) * BATCH_SIZE * TILE_SIZE
+  T *shared_norm_weight = (T *)(smem + SHARED_NORM_WEIGHT_OFFSET);
+  T *shared_norm_weight_buffer = (T *)(smem + SHARED_NORM_WEIGHT_BUFFER_OFFSET);
 
   // copy weight
-  T *shared_weight =
-      (T *)((char *)shared_norm_weight_buffer +
-            sizeof(T) * BATCH_SIZE *
-                TILE_SIZE); // sizeof(T) * TILE_SIZE * OUTPUT_ATOM_SIZE
-  T *shared_weight_buffer =
-      (T *)((char *)shared_weight +
-            sizeof(T) * TILE_SIZE *
-                OUTPUT_ATOM_SIZE); // sizeof(T) * TILE_SIZE * OUTPUT_ATOM_SIZE
+  T *shared_weight = (T *)(smem + SHARED_WEIGHT_OFFSET);
+  T *shared_weight_buffer = (T *)(smem + SHARED_WEIGHT_BUFFER_OFFSET);
 
   // intermediate
-  T *mul_output =
-      (T *)((char *)shared_weight_buffer +
-            sizeof(T) * TILE_SIZE *
-                OUTPUT_ATOM_SIZE); // sizeof(T) * BATCH_SIZE * TILE_SIZE
-
-  T *element_unary_output =
-      (T *)((char *)mul_output +
-            sizeof(T) * BATCH_SIZE *
-                TILE_SIZE); // sizeof(T) * BATCH_SIZE * TILE_SIZE
+  T *mul_output = (T *)(smem + MUL_OUTPUT_OFFSET);
+  T *element_unary_output = (T *)(smem + ELEMENT_UNARY_OUTPUT_OFFSET);
   for (int i = threadIdx.x; i < BATCH_SIZE * TILE_SIZE; i += NUM_THREADS) {
     element_unary_output[i] = T(0.0f);
   }
+  T *mm_intermediate = (T *)(smem + MM_INTERMEDIATE_OFFSET);
+  T *mm_output = (T *)(smem + MM_OUTPUT_OFFSET);
+  T *reduction_output = (T *)(smem + REDUCTION_OUTPUT_OFFSET);
 
-  T *mm_intermediate = (T *)((char *)element_unary_output +
-                             sizeof(T) * BATCH_SIZE *
-                                 TILE_SIZE); // sizeof(T) * BATCH_SIZE *
-                                             // OUTPUT_ATOM_SIZE * NUM_WARPS_K
-
-  T *mm_output =
-      (T *)((char *)mm_intermediate +
-            sizeof(T) * BATCH_SIZE * OUTPUT_ATOM_SIZE *
-                NUM_WARPS_K); // sizeof(T) * BATCH_SIZE * OUTPUT_ATOM_SIZE
-
-  T *reduction_output =
-      (T *)((char *)mm_output +
-            sizeof(T) * BATCH_SIZE *
-                OUTPUT_ATOM_SIZE); // sizeof(T) * BATCH_SIZE * 1
-
-  // out
-  T *shared_output = mm_intermediate; // reuse mm_intermediate
+  // output
+  T *shared_output = (T *)(smem + SHARED_OUTPUT_OFFSET);
 
   // define the swizzle mode
-
   using ZeroBufferSmem = smem_row<T, 0, 0, 0, 1, 8, 8>;
   using InputSmem = smem_row<T, 0, 0, 0, BATCH_SIZE, TILE_SIZE, TILE_SIZE>;
   using WeightSmem =
@@ -167,12 +181,11 @@ __device__ __forceinline__ void
                                           0,
                                           0,
                                           0,
-                                          BATCH_SIZE * NUM_WARPS_K,
+                                          NUM_WARPS_K * BATCH_SIZE,
                                           OUTPUT_ATOM_SIZE,
                                           OUTPUT_ATOM_SIZE>;
   using ReductionOutputSmem = smem_row<T, 0, 0, 0, BATCH_SIZE, 1, 1>;
 
-  // zero buffer
   ZeroBufferSmem zero_buffer(zero_buf);
 
   InputSmem input_smem(shared_input);
@@ -185,15 +198,12 @@ __device__ __forceinline__ void
   WeightSmem input_weight_smem_buffer(shared_weight_buffer);
 
   InputSmem mul_output_smem(mul_output);
-
   InputSmem element_unary_smem(element_unary_output);
-
   MatMulIntermediateSmem mm_intermediate_smem(mm_intermediate);
-
   OutputSmem mm_output_smem(mm_output);
-  OutputSmem output_smem(shared_output);
-
   ReductionOutputSmem reduction_output_smem(reduction_output);
+
+  OutputSmem output_smem(shared_output);
 
   for (int output_atom_idx = 0; output_atom_idx < NUM_OUTPUT_ATOMS;
        output_atom_idx++,
@@ -202,25 +212,17 @@ __device__ __forceinline__ void
     weight_dmem.set_ptr(d_weight);
     output_dmem.set_ptr(d_output);
 
-// load input
+    // load input and norm weight
 #pragma unroll
     for (int i = threadIdx.x; i < NUM_CHUNKS_A; i += NUM_THREADS) {
       // offset
       int row = i >> log2_CHUNKS_PER_ROW_A;
       int col = (i & (CHUNKS_PER_ROW_A - 1)) << log2_CHUNK_SIZE;
       load_smem(input_smem_buffer(row, col), input_dmem(row, col));
-    }
-
-// load norm weight
-#pragma unroll
-    for (int i = threadIdx.x; i < NUM_CHUNKS_A; i += NUM_THREADS) {
-      // offset
-      int row = i >> log2_CHUNKS_PER_ROW_A;
-      int col = (i & (CHUNKS_PER_ROW_A - 1)) << log2_CHUNK_SIZE;
       load_smem(norm_weight_smem_buffer(row, col), norm_weight_dmem(row, col));
     }
 
-// load weight
+    // load weight
 #pragma unroll
     for (int i = threadIdx.x; i < NUM_CHUNKS_B; i += NUM_THREADS) {
       int row = (i & (CHUNKS_PER_COL_B - 1)) << log2_CHUNK_SIZE;
@@ -229,9 +231,10 @@ __device__ __forceinline__ void
     }
     cp_async_fence();
 
-    //  accumulator
+    // accumulator
     float s_frag[NUM_ITERS_M][NUM_ITERS_N][8];
     for (uint32_t m = 0; m < NUM_ITERS_M; m++) {
+#pragma unroll
       for (uint32_t n = 0; n < NUM_ITERS_N; n++) {
 #pragma unroll
         for (uint32_t i = 0; i < 8; i++) {
@@ -244,7 +247,7 @@ __device__ __forceinline__ void
       // copy
       if (for_idx + 1 != FORLOOP_RANGE) {
         InputDmem input_dmem_buffer(d_input + TILE_SIZE * (for_idx + 1));
-        InputDmem norm_weight_dmem_nuffer(d_norm_weight +
+        InputDmem norm_weight_dmem_buffer(d_norm_weight +
                                           TILE_SIZE * (for_idx + 1));
         WeightDmem weight_dmem_buffer(d_weight + TILE_SIZE * (for_idx + 1));
 
@@ -253,14 +256,8 @@ __device__ __forceinline__ void
           int row = i >> log2_CHUNKS_PER_ROW_A;
           int col = (i & (CHUNKS_PER_ROW_A - 1)) << log2_CHUNK_SIZE;
           load_smem(input_smem(row, col), input_dmem_buffer(row, col));
-        }
-
-#pragma unroll
-        for (int i = threadIdx.x; i < NUM_CHUNKS_A; i += NUM_THREADS) {
-          int row = i >> log2_CHUNKS_PER_ROW_A;
-          int col = (i & (CHUNKS_PER_ROW_A - 1)) << log2_CHUNK_SIZE;
           load_smem(norm_weight_smem(row, col),
-                    norm_weight_dmem_nuffer(row, col));
+                    norm_weight_dmem_buffer(row, col));
         }
 
 #pragma unroll
@@ -272,7 +269,8 @@ __device__ __forceinline__ void
         cp_async_fence();
         cp_async_wait<1>();
       }
-      // SWAP the double buffer
+
+      // swap the double buffer
       if ((for_idx & 1) == 0) {
         input_smem.set_ptr(shared_input_buffer);
         input_smem_buffer.set_ptr(shared_input);
@@ -290,7 +288,6 @@ __device__ __forceinline__ void
       }
       __syncthreads();
 
-      // do mul with norm_weight
       mul<decltype(mul_output_smem),
           decltype(input_smem),
           decltype(norm_weight_smem)>(
@@ -301,14 +298,15 @@ __device__ __forceinline__ void
       for (uint32_t m = 0; m < NUM_ITERS_M; m++) {
         int m_row = (lane_idx & 0xF);
         bool is_valid = (m_row < BATCH_SIZE);
+#pragma unroll
         for (uint32_t n = 0; n < NUM_ITERS_N; n++) {
-          int n_col =
-              (warp_col << 4) + ((lane_idx >> 4) << 3) + (lane_idx & 0x7);
+          int n_col = (n << (4 + log2_NUM_WARPS_N)) + (warp_col << 4) +
+                      ((lane_idx >> 4) << 3) + (lane_idx & 0x7);
 #pragma unroll
           for (uint32_t k = 0; k < NUM_ITERS_K; k++) {
-            int m_col = (warp_row << (4 + log2_NUM_WARPS_N)) + (k << 4) +
+            int m_col = (warp_row << (4 + log2_NUM_ITERS_K)) + (k << 4) +
                         ((lane_idx >> 4) << 3);
-            int n_row = (warp_row << (4 + log2_NUM_WARPS_N)) + (k << 4) +
+            int n_row = (warp_row << (4 + log2_NUM_ITERS_K)) + (k << 4) +
                         (((lane_idx & 0xF) >> 3) << 3);
             T *src_ptr =
                 is_valid ? mul_output_smem(m_row, m_col) : zero_buffer(0, 0);
@@ -330,15 +328,16 @@ __device__ __forceinline__ void
       __syncthreads();
     }
 
-    // reg write back to smem
+    // write back to shared memory
     for (uint32_t m = 0; m < NUM_ITERS_M; m++) {
+#pragma unroll
       for (uint32_t n = 0; n < NUM_ITERS_N; n++) {
 #pragma unroll
         for (uint32_t i = 0; i < 4; i++) {
           int row_in_warp = (lane_idx >> 2) + ((i & 0x1) << 3);
           if (row_in_warp < BATCH_SIZE) {
-            int col =
-                (warp_col << 4) + ((lane_idx & 0x3) << 1) + ((i >> 1) << 3);
+            int col = (n << (4 + log2_NUM_WARPS_N)) + (warp_col << 4) +
+                      ((lane_idx & 0x3) << 1) + ((i >> 1) << 3);
             mm_intermediate_smem.at(warp_row + row_in_warp, col) =
                 bfloat16(s_frag[m][n][(i << 1)]);
             mm_intermediate_smem.at(warp_row + row_in_warp, col + 1) =


### PR DESCRIPTION
**Description of changes:**

- Compute the offsets of STensors in compiling stage
- Increase `TILE_SIZE` to 128
- TODO: adjust `OUTPUT_SIZE` to multiple of 128

**Related Issues:**

Linked Issues:
- Issue #305 


