### PR TITLE
[MPK] Remove mpi4py dependency for running the Qwen3 demo on a single GPU

### DIFF
--- a/demo/qwen3/demo.py
+++ b/demo/qwen3/demo.py
@@ -5,7 +5,6 @@ import torch
 import torch.distributed as dist
 import argparse
 import os
-from mpi4py import MPI
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -14,13 +13,18 @@ if __name__ == "__main__":
         "--profiling", action="store_true", help="Use Profiler to generate trace"
     )
     args = parser.parse_args()
-    comm = MPI.COMM_WORLD
-    world_size = comm.Get_size()
-    rank = comm.Get_rank()
-    os.environ["RANK"] = str(rank)
-    os.environ["WORLD_SIZE"] = str(world_size)
-    os.environ["MASTER_ADDR"] = "localhost"
-    os.environ["MASTER_PORT"] = "12355"
+    try:
+        from mpi4py import MPI
+        comm = MPI.COMM_WORLD
+        world_size = comm.Get_size()
+        rank = comm.Get_rank()
+        os.environ["RANK"] = str(rank)
+        os.environ["WORLD_SIZE"] = str(world_size)
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = "12355"
+    except ImportError:
+        world_size = 1
+        rank = 0
 
     if world_size > 1:
         dist.init_process_group(backend="nccl", init_method="env://")


### PR DESCRIPTION
**Description of changes:**

This PR removes the mpi4py dependency for running the Qwen3 demo on a single GPU

**Related Issues:**

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #


