### PR TITLE
Introduce window rmsnorm kernel

### DIFF
--- a/include/mirage/persistent_kernel/tasks/norm.cuh
+++ b/include/mirage/persistent_kernel/tasks/norm.cuh
@@ -17,6 +17,7 @@
 #include "common.h"
 #include "utils.cuh"
 namespace kernel {
+// TODO(Wenqin): modify 128 in this kernel as NUM_THREADS
 template <typename T, typename InputSmem, int NUM_HEAD, int HEAD_DIM = 128>
 __device__ __forceinline__ void rms_norm(InputSmem smem_input,
                                          T const *weight_ptr,
@@ -88,6 +89,88 @@ __device__ __forceinline__ void rms_norm(InputSmem smem_input,
               (float)smem_input.at(head_idx + row_offset, i - HEAD_DIM / 2);
           float v_rot = v1 * cos + v2 * sin;
           smem_input.at(head_idx + row_offset, i) = (T)v_rot;
+        }
+      }
+    }
+  }
+}
+
+template <typename T, typename InputSmem, int NUM_HEAD, int WINDOW_SIZE, int HEAD_DIM = 128>
+__device__ __forceinline__ void window_rms_norm(InputSmem smem_input,
+                                         T const *weight_ptr,
+                                         float *reduce_smem,
+                                         float eps,
+                                         bool rotary_emd = false,
+                                         T const *cos_ptr = nullptr,
+                                         T const *sin_ptr = nullptr) {
+  // smem_input: NUM_HEADS * WINDOW_SIZE, HEAD_DIM
+  int warp_idx = warp_id();
+#pragma unroll
+  for (int head_idx = 0; head_idx < NUM_HEAD; ++head_idx) {
+#pragma unroll
+    for(int win_idx = 0; win_idx < WINDOW_SIZE; win_idx ++) {
+      float sum = 0.0f;
+#pragma unroll
+      for (uint32_t i = 0; i < (HEAD_DIM / NUM_THREADS); i++) {
+        sum +=
+            (float)smem_input.at(head_idx * WINDOW_SIZE + win_idx, threadIdx.x + i * NUM_THREADS) *
+            (float)smem_input.at(head_idx * WINDOW_SIZE + win_idx, threadIdx.x + i * NUM_THREADS);
+      }
+
+  #pragma unroll
+      for (uint32_t offset = NUM_THREADS_PER_WARP / 2; offset > 0; offset /= 2) {
+        sum += shfl_xor_sync(sum, offset);
+      }
+
+      if (threadIdx.x % 32 == 0) {
+        reduce_smem[warp_idx] = sum;
+      }
+      __syncthreads();
+      sum = threadIdx.x < NUM_WARPS ? reduce_smem[threadIdx.x] : 0.0f;
+
+  #pragma unroll
+      for (uint32_t offset = NUM_THREADS_PER_WARP / 2; offset > 0; offset /= 2) {
+        sum += shfl_xor_sync(sum, offset);
+      }
+
+      if (threadIdx.x == 0) {
+        reduce_smem[0] = sum;
+      }
+
+      __syncthreads();
+
+      float rms_rcp = rsqrt(reduce_smem[0] / float(HEAD_DIM) + eps);
+
+      // multiply with weight
+  #pragma unroll
+      for (uint32_t i = threadIdx.x; i < HEAD_DIM; i += NUM_THREADS) {
+        float val = smem_input.at(head_idx * WINDOW_SIZE + win_idx, i);
+        float w = (float)weight_ptr[i];
+        val *= rms_rcp * w;
+        smem_input.at(head_idx * WINDOW_SIZE + win_idx, i) = (T)val;
+
+        if (rotary_emd) {
+          // we should do rope for all the window size q and k, because they
+          // came from hidden states, we didn't apply rope yet.
+          __syncthreads();
+          int offset = (i / HEAD_DIM) * HEAD_DIM + i;
+          const T* cur_cos_ptr = cos_ptr + win_idx * HEAD_DIM;
+          const T* cur_sin_ptr = sin_ptr + win_idx* HEAD_DIM;
+          float cos = (float)cur_cos_ptr[offset];
+          float sin = (float)cur_sin_ptr[offset];
+          if (i < HEAD_DIM / 2) {
+            float v1 = (float)smem_input.at(head_idx * WINDOW_SIZE + win_idx, i);
+            float v2 =
+                (float)smem_input.at(head_idx * WINDOW_SIZE + win_idx, i + HEAD_DIM / 2);
+            float v_rot = v1 * cos - v2 * sin;
+            smem_input.at(head_idx * WINDOW_SIZE + win_idx, i) = (T)v_rot;
+          } else {
+            float v1 = (float)smem_input.at(head_idx * WINDOW_SIZE + win_idx, i);
+            float v2 =
+                (float)smem_input.at(head_idx * WINDOW_SIZE + win_idx, i - HEAD_DIM / 2);
+            float v_rot = v1 * cos + v2 * sin;
+            smem_input.at(head_idx * WINDOW_SIZE + win_idx, i) = (T)v_rot;
+          }
         }
       }
     }

--- a/tests/runtime_python/runtime_kernel_wrapper.cu
+++ b/tests/runtime_python/runtime_kernel_wrapper.cu
@@ -422,24 +422,24 @@ void norm_linear(torch::Tensor input,
 
 template <typename T, int BATCH_SIZE, int WINDOW_SIZE, int HEAD_DIM>
 __global__ void window_rms_norm_kernel_wrapper(void const *input_ptr,
-                                          void const *weight_ptr,
-                                          float eps,
-                                          void *output_ptr,
-                                          bool rotary_emd = false,
-                                          void const *cos_ptr = nullptr,
-                                          void const *sin_ptr = nullptr) {
+                                               void const *weight_ptr,
+                                               float eps,
+                                               void *output_ptr,
+                                               bool rotary_emd = false,
+                                               void const *cos_ptr = nullptr,
+                                               void const *sin_ptr = nullptr) {
   constexpr size_t q_num = BATCH_SIZE * WINDOW_SIZE;
   using Smem = kernel::smem_row<T, 3, 3, 3, q_num, 128, 128>;
 
   extern __shared__ char smem[];
-  T* smem_ptr = reinterpret_cast<T*>(smem);
+  T *smem_ptr = reinterpret_cast<T *>(smem);
   Smem input_smem(smem_ptr);
 
   // TODO(Wenqin): q_num * HEAD_DIM is a conservative number.
-  float* reduce_smem = reinterpret_cast<float*>(smem) + q_num * HEAD_DIM;
+  float *reduce_smem = reinterpret_cast<float *>(smem) + q_num * HEAD_DIM;
 
-  T const* d_input = static_cast<T const*>(input_ptr);
-  T* d_output = const_cast<T*>(static_cast<T const*>(output_ptr));
+  T const *d_input = static_cast<T const *>(input_ptr);
+  T *d_output = const_cast<T *>(static_cast<T const *>(output_ptr));
 
   kernel::dmem_row_const<T, q_num, 128, 128> input_dmem(d_input);
   kernel::dmem_row<T, q_num, 128, 128> output_dmem(d_output);
@@ -456,86 +456,89 @@ __global__ void window_rms_norm_kernel_wrapper(void const *input_ptr,
   // to wait.
   __syncthreads();
 
-  T const* norm_weight_ptr = static_cast<T const*>(weight_ptr);
-  T const* rope_cos_ptr = static_cast<T const*>(cos_ptr);
-  T const* rope_sin_ptr = static_cast<T const*>(sin_ptr);
+  T const *norm_weight_ptr = static_cast<T const *>(weight_ptr);
+  T const *rope_cos_ptr = static_cast<T const *>(cos_ptr);
+  T const *rope_sin_ptr = static_cast<T const *>(sin_ptr);
 
-  kernel::window_rms_norm<T, Smem, 1,
-                        WINDOW_SIZE,
-                        HEAD_DIM>(
-      input_smem, norm_weight_ptr, reduce_smem, eps, rotary_emd, rope_cos_ptr, rope_sin_ptr);
+  kernel::window_rms_norm<T, Smem, 1, WINDOW_SIZE, HEAD_DIM>(input_smem,
+                                                             norm_weight_ptr,
+                                                             reduce_smem,
+                                                             eps,
+                                                             rotary_emd,
+                                                             rope_cos_ptr,
+                                                             rope_sin_ptr);
 
   __syncthreads();
-  
+
   for (int i = threadIdx.x; i < q_num * (HEAD_DIM / 8); i += NUM_THREADS) {
     // write back
     int row = i / 16;
     int col = (i % 16) * 8;
-    for(int j = 0; j < 8; j ++) {
+    for (int j = 0; j < 8; j++) {
       int col_j = col + j;
       *output_dmem(row, col_j) = *input_smem(row, col_j);
     }
   }
 }
 
-#define WINDOW_RMSNORM_LINEAR_LAUNCHER(HEAD_DIM, WINDOW_SIZE)            \
-  launch_window_rms_norm<bfloat16, 1, WINDOW_SIZE, HEAD_DIM>(         \
+#define WINDOW_RMSNORM_LINEAR_LAUNCHER(HEAD_DIM, WINDOW_SIZE)                  \
+  launch_window_rms_norm<bfloat16, 1, WINDOW_SIZE, HEAD_DIM>(                  \
       input_ptr, weight_ptr, eps, output_ptr, rotary_emd, cos_ptr, sin_ptr);
 
-#define DISPATCH_WINDOW_RMSNORM_LINEAR_WINDOW_SIZE(HEAD_DIM)            \
-  switch (window_size) {                                                   \
-    case 1:                                                                \
-      WINDOW_RMSNORM_LINEAR_LAUNCHER(HEAD_DIM, 1);                       \
-      break;                                                               \
-    case 2:                                                                \
-      WINDOW_RMSNORM_LINEAR_LAUNCHER(HEAD_DIM, 2);                       \
-      break;                                                               \
-    case 3:                                                                \
-      WINDOW_RMSNORM_LINEAR_LAUNCHER(HEAD_DIM, 3);                       \
-      break;                                                               \
-    case 4:                                                                \
-      WINDOW_RMSNORM_LINEAR_LAUNCHER(HEAD_DIM, 4);                       \
-      break;                                                               \
-    default:                                                               \
-      printf("Unsupported window size in test: %zu\n", window_size);       \
-      break;                                                               \
+#define DISPATCH_WINDOW_RMSNORM_LINEAR_WINDOW_SIZE(HEAD_DIM)                   \
+  switch (window_size) {                                                       \
+    case 1:                                                                    \
+      WINDOW_RMSNORM_LINEAR_LAUNCHER(HEAD_DIM, 1);                             \
+      break;                                                                   \
+    case 2:                                                                    \
+      WINDOW_RMSNORM_LINEAR_LAUNCHER(HEAD_DIM, 2);                             \
+      break;                                                                   \
+    case 3:                                                                    \
+      WINDOW_RMSNORM_LINEAR_LAUNCHER(HEAD_DIM, 3);                             \
+      break;                                                                   \
+    case 4:                                                                    \
+      WINDOW_RMSNORM_LINEAR_LAUNCHER(HEAD_DIM, 4);                             \
+      break;                                                                   \
+    default:                                                                   \
+      printf("Unsupported window size in test: %zu\n", window_size);           \
+      break;                                                                   \
   }
 
-#define DISPATCH_WINDOW_RMSNORM_LINEAR_HEAD_DIM()                       \
-  switch (head_dim) {                                                   \
-    case 16:                                                               \
-      DISPATCH_WINDOW_RMSNORM_LINEAR_WINDOW_SIZE(16);                       \
-      break;                                                               \
-    case 32:                                                               \
-      DISPATCH_WINDOW_RMSNORM_LINEAR_WINDOW_SIZE(32);                       \
-      break;                                                               \
-    case 64:                                                               \
-      DISPATCH_WINDOW_RMSNORM_LINEAR_WINDOW_SIZE(64);                       \
-      break;                                                               \
-    case 128:                                                               \
-      DISPATCH_WINDOW_RMSNORM_LINEAR_WINDOW_SIZE(128);                       \
-      break;                                                               \
-    case 256:                                                              \
-      DISPATCH_WINDOW_RMSNORM_LINEAR_WINDOW_SIZE(256);                      \
-      break;                                                               \
-    case 1600:                                                             \
-      DISPATCH_WINDOW_RMSNORM_LINEAR_WINDOW_SIZE(1600);                     \
-      break;                                                               \
-    default:                                                               \
-      printf("Unsupported head dim in test: %zu\n", head_dim);       \
-      break;                                                               \
+#define DISPATCH_WINDOW_RMSNORM_LINEAR_HEAD_DIM()                              \
+  switch (head_dim) {                                                          \
+    case 16:                                                                   \
+      DISPATCH_WINDOW_RMSNORM_LINEAR_WINDOW_SIZE(16);                          \
+      break;                                                                   \
+    case 32:                                                                   \
+      DISPATCH_WINDOW_RMSNORM_LINEAR_WINDOW_SIZE(32);                          \
+      break;                                                                   \
+    case 64:                                                                   \
+      DISPATCH_WINDOW_RMSNORM_LINEAR_WINDOW_SIZE(64);                          \
+      break;                                                                   \
+    case 128:                                                                  \
+      DISPATCH_WINDOW_RMSNORM_LINEAR_WINDOW_SIZE(128);                         \
+      break;                                                                   \
+    case 256:                                                                  \
+      DISPATCH_WINDOW_RMSNORM_LINEAR_WINDOW_SIZE(256);                         \
+      break;                                                                   \
+    case 1600:                                                                 \
+      DISPATCH_WINDOW_RMSNORM_LINEAR_WINDOW_SIZE(1600);                        \
+      break;                                                                   \
+    default:                                                                   \
+      printf("Unsupported head dim in test: %zu\n", head_dim);                 \
+      break;                                                                   \
   }
 
 #define WINDOW_RMSNORM_LINEAR() DISPATCH_WINDOW_RMSNORM_LINEAR_HEAD_DIM()
 
 template <typename T, int BATCH_SIZE, int WINDOW_SIZE, int HEAD_DIM>
 void launch_window_rms_norm(void const *input_ptr,
-                        void const *weight_ptr,
-                        float eps,
-                        void *output_ptr,
-                        bool rotary_emd = false,
-                        void const *cos_ptr = nullptr,
-                        void const *sin_ptr = nullptr) {
+                            void const *weight_ptr,
+                            float eps,
+                            void *output_ptr,
+                            bool rotary_emd = false,
+                            void const *cos_ptr = nullptr,
+                            void const *sin_ptr = nullptr) {
   dim3 grid_dim(1, 1, 1);
   dim3 block_dim(128, 1, 1);
   size_t smem_size = 1024 * 99;
@@ -550,13 +553,14 @@ void launch_window_rms_norm(void const *input_ptr,
           input_ptr, weight_ptr, eps, output_ptr, rotary_emd, cos_ptr, sin_ptr);
 }
 
-void window_rms_norm(torch::Tensor input, // shape [batch, window_size, head_dim]
-                      torch::Tensor weight,
-                      float eps,
-                      torch::Tensor output,
-                      bool rotary_emd = false,
-                      torch::optional<torch::Tensor> cos = c10::nullopt,
-                      torch::optional<torch::Tensor> sin = c10::nullopt) {
+void window_rms_norm(
+    torch::Tensor input, // shape [batch, window_size, head_dim]
+    torch::Tensor weight,
+    float eps,
+    torch::Tensor output,
+    bool rotary_emd = false,
+    torch::optional<torch::Tensor> cos = c10::nullopt,
+    torch::optional<torch::Tensor> sin = c10::nullopt) {
   void const *input_ptr = input.data_ptr();
   void const *weight_ptr = weight.data_ptr();
   void const *cos_ptr = cos ? cos->data_ptr() : nullptr;
@@ -570,7 +574,8 @@ void window_rms_norm(torch::Tensor input, // shape [batch, window_size, head_dim
 
   cudaError_t err = cudaDeviceSynchronize();
   if (err != cudaSuccess) {
-    printf("CUDA window_norm_linear kernel launch error: %s\n", cudaGetErrorString(err));
+    printf("CUDA window_norm_linear kernel launch error: %s\n",
+           cudaGetErrorString(err));
   }
 }
 

--- a/tests/runtime_python/runtime_kernel_wrapper.cu
+++ b/tests/runtime_python/runtime_kernel_wrapper.cu
@@ -1,6 +1,7 @@
 #include "argmax.cuh"
 #include "bfloat16.h"
 #include "linear.cuh"
+#include "norm.cuh"
 #include "norm_linear.cuh"
 #include "paged_attention.cuh"
 #include "silu_mul_linear.cuh"
@@ -362,7 +363,7 @@ void launch_norm_linear(void const *input_ptr,
                         void *output_ptr) {
   dim3 grid_dim(1, 1, 1);
   dim3 block_dim(128, 1, 1);
-  size_t smem_size = 112640;
+  size_t smem_size = 1024 * 99;
 
   cudaFuncSetAttribute(
       norm_linear_kernel_wrapper<T, BATCH_SIZE, OUTPUT_SIZE, REDUCTION_SIZE>,
@@ -414,6 +415,147 @@ void norm_linear(torch::Tensor input,
   cudaError_t err = cudaDeviceSynchronize();
   if (err != cudaSuccess) {
     printf("CUDA kernel launch error: %s\n", cudaGetErrorString(err));
+  }
+}
+
+// Window RMSNorm Linear
+
+template <typename T, int BATCH_SIZE, int WINDOW_SIZE, int HEAD_DIM>
+__global__ void window_rms_norm_kernel_wrapper(void const *input_ptr,
+                                          void const *weight_ptr,
+                                          float eps,
+                                          void *output_ptr,
+                                          bool rotary_emd = false,
+                                          T const *cos_ptr = nullptr,
+                                          T const *sin_ptr = nullptr) {
+  constexpr size_t q_num = BATCH_SIZE * WINDOW_SIZE;
+  using Smem = kernel::smem_row<T, 3, 3, 3, q_num, 128, 128>;
+
+  extern __shared__ char smem[];
+  T* smem_ptr = reinterpret_cast<T*>(smem);
+  Smem input_smem(smem_ptr);
+
+  // TODO(Wenqin): q_num * HEAD_DIM is a conservative number.
+  float* reduce_smem = reinterpret_cast<float*>(smem) + q_num * HEAD_DIM;
+
+  T const* d_input = static_cast<T const*>(input_ptr);
+  T* d_output = const_cast<T*>(static_cast<T const*>(output_ptr));
+
+  kernel::dmem_row_const<T, q_num, 128, 128> input_dmem(d_input);
+  kernel::dmem_row<T, q_num, 128, 128> output_dmem(d_output);
+
+  for (int i = threadIdx.x; i < q_num * (HEAD_DIM / 8); i += NUM_THREADS) {
+    int row = i / 16;
+    int col = (i % 16) * 8;
+    kernel::load_smem(input_smem(row, col), input_dmem(row, col));
+  }
+  kernel::cp_async_fence();
+  kernel::cp_async_wait<0>();
+
+  T const* norm_weight_ptr = static_cast<T const*>(weight_ptr);
+
+  kernel::window_rms_norm<T, Smem, 1,
+                        WINDOW_SIZE,
+                        HEAD_DIM>(
+      input_smem, norm_weight_ptr, reduce_smem, eps, rotary_emd, cos_ptr, sin_ptr);
+
+  __syncthreads();
+
+  for (int i = threadIdx.x; i < q_num * (HEAD_DIM / 8); i += NUM_THREADS) {
+    // write back
+    int row = i / 16;
+    int col = (i % 16) * 8;
+    for(int j = 0; j < 8; j ++) {
+      int col_j = col + j;
+      *output_dmem(row, col_j) = *input_smem(row, col_j);
+    }
+  }
+}
+
+#define WINDOW_RMSNORM_LINEAR_LAUNCHER(HEAD_DIM, WINDOW_SIZE)            \
+  launch_window_rms_norm<bfloat16, 1, WINDOW_SIZE, HEAD_DIM>(         \
+      input_ptr, weight_ptr, eps, output_ptr);
+
+#define DISPATCH_WINDOW_RMSNORM_LINEAR_WINDOW_SIZE(HEAD_DIM)            \
+  switch (window_size) {                                                   \
+    case 1:                                                                \
+      WINDOW_RMSNORM_LINEAR_LAUNCHER(HEAD_DIM, 1);                       \
+      break;                                                               \
+    case 2:                                                                \
+      WINDOW_RMSNORM_LINEAR_LAUNCHER(HEAD_DIM, 2);                       \
+      break;                                                               \
+    case 3:                                                                \
+      WINDOW_RMSNORM_LINEAR_LAUNCHER(HEAD_DIM, 3);                       \
+      break;                                                               \
+    case 4:                                                                \
+      WINDOW_RMSNORM_LINEAR_LAUNCHER(HEAD_DIM, 4);                       \
+      break;                                                               \
+    default:                                                               \
+      printf("Unsupported window size in test: %zu\n", window_size);       \
+      break;                                                               \
+  }
+
+#define DISPATCH_WINDOW_RMSNORM_LINEAR_HEAD_DIM()                       \
+  switch (head_dim) {                                                   \
+    case 16:                                                               \
+      DISPATCH_WINDOW_RMSNORM_LINEAR_WINDOW_SIZE(16);                       \
+      break;                                                               \
+    case 32:                                                               \
+      DISPATCH_WINDOW_RMSNORM_LINEAR_WINDOW_SIZE(32);                       \
+      break;                                                               \
+    case 64:                                                               \
+      DISPATCH_WINDOW_RMSNORM_LINEAR_WINDOW_SIZE(64);                       \
+      break;                                                               \
+    case 128:                                                               \
+      DISPATCH_WINDOW_RMSNORM_LINEAR_WINDOW_SIZE(128);                       \
+      break;                                                               \
+    case 256:                                                              \
+      DISPATCH_WINDOW_RMSNORM_LINEAR_WINDOW_SIZE(256);                      \
+      break;                                                               \
+    case 1600:                                                             \
+      DISPATCH_WINDOW_RMSNORM_LINEAR_WINDOW_SIZE(1600);                     \
+      break;                                                               \
+    default:                                                               \
+      printf("Unsupported head dim in test: %zu\n", head_dim);       \
+      break;                                                               \
+  }
+
+#define WINDOW_RMSNORM_LINEAR() DISPATCH_WINDOW_RMSNORM_LINEAR_HEAD_DIM()
+
+template <typename T, int BATCH_SIZE, int WINDOW_SIZE, int HEAD_DIM>
+void launch_window_rms_norm(void const *input_ptr,
+                        void const *weight_ptr,
+                        float eps,
+                        void *output_ptr) {
+  dim3 grid_dim(1, 1, 1);
+  dim3 block_dim(128, 1, 1);
+  size_t smem_size = 1024 * 99;
+
+  cudaFuncSetAttribute(
+      window_rms_norm_kernel_wrapper<T, BATCH_SIZE, WINDOW_SIZE, HEAD_DIM>,
+      cudaFuncAttributeMaxDynamicSharedMemorySize,
+      smem_size);
+
+  window_rms_norm_kernel_wrapper<T, BATCH_SIZE, WINDOW_SIZE, HEAD_DIM>
+      <<<grid_dim, block_dim, smem_size>>>(
+          input_ptr, weight_ptr, eps, output_ptr);
+}
+
+void window_rms_norm(torch::Tensor input, // shape [batch, window_size, head_dim]
+                 torch::Tensor weight,
+                 float eps,
+                 torch::Tensor output) {
+  void const *input_ptr = input.data_ptr();
+  void const *weight_ptr = weight.data_ptr();
+  void *output_ptr = output.data_ptr();
+  size_t head_dim = output.size(2);
+  size_t window_size = output.size(1);
+
+  DISPATCH_WINDOW_RMSNORM_LINEAR_HEAD_DIM();
+
+  cudaError_t err = cudaDeviceSynchronize();
+  if (err != cudaSuccess) {
+    printf("CUDA window_norm_linear kernel launch error: %s\n", cudaGetErrorString(err));
   }
 }
 
@@ -605,4 +747,5 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
         py::arg("q_eps") = 0.0f,
         py::arg("k_eps") = 0.0f);
   m.def("paged_attention", &paged_attention, "Paged Attention");
+  m.def("window_rms_norm", &window_rms_norm, "Window RMSNorm");
 }

--- a/tests/runtime_python/test_window_rmsnorm.py
+++ b/tests/runtime_python/test_window_rmsnorm.py
@@ -1,0 +1,52 @@
+import torch
+from runtime_kernel import window_rms_norm
+
+torch.set_printoptions(sci_mode=False)
+seed_value = 611
+torch.manual_seed(seed_value)
+
+def torch_rms_norm(X, W, eps):
+    # TODO(Wenqin): add rope test
+    variance = X.pow(2).mean(-1, keepdim=True)
+    X = X * torch.rsqrt(variance + eps)
+    X = torch.mul(X, W)
+    return X
+
+# Define the input tensor and parameters
+EPS = 1e-5
+batch_size = 1
+window_size = 2
+head_dim = 128
+
+input_tensor = torch.randn((batch_size, window_size, head_dim), dtype=torch.bfloat16, device="cuda")
+torch_output = torch.randn((batch_size, window_size, head_dim), dtype=torch.bfloat16, device="cuda")
+kernel_output = torch.randn((batch_size, window_size, head_dim), dtype=torch.bfloat16, device="cuda")
+weights = torch.randn((head_dim), dtype=torch.bfloat16, device="cuda")
+# input_tensor = torch.ones((batch_size, window_size, head_dim), dtype=torch.bfloat16, device="cuda")
+# torch_output = torch.ones((batch_size, window_size, head_dim), dtype=torch.bfloat16, device="cuda")
+# kernel_output = torch.ones((batch_size, window_size, head_dim), dtype=torch.bfloat16, device="cuda")
+# weights = torch.ones((head_dim), dtype=torch.bfloat16, device="cuda")
+# weights /= 2
+
+
+window_rms_norm(
+    input_tensor,
+    weights,
+    EPS,
+    kernel_output,
+)
+
+# Print the output tensor
+print("Output from window_norm:")
+print(kernel_output)
+print("Shape of output tensor:", kernel_output.shape)
+
+# Compare the output with the expected output
+torch_output = torch_rms_norm(input_tensor, weights, EPS)
+print("Output from expected window norm:")
+print(torch_output)
+print("Shape of expected tensor:", torch_output.shape)
+
+print("===========================")
+print("Ratio (kernel / torch):")
+print(torch_output / kernel_output)

--- a/tests/runtime_python/test_window_rmsnorm.py
+++ b/tests/runtime_python/test_window_rmsnorm.py
@@ -4,29 +4,65 @@ from runtime_kernel import window_rms_norm
 torch.set_printoptions(sci_mode=False)
 seed_value = 611
 torch.manual_seed(seed_value)
+# TODO: Just support bf16 yet, try to support other data type later.
+dtype=torch.bfloat16
+device="cuda"
 
-def torch_rms_norm(X, W, eps):
-    # TODO(Wenqin): add rope test
+def precompute_rope_freqs_cis(
+    dim,
+    max_position_embeddings=2048,
+    base=10000.0,
+    dtype=dtype,
+    device=device
+):
+    inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=dtype, device=device) / dim))
+    t = torch.arange(max_position_embeddings, dtype=dtype, device=device)
+
+    freqs = torch.outer(t, inv_freq)
+    emb = torch.stack([freqs, freqs], dim=-1).reshape(*freqs.shape[:-1], -1)
+
+    cos = emb.cos().to(dtype)
+    sin = emb.sin().to(dtype)
+
+    return cos, sin
+
+def apply_rope_rotation(x, cos, sin, position_ids):
+    assert x.size(-2) == position_ids.size(-1), "seq_len of x should be equal to size of position_ids"
+    cos_pos = cos[position_ids].to(x.dtype)
+    sin_pos = sin[position_ids].to(x.dtype)
+
+    x_rot_real = x[..., :x.shape[-1] // 2]
+    x_rot_imag = x[..., x.shape[-1] // 2:]
+
+    x_out_real = x_rot_real * cos_pos[..., :x.shape[-1] // 2] - x_rot_imag * sin_pos[..., :x.shape[-1] // 2]
+    x_out_imag = x_rot_real * sin_pos[..., x.shape[-1] // 2:] + x_rot_imag * cos_pos[..., x.shape[-1] // 2:]
+
+    x_rotated = torch.cat((x_out_real, x_out_imag), dim=-1)
+
+    return x_rotated
+
+def torch_rms_norm(X, W, eps, cos=None, sin=None, position_ids=None):
     variance = X.pow(2).mean(-1, keepdim=True)
     X = X * torch.rsqrt(variance + eps)
     X = torch.mul(X, W)
+    if cos != None and sin != None and position_ids != None:
+        X = apply_rope_rotation(X, cos, sin, position_ids)
     return X
 
 # Define the input tensor and parameters
 EPS = 1e-5
 batch_size = 1
-window_size = 2
+window_size = 3
 head_dim = 128
 
-input_tensor = torch.randn((batch_size, window_size, head_dim), dtype=torch.bfloat16, device="cuda")
-torch_output = torch.randn((batch_size, window_size, head_dim), dtype=torch.bfloat16, device="cuda")
-kernel_output = torch.randn((batch_size, window_size, head_dim), dtype=torch.bfloat16, device="cuda")
-weights = torch.randn((head_dim), dtype=torch.bfloat16, device="cuda")
-# input_tensor = torch.ones((batch_size, window_size, head_dim), dtype=torch.bfloat16, device="cuda")
-# torch_output = torch.ones((batch_size, window_size, head_dim), dtype=torch.bfloat16, device="cuda")
-# kernel_output = torch.ones((batch_size, window_size, head_dim), dtype=torch.bfloat16, device="cuda")
-# weights = torch.ones((head_dim), dtype=torch.bfloat16, device="cuda")
-# weights /= 2
+input_tensor = torch.randn((batch_size, window_size, head_dim), dtype=dtype, device=device)
+torch_output = torch.randn((batch_size, window_size, head_dim), dtype=dtype, device=device)
+kernel_output = torch.randn((batch_size, window_size, head_dim), dtype=dtype, device=device)
+weights = torch.randn((head_dim), dtype=dtype, device=device)
+
+cos, sin = precompute_rope_freqs_cis(head_dim)
+position_ids = torch.arange(0, window_size, dtype=torch.int32, device=device).unsqueeze(0)
+print("cos: ", cos)
 
 
 window_rms_norm(
@@ -34,6 +70,9 @@ window_rms_norm(
     weights,
     EPS,
     kernel_output,
+    True,
+    cos,
+    sin,
 )
 
 # Print the output tensor
@@ -42,8 +81,8 @@ print(kernel_output)
 print("Shape of output tensor:", kernel_output.shape)
 
 # Compare the output with the expected output
-torch_output = torch_rms_norm(input_tensor, weights, EPS)
-print("Output from expected window norm:")
+torch_output = torch_rms_norm(input_tensor, weights, EPS, cos, sin, position_ids)
+print("Output from expected torch window norm:")
 print(torch_output)
 print("Shape of expected tensor:", torch_output.shape)
 


### PR DESCRIPTION
**Description of changes:**
This PR introduces a window rmsnorm kernel, which will be used in window attention kernel for speculative decoding.


**Related Issues:**

Linked Issues:
- Issue #329

Issues closed by this PR:
- Closes #


