### PR TITLE
Clear buffers in a unified way

### DIFF
--- a/include/mirage/persistent_kernel/tasks/linear.cuh
+++ b/include/mirage/persistent_kernel/tasks/linear.cuh
@@ -215,8 +215,7 @@ __device__ __forceinline__ void linear_kernel(void const *input_ptr,
     for (uint32_t m = 0; m < NUM_ITERS_M; m++) {
 #pragma unroll
       for (uint32_t n = 0; n < NUM_ITERS_N; n++) {
-        *((__uint128_t *)s_frag[m][n]) = 0ul;
-        *((__uint128_t *)(s_frag[m][n] + 4)) = 0ul;
+        CLEAR_8_FLOATS(s_frag[m][n]);
       }
     }
 

--- a/include/mirage/persistent_kernel/tasks/linear.cuh
+++ b/include/mirage/persistent_kernel/tasks/linear.cuh
@@ -215,10 +215,7 @@ __device__ __forceinline__ void linear_kernel(void const *input_ptr,
     for (uint32_t m = 0; m < NUM_ITERS_M; m++) {
 #pragma unroll
       for (uint32_t n = 0; n < NUM_ITERS_N; n++) {
-#pragma unroll
-        for (uint32_t i = 0; i < 8; i++) {
-          s_frag[m][n][i] = 0.0f;
-        }
+        *((__uint128_t *)s_frag[m][n]) = 0ul;
       }
     }
 

--- a/include/mirage/persistent_kernel/tasks/linear.cuh
+++ b/include/mirage/persistent_kernel/tasks/linear.cuh
@@ -216,6 +216,7 @@ __device__ __forceinline__ void linear_kernel(void const *input_ptr,
 #pragma unroll
       for (uint32_t n = 0; n < NUM_ITERS_N; n++) {
         *((__uint128_t *)s_frag[m][n]) = 0ul;
+        *((__uint128_t *)(s_frag[m][n] + 4)) = 0ul;
       }
     }
 

--- a/include/mirage/persistent_kernel/tasks/linear.cuh
+++ b/include/mirage/persistent_kernel/tasks/linear.cuh
@@ -215,7 +215,7 @@ __device__ __forceinline__ void linear_kernel(void const *input_ptr,
     for (uint32_t m = 0; m < NUM_ITERS_M; m++) {
 #pragma unroll
       for (uint32_t n = 0; n < NUM_ITERS_N; n++) {
-        CLEAR_8_FLOATS(s_frag[m][n]);
+        clear_8_floats(s_frag[m][n]);
       }
     }
 

--- a/include/mirage/persistent_kernel/tasks/matmul_demo.cuh
+++ b/include/mirage/persistent_kernel/tasks/matmul_demo.cuh
@@ -108,10 +108,7 @@ __device__ __forceinline__ void norm_linear_kernel(void const *input_ptr,
 
   //  accumulator
   float s_frag[num_m][num_n][8];
-#pragma unroll
-  for (int i = 0; i < 8; ++i) {
-    s_frag[0][0][i] = 0.0f;
-  }
+  *((__uint128_t *)s_frag[0][0]) = 0ul;
 
   for (int for_idx = 0; for_idx < 64; for_idx++) {
     // copy

--- a/include/mirage/persistent_kernel/tasks/matmul_demo.cuh
+++ b/include/mirage/persistent_kernel/tasks/matmul_demo.cuh
@@ -109,6 +109,7 @@ __device__ __forceinline__ void norm_linear_kernel(void const *input_ptr,
   //  accumulator
   float s_frag[num_m][num_n][8];
   *((__uint128_t *)s_frag[0][0]) = 0ul;
+  *((__uint128_t *)(s_frag[0][0] + 4)) = 0ul;
 
   for (int for_idx = 0; for_idx < 64; for_idx++) {
     // copy

--- a/include/mirage/persistent_kernel/tasks/matmul_demo.cuh
+++ b/include/mirage/persistent_kernel/tasks/matmul_demo.cuh
@@ -108,8 +108,7 @@ __device__ __forceinline__ void norm_linear_kernel(void const *input_ptr,
 
   //  accumulator
   float s_frag[num_m][num_n][8];
-  *((__uint128_t *)s_frag[0][0]) = 0ul;
-  *((__uint128_t *)(s_frag[0][0] + 4)) = 0ul;
+  CLEAR_8_FLOATS(s_frag[0][0]);
 
   for (int for_idx = 0; for_idx < 64; for_idx++) {
     // copy

--- a/include/mirage/persistent_kernel/tasks/matmul_demo.cuh
+++ b/include/mirage/persistent_kernel/tasks/matmul_demo.cuh
@@ -108,7 +108,7 @@ __device__ __forceinline__ void norm_linear_kernel(void const *input_ptr,
 
   //  accumulator
   float s_frag[num_m][num_n][8];
-  CLEAR_8_FLOATS(s_frag[0][0]);
+  clear_8_floats(s_frag[0][0]);
 
   for (int for_idx = 0; for_idx < 64; for_idx++) {
     // copy

--- a/include/mirage/persistent_kernel/tasks/norm_linear.cuh
+++ b/include/mirage/persistent_kernel/tasks/norm_linear.cuh
@@ -152,9 +152,7 @@ __device__ __forceinline__ void
   // intermediate
   T *mul_output = (T *)(smem + MUL_OUTPUT_OFFSET);
   T *element_unary_output = (T *)(smem + ELEMENT_UNARY_OUTPUT_OFFSET);
-  for (int i = threadIdx.x; i < BATCH_SIZE * TILE_SIZE; i += NUM_THREADS) {
-    element_unary_output[i] = T(0.0f);
-  }
+  clear_smem_buffer<T, BATCH_SIZE * TILE_SIZE>(element_unary_output);
   T *mm_intermediate = (T *)(smem + MM_INTERMEDIATE_OFFSET);
   T *mm_output = (T *)(smem + MM_OUTPUT_OFFSET);
   T *reduction_output = (T *)(smem + REDUCTION_OUTPUT_OFFSET);
@@ -237,7 +235,6 @@ __device__ __forceinline__ void
 
     // accumulator
     float s_frag[NUM_ITERS_M][NUM_ITERS_N][8];
-#pragma unroll
     for (uint32_t m = 0; m < NUM_ITERS_M; m++) {
 #pragma unroll
       for (uint32_t n = 0; n < NUM_ITERS_N; n++) {

--- a/include/mirage/persistent_kernel/tasks/norm_linear.cuh
+++ b/include/mirage/persistent_kernel/tasks/norm_linear.cuh
@@ -238,7 +238,7 @@ __device__ __forceinline__ void
     for (uint32_t m = 0; m < NUM_ITERS_M; m++) {
 #pragma unroll
       for (uint32_t n = 0; n < NUM_ITERS_N; n++) {
-        CLEAR_8_FLOATS(s_frag[m][n]);
+        clear_8_floats(s_frag[m][n]);
       }
     }
 

--- a/include/mirage/persistent_kernel/tasks/norm_linear.cuh
+++ b/include/mirage/persistent_kernel/tasks/norm_linear.cuh
@@ -239,6 +239,7 @@ __device__ __forceinline__ void
 #pragma unroll
       for (uint32_t n = 0; n < NUM_ITERS_N; n++) {
         *((__uint128_t *)s_frag[m][n]) = 0ul;
+        *((__uint128_t *)(s_frag[m][n] + 4)) = 0ul;
       }
     }
 

--- a/include/mirage/persistent_kernel/tasks/norm_linear.cuh
+++ b/include/mirage/persistent_kernel/tasks/norm_linear.cuh
@@ -238,8 +238,7 @@ __device__ __forceinline__ void
     for (uint32_t m = 0; m < NUM_ITERS_M; m++) {
 #pragma unroll
       for (uint32_t n = 0; n < NUM_ITERS_N; n++) {
-        *((__uint128_t *)s_frag[m][n]) = 0ul;
-        *((__uint128_t *)(s_frag[m][n] + 4)) = 0ul;
+        CLEAR_8_FLOATS(s_frag[m][n]);
       }
     }
 

--- a/include/mirage/persistent_kernel/tasks/norm_linear.cuh
+++ b/include/mirage/persistent_kernel/tasks/norm_linear.cuh
@@ -237,13 +237,11 @@ __device__ __forceinline__ void
 
     // accumulator
     float s_frag[NUM_ITERS_M][NUM_ITERS_N][8];
+#pragma unroll
     for (uint32_t m = 0; m < NUM_ITERS_M; m++) {
 #pragma unroll
       for (uint32_t n = 0; n < NUM_ITERS_N; n++) {
-#pragma unroll
-        for (uint32_t i = 0; i < 8; i++) {
-          s_frag[m][n][i] = 0.0f;
-        }
+        *((__uint128_t *)s_frag[m][n]) = 0ul;
       }
     }
 

--- a/include/mirage/persistent_kernel/tasks/silu_mul_linear.cuh
+++ b/include/mirage/persistent_kernel/tasks/silu_mul_linear.cuh
@@ -242,10 +242,7 @@ __device__ __forceinline__ void
     for (uint32_t m = 0; m < NUM_ITERS_M; m++) {
 #pragma unroll
       for (uint32_t n = 0; n < NUM_ITERS_N; n++) {
-#pragma unroll
-        for (uint32_t i = 0; i < 8; i++) {
-          s_frag[m][n][i] = 0.0f;
-        }
+        *((__uint128_t *)s_frag[m][n]) = 0ul;
       }
     }
 

--- a/include/mirage/persistent_kernel/tasks/silu_mul_linear.cuh
+++ b/include/mirage/persistent_kernel/tasks/silu_mul_linear.cuh
@@ -242,8 +242,7 @@ __device__ __forceinline__ void
     for (uint32_t m = 0; m < NUM_ITERS_M; m++) {
 #pragma unroll
       for (uint32_t n = 0; n < NUM_ITERS_N; n++) {
-        *((__uint128_t *)s_frag[m][n]) = 0ul;
-        *((__uint128_t *)(s_frag[m][n] + 4)) = 0ul;
+        CLEAR_8_FLOATS(s_frag[m][n]);
       }
     }
 

--- a/include/mirage/persistent_kernel/tasks/silu_mul_linear.cuh
+++ b/include/mirage/persistent_kernel/tasks/silu_mul_linear.cuh
@@ -242,7 +242,7 @@ __device__ __forceinline__ void
     for (uint32_t m = 0; m < NUM_ITERS_M; m++) {
 #pragma unroll
       for (uint32_t n = 0; n < NUM_ITERS_N; n++) {
-        CLEAR_8_FLOATS(s_frag[m][n]);
+        clear_8_floats(s_frag[m][n]);
       }
     }
 

--- a/include/mirage/persistent_kernel/tasks/silu_mul_linear.cuh
+++ b/include/mirage/persistent_kernel/tasks/silu_mul_linear.cuh
@@ -243,6 +243,7 @@ __device__ __forceinline__ void
 #pragma unroll
       for (uint32_t n = 0; n < NUM_ITERS_N; n++) {
         *((__uint128_t *)s_frag[m][n]) = 0ul;
+        *((__uint128_t *)(s_frag[m][n] + 4)) = 0ul;
       }
     }
 

--- a/include/mirage/persistent_kernel/tasks/single_batch_decoding.cuh
+++ b/include/mirage/persistent_kernel/tasks/single_batch_decoding.cuh
@@ -146,8 +146,7 @@ __device__ __forceinline__ void
   float o[8][8];
 #pragma unroll
   for (int n = 0; n < 8; n++) {
-    *((__uint128_t *)o[n]) = 0ul;
-    *((__uint128_t *)(o[n] + 4)) = 0ul;
+    CLEAR_8_FLOATS(o[n]);
   }
   float d_sum = 1.f;
   float m = -inf;
@@ -264,8 +263,7 @@ __device__ __forceinline__ void
     __syncthreads();
 
     float s_frag[8];
-    *((__uint128_t *)s_frag) = 0ul;
-    *((__uint128_t *)(s_frag + 4)) = 0ul;
+    CLEAR_8_FLOATS(s_frag);
 
     uint32_t a_frag[4], b_frag[4], v_frag[4];
 

--- a/include/mirage/persistent_kernel/tasks/single_batch_decoding.cuh
+++ b/include/mirage/persistent_kernel/tasks/single_batch_decoding.cuh
@@ -146,10 +146,7 @@ __device__ __forceinline__ void
   float o[8][8];
 #pragma unroll
   for (int n = 0; n < 8; n++) {
-#pragma unroll
-    for (int frag_idx = 0; frag_idx < 8; frag_idx++) {
-      o[n][frag_idx] = 0.0f;
-    }
+    *((__uint128_t *)o[n]) = 0ul;
   }
   float d_sum = 1.f;
   float m = -inf;
@@ -266,10 +263,7 @@ __device__ __forceinline__ void
     __syncthreads();
 
     float s_frag[8];
-#pragma unroll
-    for (int frag_idx = 0; frag_idx < 8; frag_idx++) {
-      s_frag[frag_idx] = 0.0f;
-    }
+    *((__uint128_t *)s_frag) = 0ul;
 
     uint32_t a_frag[4], b_frag[4], v_frag[4];
 

--- a/include/mirage/persistent_kernel/tasks/single_batch_decoding.cuh
+++ b/include/mirage/persistent_kernel/tasks/single_batch_decoding.cuh
@@ -147,6 +147,7 @@ __device__ __forceinline__ void
 #pragma unroll
   for (int n = 0; n < 8; n++) {
     *((__uint128_t *)o[n]) = 0ul;
+    *((__uint128_t *)(o[n] + 4)) = 0ul;
   }
   float d_sum = 1.f;
   float m = -inf;
@@ -264,6 +265,7 @@ __device__ __forceinline__ void
 
     float s_frag[8];
     *((__uint128_t *)s_frag) = 0ul;
+    *((__uint128_t *)(s_frag + 4)) = 0ul;
 
     uint32_t a_frag[4], b_frag[4], v_frag[4];
 

--- a/include/mirage/persistent_kernel/tasks/single_batch_decoding.cuh
+++ b/include/mirage/persistent_kernel/tasks/single_batch_decoding.cuh
@@ -146,7 +146,7 @@ __device__ __forceinline__ void
   float o[8][8];
 #pragma unroll
   for (int n = 0; n < 8; n++) {
-    CLEAR_8_FLOATS(o[n]);
+    clear_8_floats(o[n]);
   }
   float d_sum = 1.f;
   float m = -inf;
@@ -263,7 +263,7 @@ __device__ __forceinline__ void
     __syncthreads();
 
     float s_frag[8];
-    CLEAR_8_FLOATS(s_frag);
+    clear_8_floats(s_frag);
 
     uint32_t a_frag[4], b_frag[4], v_frag[4];
 

--- a/include/mirage/persistent_kernel/tasks/single_batch_gqa.cuh
+++ b/include/mirage/persistent_kernel/tasks/single_batch_gqa.cuh
@@ -146,7 +146,7 @@ __device__ __forceinline__ void
   float o[8][8];
 #pragma unroll
   for (int n = 0; n < 8; n++) {
-    CLEAR_8_FLOATS(o[n]);
+    clear_8_floats(o[n]);
   }
 
   // 16 * 128
@@ -257,7 +257,7 @@ __device__ __forceinline__ void
     __syncthreads();
 
     float s_frag[8];
-    CLEAR_8_FLOATS(s_frag);
+    clear_8_floats(s_frag);
 
     uint32_t a_frag[4], b_frag[4], v_frag[4];
     // MNK = 7, 64, 128, tiledMMA 7, 64, 16, thread layout 1,4,1

--- a/include/mirage/persistent_kernel/tasks/single_batch_gqa.cuh
+++ b/include/mirage/persistent_kernel/tasks/single_batch_gqa.cuh
@@ -147,6 +147,7 @@ __device__ __forceinline__ void
 #pragma unroll
   for (int n = 0; n < 8; n++) {
     *((__uint128_t *)o[n]) = 0ul;
+    *((__uint128_t *)(o[n] + 4)) = 0ul;
   }
 
   // 16 * 128

--- a/include/mirage/persistent_kernel/tasks/single_batch_gqa.cuh
+++ b/include/mirage/persistent_kernel/tasks/single_batch_gqa.cuh
@@ -146,10 +146,7 @@ __device__ __forceinline__ void
   float o[8][8];
 #pragma unroll
   for (int n = 0; n < 8; n++) {
-#pragma unroll
-    for (int frag_idx = 0; frag_idx < 8; frag_idx++) {
-      o[n][frag_idx] = 0.0f;
-    }
+    *((__uint128_t *)o[n]) = 0ul;
   }
 
   // 16 * 128
@@ -260,10 +257,7 @@ __device__ __forceinline__ void
     __syncthreads();
 
     float s_frag[8];
-#pragma unroll
-    for (int frag_idx = 0; frag_idx < 8; frag_idx++) {
-      s_frag[frag_idx] = 0.0f;
-    }
+    *((__uint128_t *)s_frag) = 0ul;
 
     uint32_t a_frag[4], b_frag[4], v_frag[4];
     // MNK = 7, 64, 128, tiledMMA 7, 64, 16, thread layout 1,4,1

--- a/include/mirage/persistent_kernel/tasks/single_batch_gqa.cuh
+++ b/include/mirage/persistent_kernel/tasks/single_batch_gqa.cuh
@@ -257,7 +257,7 @@ __device__ __forceinline__ void
     __syncthreads();
 
     float s_frag[8];
-    *((__uint128_t *)s_frag) = 0ul;
+    CLEAR_8_FLOATS(s_frag);
 
     uint32_t a_frag[4], b_frag[4], v_frag[4];
     // MNK = 7, 64, 128, tiledMMA 7, 64, 16, thread layout 1,4,1

--- a/include/mirage/persistent_kernel/tasks/single_batch_gqa.cuh
+++ b/include/mirage/persistent_kernel/tasks/single_batch_gqa.cuh
@@ -146,8 +146,7 @@ __device__ __forceinline__ void
   float o[8][8];
 #pragma unroll
   for (int n = 0; n < 8; n++) {
-    *((__uint128_t *)o[n]) = 0ul;
-    *((__uint128_t *)(o[n] + 4)) = 0ul;
+    CLEAR_8_FLOATS(o[n]);
   }
 
   // 16 * 128

--- a/include/mirage/persistent_kernel/tasks/utils.cuh
+++ b/include/mirage/persistent_kernel/tasks/utils.cuh
@@ -14,11 +14,6 @@
  */
 #pragma once
 #include "common.h"
-
-#define CLEAR_8_FLOATS(v) \
-  *((__uint128_t *)(v)) = 0ul; \
-  *((__uint128_t *)(v + 4)) = 0ul;
-
 namespace kernel {
 using bfloat16 = type::bfloat16_t;
 
@@ -81,6 +76,11 @@ __device__ __forceinline__ void clear_smem_buffer(T *buffer) {
       buffer[i] = T(0.0f);
     }
   }
+}
+
+static __device__ __forceinline__ void clear_8_floats(float *buffer) {
+  *((__uint128_t *)(buffer)) = 0ul;
+  *((__uint128_t *)(buffer + 4)) = 0ul;
 }
 
 } // namespace kernel

--- a/include/mirage/persistent_kernel/tasks/utils.cuh
+++ b/include/mirage/persistent_kernel/tasks/utils.cuh
@@ -14,6 +14,11 @@
  */
 #pragma once
 #include "common.h"
+
+#define CLEAR_8_FLOATS(v) \
+  *((__uint128_t *)(v)) = 0ul; \
+  *((__uint128_t *)(v + 4)) = 0ul;
+
 namespace kernel {
 using bfloat16 = type::bfloat16_t;
 

--- a/tests/runtime_python/runtime_kernel_wrapper.cu
+++ b/tests/runtime_python/runtime_kernel_wrapper.cu
@@ -16,166 +16,6 @@ using kernel::single_batch_decoding_kernel;
 using kernel::single_batch_gqa_kernel;
 using bfloat16 = type::bfloat16_t;
 
-#define DISPATCH_OUTPUT_SIZE(OUTPUT_SIZE, FUNC, T, ...)                        \
-  if ((OUTPUT_SIZE) == 16) {                                                   \
-    FUNC<T, 1, 16, 4096>(__VA_ARGS__);                                         \
-  } else if ((OUTPUT_SIZE) == 32) {                                            \
-    FUNC<T, 1, 32, 4096>(__VA_ARGS__);                                         \
-  } else if ((OUTPUT_SIZE) == 64) {                                            \
-    FUNC<T, 1, 64, 4096>(__VA_ARGS__);                                         \
-  } else {                                                                     \
-    printf("Unsupported output size: %d\n", OUTPUT_SIZE);                      \
-  }
-
-#define DISPATCH_OUTPUT_SIZE_FOR_RED_SIZE_4K(OUTPUT_SIZE, FUNC, T, ...)        \
-  if ((OUTPUT_SIZE) == 16) {                                                   \
-    FUNC<T, 1, 16, 4096>(__VA_ARGS__);                                         \
-  } else if ((OUTPUT_SIZE) == 32) {                                            \
-    FUNC<T, 1, 32, 4096>(__VA_ARGS__);                                         \
-  } else if ((OUTPUT_SIZE) == 64) {                                            \
-    FUNC<T, 1, 64, 4096>(__VA_ARGS__);                                         \
-  } else if ((OUTPUT_SIZE) == 256) {                                           \
-    FUNC<T, 1, 256, 4096>(__VA_ARGS__);                                        \
-  } else if ((OUTPUT_SIZE) == 1600) {                                          \
-    FUNC<T, 1, 1600, 4096>(__VA_ARGS__);                                       \
-  } else {                                                                     \
-    printf("Unsupported output size: %d\n", OUTPUT_SIZE);                      \
-  }
-
-#define DISPATCH_OUTPUT_SIZE_FOR_RED_SIZE_12K(OUTPUT_SIZE, FUNC, T, ...)       \
-  if ((OUTPUT_SIZE) == 16) {                                                   \
-    FUNC<T, 1, 16, 12288>(__VA_ARGS__);                                        \
-  } else if ((OUTPUT_SIZE) == 32) {                                            \
-    FUNC<T, 1, 32, 12288>(__VA_ARGS__);                                        \
-  } else if ((OUTPUT_SIZE) == 64) {                                            \
-    FUNC<T, 1, 64, 12288>(__VA_ARGS__);                                        \
-  } else {                                                                     \
-    printf("Unsupported output size: %d\n", OUTPUT_SIZE);                      \
-  }
-
-#define DISPATCH_SEQ_LEN(SEQ_LEN, FUNC, T, ...)                                \
-  if ((SEQ_LEN) <= 8) {                                                        \
-    FUNC<T, 8>(__VA_ARGS__);                                                   \
-  } else if ((SEQ_LEN) <= 16) {                                                \
-    FUNC<T, 16>(__VA_ARGS__);                                                  \
-  } else if ((SEQ_LEN) <= 24) {                                                \
-    FUNC<T, 24>(__VA_ARGS__);                                                  \
-  } else if ((SEQ_LEN) <= 32) {                                                \
-    FUNC<T, 32>(__VA_ARGS__);                                                  \
-  } else if ((SEQ_LEN) <= 40) {                                                \
-    FUNC<T, 40>(__VA_ARGS__);                                                  \
-  } else if ((SEQ_LEN) <= 48) {                                                \
-    FUNC<T, 48>(__VA_ARGS__);                                                  \
-  } else if ((SEQ_LEN) <= 56) {                                                \
-    FUNC<T, 56>(__VA_ARGS__);                                                  \
-  } else if ((SEQ_LEN) <= 64) {                                                \
-    FUNC<T, 64>(__VA_ARGS__);                                                  \
-  } else if ((SEQ_LEN) <= 72) {                                                \
-    FUNC<T, 72>(__VA_ARGS__);                                                  \
-  } else if ((SEQ_LEN) <= 80) {                                                \
-    FUNC<T, 80>(__VA_ARGS__);                                                  \
-  } else if ((SEQ_LEN) <= 88) {                                                \
-    FUNC<T, 88>(__VA_ARGS__);                                                  \
-  } else if ((SEQ_LEN) <= 96) {                                                \
-    FUNC<T, 96>(__VA_ARGS__);                                                  \
-  } else if ((SEQ_LEN) <= 104) {                                               \
-    FUNC<T, 104>(__VA_ARGS__);                                                 \
-  } else if ((SEQ_LEN) <= 112) {                                               \
-    FUNC<T, 112>(__VA_ARGS__);                                                 \
-  } else if ((SEQ_LEN) <= 120) {                                               \
-    FUNC<T, 120>(__VA_ARGS__);                                                 \
-  } else if ((SEQ_LEN) <= 128) {                                               \
-    FUNC<T, 128>(__VA_ARGS__);                                                 \
-  } else {                                                                     \
-    printf("Unsupported seq_len: %zu\n", SEQ_LEN);                             \
-  }
-
-// Single Batch Decoding
-
-// template <typename T>
-// __global__ void
-//     single_batch_decoding_kernel_wrapper(void const *qkv_ptr,
-//                                          void *k_cache_ptr,
-//                                          void *v_cache_ptr,
-//                                          void *output_ptr,
-//                                          size_t seq_len,
-//                                          bool qk_norm,
-//                                          bool rotary_embed,
-//                                          void const *qnorm_weight_ptr,
-//                                          void const *knorm_weight_ptr,
-//                                          void const *cos_ptr,
-//                                          void const *sin_ptr,
-//                                          float q_eps,
-//                                          float k_eps) {
-//   single_batch_decoding_kernel<T, 4>(qkv_ptr,
-//                                      k_cache_ptr,
-//                                      v_cache_ptr,
-//                                      output_ptr,
-//                                      seq_len,
-//                                      qk_norm,
-//                                      rotary_embed,
-//                                      qnorm_weight_ptr,
-//                                      knorm_weight_ptr,
-//                                      cos_ptr,
-//                                      sin_ptr,
-//                                      q_eps,
-//                                      k_eps);
-// }
-
-// void single_batch_decoding(
-//     torch::Tensor qkv,
-//     torch::Tensor k_cache,
-//     torch::Tensor v_cache,
-//     torch::Tensor output,
-//     size_t seq_len,
-//     bool qk_norm,
-//     bool rotary_embed,
-//     torch::optional<torch::Tensor> qnorm_weight = torch::nullopt,
-//     torch::optional<torch::Tensor> knorm_weight = torch::nullopt,
-//     torch::optional<torch::Tensor> cos = torch::nullopt,
-//     torch::optional<torch::Tensor> sin = torch::nullopt,
-//     float q_eps = 0.0f,
-//     float k_eps = 0.0f) {
-
-//   void const *qkv_ptr = qkv.data_ptr();
-//   void *k_cache_ptr = k_cache.data_ptr();
-//   void *v_cache_ptr = v_cache.data_ptr();
-//   void *output_ptr = output.data_ptr();
-
-//   void const *qnorm_weight_ptr = qk_norm ? qnorm_weight->data_ptr() :
-//   nullptr; void const *knorm_weight_ptr = qk_norm ? knorm_weight->data_ptr()
-//   : nullptr; void const *cos_ptr = rotary_embed ? cos->data_ptr() : nullptr;
-//   void const *sin_ptr = rotary_embed ? sin->data_ptr() : nullptr;
-
-//   dim3 grid_dim(1, 1, 1);
-//   dim3 block_dim(128, 1, 1);
-//   size_t smem_size = 88888;
-
-//   cudaFuncSetAttribute(single_batch_decoding_kernel_wrapper<bfloat16>,
-//                        cudaFuncAttributeMaxDynamicSharedMemorySize,
-//                        smem_size);
-
-//   single_batch_decoding_kernel_wrapper<bfloat16>
-//       <<<grid_dim, block_dim, smem_size>>>(qkv_ptr,
-//                                            k_cache_ptr,
-//                                            v_cache_ptr,
-//                                            output_ptr,
-//                                            seq_len,
-//                                            qk_norm,
-//                                            rotary_embed,
-//                                            qnorm_weight_ptr,
-//                                            knorm_weight_ptr,
-//                                            cos_ptr,
-//                                            sin_ptr,
-//                                            q_eps,
-//                                            k_eps);
-
-//   cudaError_t err = cudaDeviceSynchronize();
-//   if (err != cudaSuccess) {
-//     printf("CUDA kernel launch error: %s\n", cudaGetErrorString(err));
-//   }
-// }
-
 template <typename T>
 __global__ void single_batch_gqa_kernel_wrapper(void const *qkv_ptr,
                                                 void *k_cache_ptr,
@@ -305,14 +145,31 @@ void norm_linear(torch::Tensor input,
   void const *weight_ptr = weight.data_ptr();
   void *output_ptr = output.data_ptr();
 
-  DISPATCH_OUTPUT_SIZE_FOR_RED_SIZE_4K(output.size(1),
-                                       launch_norm_linear,
-                                       bfloat16,
-                                       input_ptr,
-                                       norm_weight_ptr,
-                                       weight_ptr,
-                                       eps,
-                                       output_ptr);
+  switch (output.size(1)) {
+    case 16:
+      launch_norm_linear<bfloat16, 1, 16, 4096>(input_ptr, norm_weight_ptr,
+                                                weight_ptr, eps, output_ptr);
+      break;
+    case 32:
+      launch_norm_linear<bfloat16, 1, 32, 4096>(input_ptr, norm_weight_ptr,
+                                                weight_ptr, eps, output_ptr);
+      break;
+    case 64:
+      launch_norm_linear<bfloat16, 1, 64, 4096>(input_ptr, norm_weight_ptr,
+                                                weight_ptr, eps, output_ptr);
+      break;
+    case 256:
+      launch_norm_linear<bfloat16, 1, 256, 4096>(input_ptr, norm_weight_ptr,
+                                                weight_ptr, eps, output_ptr);
+      break;
+    case 1600:
+      launch_norm_linear<bfloat16, 1, 1600, 4096>(input_ptr, norm_weight_ptr,
+                                                weight_ptr, eps, output_ptr);
+      break;
+    default:
+      printf("Unsupported output size in test: %zu\n", output.size(1));
+      break;
+  }
 
   cudaError_t err = cudaDeviceSynchronize();
   if (err != cudaSuccess) {
@@ -362,13 +219,23 @@ void silu_mul_linear(torch::Tensor input,
   void const *bias_ptr = bias.data_ptr();
   void *output_ptr = output.data_ptr();
 
-  DISPATCH_OUTPUT_SIZE_FOR_RED_SIZE_12K(output.size(1),
-                                        launch_silu_mul_linear,
-                                        bfloat16,
-                                        input_ptr,
-                                        weight_ptr,
-                                        bias_ptr,
-                                        output_ptr);
+  switch (output.size(1)) {
+    case 16:
+      launch_silu_mul_linear<bfloat16, 1, 16, 12288>(input_ptr, weight_ptr,
+                                                     bias_ptr, output_ptr);
+      break;
+    case 32:
+      launch_silu_mul_linear<bfloat16, 1, 32, 12288>(input_ptr, weight_ptr,
+                                                     bias_ptr, output_ptr);
+      break;
+    case 64:
+      launch_silu_mul_linear<bfloat16, 1, 64, 12288>(input_ptr, weight_ptr,
+                                                     bias_ptr, output_ptr);
+      break;
+    default:
+      printf("Unsupported output size in test: %zu\n", output.size(1));
+      break;
+  }
 
   cudaError_t err = cudaDeviceSynchronize();
   if (err != cudaSuccess) {
@@ -416,13 +283,23 @@ void linear(torch::Tensor input,
   void const *residual_ptr = residual.data_ptr();
   void *output_ptr = output.data_ptr();
 
-  DISPATCH_OUTPUT_SIZE_FOR_RED_SIZE_4K(output.size(1),
-                                       launch_linear,
-                                       bfloat16,
-                                       input_ptr,
-                                       weight_ptr,
-                                       residual_ptr,
-                                       output_ptr);
+  switch (output.size(1)) {
+    case 16:
+      launch_linear<bfloat16, 1, 16, 4096>(input_ptr, weight_ptr,
+                                           residual_ptr, output_ptr);
+      break;
+    case 32:
+      launch_linear<bfloat16, 1, 32, 4096>(input_ptr, weight_ptr,
+                                           residual_ptr, output_ptr);
+      break;
+    case 64:
+      launch_linear<bfloat16, 1, 64, 4096>(input_ptr, weight_ptr,
+                                           residual_ptr, output_ptr);
+      break;
+    default:
+      printf("Unsupported output size in test: %zu\n", output.size(1));
+      break;
+  }
 
   cudaError_t err = cudaDeviceSynchronize();
   if (err != cudaSuccess) {

--- a/tests/runtime_python/test_alignment_norm_linear.py
+++ b/tests/runtime_python/test_alignment_norm_linear.py
@@ -2,31 +2,44 @@ import torch
 from runtime_kernel import norm_linear
 
 torch.set_printoptions(sci_mode=False)
-rms_norm = torch.nn.RMSNorm(4096, dtype=torch.bfloat16, device="cuda")
+reduction_size = 4096
 
-
-def torch_rms_norm(X, W):
-    D = rms_norm(X)
-    E = torch.matmul(D, W)
-    return E
-
+def torch_rms_norm(X, G, W, eps):
+    variance = X.pow(2).mean(-1, keepdim=True)
+    X = X * torch.rsqrt(variance + eps)
+    X = torch.mul(X, G)
+    WT = torch.transpose(W, 0, 1)
+    O = torch.matmul(X, WT)
+    return O
 
 # Define the input tensor and parameters
+EPS = 0.8765  # Standard epsilon value for RMSNorm
 input_token = torch.randint(32768, (1, 1), dtype=torch.uint16, device="cuda")
 embed_tokens = torch.randn((32768, 4096), dtype=torch.bfloat16, device="cuda")
-layer_0_input_layernorm = torch.randn(4096, dtype=torch.bfloat16, device="cuda")
+layer_0_input_layernorm_weight = torch.randn((1, 4096), dtype=torch.bfloat16, device="cuda")
 layer_0_q_proj = torch.randn((4096, 4096), dtype=torch.bfloat16, device="cuda")
 layer_0_k_proj = torch.randn((4096, 1024), dtype=torch.bfloat16, device="cuda")
 layer_0_v_proj = torch.randn((4096, 1024), dtype=torch.bfloat16, device="cuda")
 
-embed_out = torch.empty((1, 4096), dtype=torch.bfloat16, device="cuda")
-attn_in = torch.empty((1, 6144), dtype=torch.bfloat16, device="cuda")
+embed_out = embed_tokens[input_token[0, 0], :].unsqueeze(0)
 
-embed_out = embed_tokens[input_token[0, 0], :]
+q_tiles = [
+    layer_0_q_proj[:, i * 32 : (i + 1) * 32] for i in range(128)
+]  # [4096, 32] * 128
+k_tiles = [
+    layer_0_k_proj[:, i * 32 : (i + 1) * 32] for i in range(32)
+]  # [4096, 32] * 32
+v_tiles = [
+    layer_0_v_proj[:, i * 32 : (i + 1) * 32] for i in range(32)
+]  # [4096, 32] * 32
 
-q_tiles = [layer_0_q_proj[:, i * 32 : (i + 1) * 32] for i in range(128)]
-k_tiles = [layer_0_k_proj[:, i * 32 : (i + 1) * 32] for i in range(32)]
-v_tiles = [layer_0_v_proj[:, i * 32 : (i + 1) * 32] for i in range(32)]
+med = torch.cat(
+            q_tiles[0 * 16 : 1 * 16]
+            + k_tiles[0 * 4 : 1 * 4]
+            + v_tiles[0 * 4 : 1 * 4],
+            dim=1,
+        )
+print("med shape:", med.shape)
 
 layer_0_qkv_proj = torch.cat(
     [
@@ -35,16 +48,20 @@ layer_0_qkv_proj = torch.cat(
             + k_tiles[i * 4 : (i + 1) * 4]
             + v_tiles[i * 4 : (i + 1) * 4],
             dim=1,
-        )
+        ) # [4096, 16*32 + 4*32 + 4*32] = [4096, 768]
         for i in range(8)
     ],
     dim=1,
-)
+)  # layer_0_qkv_proj shape: torch.Size([4096, 6144])
 
 weights = [
-    layer_0_qkv_proj[:, i * 32 : (i + 1) * 32].clone().detach().to(torch.bfloat16)
+    layer_0_qkv_proj[:, i * 32 : (i + 1) * 32].transpose(0, 1)
+    .contiguous()
+    .detach()
+    .to(torch.bfloat16)
     for i in range(192)
 ]
+print("weights shape:", weights[0].shape)
 
 attn_in_tiles = [
     torch.zeros((1, 32), dtype=torch.bfloat16, device="cuda") for _ in range(192)
@@ -52,9 +69,11 @@ attn_in_tiles = [
 
 for i in range(192):
     norm_linear(
-        embed_out,
-        weights[i],
-        attn_in_tiles[i],
+        embed_out,  # [1, 4096]
+        layer_0_input_layernorm_weight, # [4096]
+        weights[i],  # [4096, 32]
+        EPS,
+        attn_in_tiles[i],  # [1, 32]
     )
 attn_in = torch.cat(attn_in_tiles, dim=1)
 
@@ -65,9 +84,11 @@ print("Shape of output tensor:", attn_in.shape)
 
 # Compare the output with the expected output
 expected_outputs = [
-    torch_rms_norm(embed_out, layer_0_qkv_proj[:, i * 32 : (i + 1) * 32]).unsqueeze(0)
+    torch_rms_norm(embed_out, layer_0_input_layernorm_weight, weights[i], EPS)
     for i in range(192)
 ]
+print("expected_outputs shape:", expected_outputs[0].shape)
+
 expected_output = torch.cat(expected_outputs, dim=1)
 
 print("Expected output:")
@@ -75,4 +96,5 @@ print(expected_output)
 print("Shape of expected output tensor:", expected_output.shape)
 
 print("Ratio (kernel / torch):")
-print(attn_in / expected_output)
+# Add a small epsilon to avoid division by zero
+print(attn_in / (expected_output))

--- a/tests/runtime_python/test_alignment_norm_linear.py
+++ b/tests/runtime_python/test_alignment_norm_linear.py
@@ -32,13 +32,6 @@ v_tiles = [
     layer_0_v_proj[:, i * 32 : (i + 1) * 32] for i in range(32)
 ]  # [4096, 32] * 32
 
-med = torch.cat(
-            q_tiles[0 * 16 : 1 * 16]
-            + k_tiles[0 * 4 : 1 * 4]
-            + v_tiles[0 * 4 : 1 * 4],
-            dim=1,
-        )
-print("med shape:", med.shape)
 
 layer_0_qkv_proj = torch.cat(
     [
@@ -60,7 +53,6 @@ weights = [
     .to(torch.bfloat16)
     for i in range(192)
 ]
-print("weights shape:", weights[0].shape)
 
 attn_in_tiles = [
     torch.zeros((1, 32), dtype=torch.bfloat16, device="cuda") for _ in range(192)
@@ -95,4 +87,4 @@ print(expected_output)
 print("Shape of expected output tensor:", expected_output.shape)
 
 print("Ratio (kernel / torch):")
-print(attn_in / (expected_output))
+print(attn_in / expected_output)

--- a/tests/runtime_python/test_alignment_norm_linear.py
+++ b/tests/runtime_python/test_alignment_norm_linear.py
@@ -2,7 +2,6 @@ import torch
 from runtime_kernel import norm_linear
 
 torch.set_printoptions(sci_mode=False)
-reduction_size = 4096
 
 def torch_rms_norm(X, G, W, eps):
     variance = X.pow(2).mean(-1, keepdim=True)
@@ -96,5 +95,4 @@ print(expected_output)
 print("Shape of expected output tensor:", expected_output.shape)
 
 print("Ratio (kernel / torch):")
-# Add a small epsilon to avoid division by zero
 print(attn_in / (expected_output))


### PR DESCRIPTION
**Description of changes:**
1. Clear buffers in a unified way
2. Fix outdated test wrapper

Alignment ratio tests all close to 1.0. Example:
```
=== Testing output_size = 64 ===
Ratio (kernel / torch):
tensor([[1.0078, 1.0000, 1.0000, 1.0000, 0.9922, 1.0156, 1.0156, 1.0078, 1.0078,
         1.0000, 1.0078, 1.0078, 1.0156, 1.0000, 0.9766, 1.0000, 1.0000, 0.9922,
         1.0000, 1.0000, 1.0000, 1.0078, 1.0078, 0.8984, 1.0078, 1.0156, 1.0000,
         1.0078, 0.9961, 0.9844, 1.0000, 1.0078, 1.1562, 1.0078, 1.0078, 0.9961,
         1.0000, 0.9883, 1.0078, 0.9883, 1.0156, 1.0000, 1.0078, 0.9922, 1.0156,
         1.0078, 1.0078, 1.0156, 1.0000, 0.9961, 1.0000, 0.9805, 1.0078, 1.0000,
         1.0078, 1.0000, 1.0000, 1.0000, 1.0000, 0.9922, 1.0000, 1.1719, 1.0000,
         1.0078]], device='cuda:0', dtype=torch.bfloat16)
Average time over 1000 runs: 0.045512 ms
Mirage average time over 1000 runs: 0.068686 ms
```

**Related Issues:**

Linked Issues:
- Issue #281 

Issues closed by this PR:
- Closes #


