### PR TITLE
fix residual issue in multi-gpu cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,5 +54,6 @@ demo/*generated*
 benchmark/*generated*
 
 # Temp file
-task_graph.json
+task_graph*.json
 test.cu
+kernel*.cu

--- a/include/mirage/persistent_kernel/tasks/silu_mul_linear.cuh
+++ b/include/mirage/persistent_kernel/tasks/silu_mul_linear.cuh
@@ -38,7 +38,8 @@ __device__ __forceinline__ void
     silu_mul_linear_task_impl(void const *input_ptr,
                               void const *weight_ptr,
                               void const *residual_ptr,
-                              void *output_ptr) {
+                              void *output_ptr,
+                              bool residual = true) {
   constexpr int CHUNK_SIZE = 16 / sizeof(T);
   constexpr int OUTPUT_ATOM_SIZE = OUTPUT_SIZE <= 128 ? OUTPUT_SIZE : 128;
   constexpr int NUM_OUTPUT_ATOMS = OUTPUT_SIZE / OUTPUT_ATOM_SIZE;
@@ -79,7 +80,8 @@ __device__ __forceinline__ void
   T const *__restrict__ d_mul =
       static_cast<T const *>(input_ptr) + REDUCTION_SIZE;
   T const *__restrict__ d_weight = static_cast<T const *>(weight_ptr);
-  T const *__restrict__ d_residual = static_cast<T const *>(residual_ptr);
+  T const *__restrict__ d_residual =
+      residual ? static_cast<T const *>(residual_ptr) : nullptr;
   T *__restrict__ d_output = static_cast<T *>(output_ptr);
 
   using InputDmem =
@@ -150,7 +152,8 @@ __device__ __forceinline__ void
   T *shared_weight_buffer = (T *)(smem + SHARED_WEIGHT_BUFFER_OFFSET);
 
   // residual
-  T *shared_residual = (T *)(smem + SHARED_RESIDUAL_OFFSET);
+  T *shared_residual =
+      residual ? (T *)(smem + SHARED_RESIDUAL_OFFSET) : nullptr;
 
   // intermidiate
   T *silu_mul_output = (T *)(smem + SILU_MUL_OUTPUT_OFFSET);
@@ -194,7 +197,7 @@ __device__ __forceinline__ void
   for (int output_atom_idx = 0; output_atom_idx < NUM_OUTPUT_ATOMS;
        output_atom_idx++,
            d_weight += OUTPUT_ATOM_SIZE * REDUCTION_SIZE,
-           d_residual += OUTPUT_ATOM_SIZE,
+           d_residual = residual ? d_residual + OUTPUT_ATOM_SIZE : nullptr,
            d_output += OUTPUT_ATOM_SIZE) {
     weight_dmem.set_ptr(d_weight);
     residual_dmem.set_ptr(d_residual);
@@ -204,11 +207,13 @@ __device__ __forceinline__ void
     InputBufferSmem mul_buffer_smem(shared_mul_buffer);
     WeightBufferSmem weight_buffer_smem(shared_weight_buffer);
 
+    if (residual) {
 #pragma unroll
-    for (int i = threadIdx.x; i < NUM_CHUNKS_C; i += NUM_THREADS) {
-      int row = i >> log2_CHUNKS_PER_ROW_C;
-      int col = (i & (CHUNKS_PER_ROW_C - 1)) << log2_CHUNK_SIZE;
-      load_smem(residual_smem(row, col), residual_dmem(row, col));
+      for (int i = threadIdx.x; i < NUM_CHUNKS_C; i += NUM_THREADS) {
+        int row = i >> log2_CHUNKS_PER_ROW_C;
+        int col = (i & (CHUNKS_PER_ROW_C - 1)) << log2_CHUNK_SIZE;
+        load_smem(residual_smem(row, col), residual_dmem(row, col));
+      }
     }
 
 #pragma unroll
@@ -357,10 +362,9 @@ __device__ __forceinline__ void
 #pragma unroll
     for (int i = threadIdx.x; i < OUTPUT_SIZE; i += NUM_THREADS) {
       int row = 0;
-      output_dmem.at(row, i) =
-          NUM_WARPS_K > 1
-              ? output_smem.at(row, i) + residual_smem.at(row, i)
-              : mm_intermediate_smem.at(row, i) + residual_smem.at(row, i);
+      T val = NUM_WARPS_K > 1 ? output_smem.at(row, i)
+                              : mm_intermediate_smem.at(row, i);
+      output_dmem.at(row, i) = residual ? val + residual_smem.at(row, i) : val;
     }
     if (output_atom_idx + 1 < NUM_OUTPUT_ATOMS) {
       __syncthreads();

--- a/src/kernel/task_register.cc
+++ b/src/kernel/task_register.cc
@@ -200,7 +200,8 @@ int TaskRegister::register_silu_mul_linear_with_residual_task(
   code.e("    task_desc.inputs[0].base_ptr,");
   code.e("    task_desc.inputs[1].base_ptr,");
   code.e("    task_desc.inputs[2].base_ptr,");
-  code.e("    task_desc.outputs[0].base_ptr);");
+  code.e("    task_desc.outputs[0].base_ptr,");
+  code.e("    runtime_config.my_gpu_id == 0);");
   return register_task_variant(TASK_SILU_MUL_LINEAR_WITH_RESIDUAL,
                                code.to_string());
 }
@@ -244,7 +245,8 @@ int TaskRegister::register_linear_with_residual_task(
   code.e("    task_desc.inputs[0].base_ptr,");
   code.e("    task_desc.inputs[1].base_ptr,");
   code.e("    task_desc.inputs[2].base_ptr,");
-  code.e("    task_desc.outputs[0].base_ptr);");
+  code.e("    task_desc.outputs[0].base_ptr,");
+  code.e("    runtime_config.my_gpu_id == 0);");
   return register_task_variant(TASK_LINEAR_WITH_RESIDUAL, code.to_string());
 }
 


### PR DESCRIPTION
**Description of changes:**

In the original implementation, the residuals of linear tasks were added multiple times when world size is greater than one. We now let the tasks add residuals only if `my_gpu_id == 0`


