### PR TITLE
fix: typo on index (landing) page of docs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,7 +10,7 @@ Mirage is a tensor algebra superoptimizer that automatically discovers highly-op
 Getting Started
 ---------------
 
-- Follow the :doc:`instllation <installation>` to install Mirage
+- Follow the :doc:`installation <installation>` to install Mirage
 - Take a look at the :doc:`tutorials <tutorials/index>` to learn how to use Mirage to superoptimize your DNNs
 
 .. toctree::


### PR DESCRIPTION
**Description of changes:**
Fixes a typo on the landing page of the documentation.
`instllation -> installation
`
**Related Issues:**

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #


