### PR TITLE
Extend attention kernel support

### DIFF
--- a/include/mirage/persistent_kernel/tasks/single_batch_extend.cuh
+++ b/include/mirage/persistent_kernel/tasks/single_batch_extend.cuh
@@ -58,8 +58,10 @@ __device__ __forceinline__ void
   int warp_idx = warp_id();
   int idx_in_warp = threadIdx.x % 32;
 
-  size_t num_iterations = (seq_len + KV_CHUNK_SIZE - 1) / KV_CHUNK_SIZE;
-  int curr_iter_len = std::min(seq_len, KV_CHUNK_SIZE);
+  size_t total_seq_len = seq_len + EXTEND_NUM;
+
+  size_t num_iterations = (total_seq_len + KV_CHUNK_SIZE - 1) / KV_CHUNK_SIZE;
+  int curr_iter_len = std::min(total_seq_len, KV_CHUNK_SIZE);
   int cp_finished_seq_len = curr_iter_len;
   int last_seq_len = curr_iter_len;
 
@@ -93,7 +95,7 @@ __device__ __forceinline__ void
   constexpr size_t O_OFFSET = MAX_OFFSET + HEAD_DIM * sizeof(float);
 
   constexpr size_t Q_NORM_SUM_OFFSET = O_OFFSET + HEAD_DIM * 32 * sizeof(float); // TODO: check
-  constexpr size_t K_NORM_SUM_OFFSET = Q_NORM_SUM_OFFSET + HEAD_DIM * sizeof(float);
+  constexpr size_t K_NORM_SUM_OFFSET = Q_NORM_SUM_OFFSET + NUM_WARPS * sizeof(float);
   
   constexpr size_t SHARED_OUTPUT_OFFSET = 128;
   constexpr size_t ZERO_BUFFER_OFFSET = 0;
@@ -140,6 +142,176 @@ __device__ __forceinline__ void
   for (int i = 0; i < 8; i++) {
     zero_buffer.at(i) = (bfloat16)0.0f;
   }
+
+  // load first Q, K, V
+#pragma unroll
+  for (int i = threadIdx.x; i < NUM_Q_HEADS * EXTEND_NUM * (HEAD_DIM / 8);
+       i += NUM_THREADS) {
+    // offset
+    int row = i / 16;
+    int col = (i % 16) * 8;
+    load_smem(q_smem(row, col), q_dmem(row, col));
+  }
+
+  // metadata for flashattention
+  // TODO: check if this is enough
+  float o[8][8];
+#pragma unroll
+  for (int n = 0; n < 8; n++) {
+    clear_8_floats(o[n]);
+  }
+  float d_sum = 1.f;
+  float m = -inf;
+
+#pragma unroll
+  for (int i = threadIdx.x; i < (curr_iter_len * 16); i += NUM_THREADS) {
+    // offset
+    int row = i / 16;
+    int col = (i % 16) * 8;
+    if (row >= seq_len - 1) { // last and extended tokens
+      // from qkv
+      load_smem(k_cache_smem_buffer(row, col), k_dmem(row - (seq_len - 1), col));
+    } else {
+      // from cache
+      load_smem(k_cache_smem_buffer(row, col), k_cache_dmem(row, col));
+    }
+  }
+
+  #pragma unroll
+  for (int i = threadIdx.x; i < (curr_iter_len * 16); i += NUM_THREADS) {
+    // offset
+    int row = i / 16;
+    int col = (i % 16) * 8;
+    if (row >= seq_len - 1) { // last and extended tokens
+      load_smem(v_cache_smem_buffer(row, col), v_dmem(row - (seq_len - 1), col));
+    } else {
+      load_smem(v_cache_smem_buffer(row, col), v_cache_dmem(row, col));
+    }
+  }
+  cp_async_fence();
+
+  // KV iteration
+  //  N = 64 per iter
+  for (uint32_t kv_idx = 0; kv_idx < num_iterations; kv_idx += 1) {
+    // load next k, v
+    int next_iter_len =
+        kv_idx + 1 < num_iterations
+            ? static_cast<int>(std::min(total_seq_len, (kv_idx + 2) * KV_CHUNK_SIZE) -
+                               (kv_idx + 1) * KV_CHUNK_SIZE)
+            : -1;
+
+      // async load next k, v
+      if (kv_idx + 1 != num_iterations) {
+#pragma unroll
+      for (int i = threadIdx.x; i < (next_iter_len * 16); i += NUM_THREADS) {
+        // offset
+        int row = i / 16;
+        int col = (i % 16) * 8;
+        if (row + cp_finished_seq_len >= seq_len - 1) {
+          load_smem(k_cache_smem(row, col), k_dmem(row + cp_finished_seq_len - (seq_len - 1), col));
+        } else {
+          load_smem(k_cache_smem(row, col),
+                    k_cache_dmem(cp_finished_seq_len + row, col));
+        }
+      }
+#pragma unroll
+      for (int i = threadIdx.x; i < (next_iter_len * 16); i += NUM_THREADS) {
+        // offset
+        int row = i / 16;
+        int col = (i % 16) * 8;
+        if (row + cp_finished_seq_len >= seq_len - 1) { 
+          load_smem(v_cache_smem(row, col), v_dmem(row + cp_finished_seq_len - (seq_len - 1), col));
+        } else {
+          load_smem(v_cache_smem(row, col),
+                    v_cache_dmem(cp_finished_seq_len + row, col));
+        }
+      }
+      cp_async_fence();
+      cp_async_wait<1>();
+    } else {
+      cp_async_wait<0>();
+    }
+
+    if ((kv_idx & 1) == 0) {
+      k_cache_smem.set_ptr(shared_k_buffer);
+      k_cache_smem_buffer.set_ptr(shared_k);
+      v_cache_smem.set_ptr(shared_v_buffer);
+      v_cache_smem_buffer.set_ptr(shared_v);
+    } else {
+      k_cache_smem.set_ptr(shared_k);
+      k_cache_smem_buffer.set_ptr(shared_k_buffer);
+      v_cache_smem.set_ptr(shared_v);
+      v_cache_smem_buffer.set_ptr(shared_v_buffer);
+    }
+    __syncthreads();
+
+    // q_norm
+    if (qk_norm && kv_idx == 0) {
+      window_rms_norm<T, QSmem, NUM_Q_HEADS, EXTEND_NUM + 1, HEAD_DIM>(
+          q_smem,
+          static_cast<T const *>(qnorm_weight_ptr),
+          qnorm_sum,
+          q_eps,
+          rotary_emd,
+          static_cast<T const *>(cos_ptr) + (seq_len - 1) * HEAD_DIM, //TODO: check the index of cos and sin
+          static_cast<T const *>(sin_ptr) + (seq_len - 1) * HEAD_DIM);
+    }
+
+    // knorm
+    if (qk_norm && kv_idx == num_iterations - 1) {
+      window_rms_norm<T, KSmem, NUM_KV_HEADS, EXTEND_NUM + 1, HEAD_DIM>(
+          k_cache_smem,
+          static_cast<T const *>(knorm_weight_ptr),
+          knorm_sum,
+          k_eps,
+          rotary_emd,
+          static_cast<T const *>(cos_ptr) + (seq_len - 1) * HEAD_DIM, //TODO: check the index of cos and sin
+          static_cast<T const *>(sin_ptr) + (seq_len - 1) * HEAD_DIM);
+    }
+    __syncthreads();
+
+    // MMA
+    constexpr int NUM_Q_TOKEN_DIM_ITER = (NUM_Q_HEADS * EXTEND_NUM + 16 - 1) / 16;
+    float s_frag[NUM_Q_TOKEN_DIM_ITER][8];
+    #pragma unroll
+    for(int i = 0; i < NUM_Q_TOKEN_DIM_ITER; i++) {
+      clear_8_floats(s_frag[i]);
+    }
+
+    uint32_t a_frag[4], b_frag[4], v_frag[4];
+
+    // QK^T
+    //  MNK = 4 * (extend_num + 1), 64, 128, tiledMMA 16, 64, 16, thread layout ()
+    //  int n_col = warp_idx * 16 + idx_in_warp / 16 * 8;
+    int n_row = (idx_in_warp / 16) * 8 + (idx_in_warp % 8) + warp_idx * 16;
+
+    #pragma unroll
+    for (uint32_t k = 0; k < 8; k++) {
+
+      int m_col = k * 16 + idx_in_warp / 16 * 8;
+      int n_col = ((idx_in_warp % 16) / 8) * 8 + k * 16;
+
+      #pragma unroll
+      for(int q_head_i = 0; q_head_i < NUM_Q_TOKEN_DIM_ITER; q_head_i++) {
+
+        int m_row = idx_in_warp % 16 + q_head_i * 16;
+
+        bool is_valid_A = (m_row < NUM_Q_HEADS * EXTEND_NUM);
+        T *src_ptr_A = is_valid_A ? q_smem(m_row, m_col) : zero_buffer(0, 0);
+        ldsm(src_ptr_A, &a_frag[0]);
+
+        bool is_valid_B = (n_row < curr_iter_len);
+        T *src_ptr_B =
+            is_valid_B ? k_cache_smem(n_row, n_col) : zero_buffer(0, 0);
+        ldsm(src_ptr_B, &b_frag[0]);
+
+        mma_m16n16k16_bf16bf16bf32(s_frag, a_frag, b_frag, s_frag);
+      }
+    }
+    __syncthreads();
+    // To be continued...
+  }
+
 
 
   // To be continued...

--- a/include/mirage/persistent_kernel/tasks/single_batch_extend.cuh
+++ b/include/mirage/persistent_kernel/tasks/single_batch_extend.cuh
@@ -1,0 +1,150 @@
+/* Copyright 2025 CMU
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include "common.h"
+#include "copy_sm80.cuh"
+#include "dmem_layout.cuh"
+#include "element_binary.cuh"
+#include "element_unary.cuh"
+#include "mma.cuh"
+#include "norm.cuh"
+#include "reduction.cuh"
+#include "smem_layout.cuh"
+#include "utils.cuh"
+namespace kernel {
+
+// kernel Input: 9X128, K_Cache: 4KX128, V_Cache:4KX128
+// Load Q = 8 X 128, K = 1 X 128, V = 1 X 128
+// load K into K_Cache, V into V_cache
+template <typename T,
+          int NUM_Q_HEADS,
+          int NUM_KV_HEADS,
+          int HEAD_DIM,
+          int WEIGHT_STRIDE,
+          int EXTEND_NUM>
+__device__ __forceinline__ void
+    single_batch_extend_kernel(void const *qkv_ptr,
+                                 void *k_cache_ptr,
+                                 void *v_cache_ptr,
+                                 void *output_ptr,
+                                 size_t seq_len,
+                                 bool qk_norm,
+                                 bool rotary_emd,
+                                 void const *qnorm_weight_ptr,
+                                 void const *knorm_weight_ptr,
+                                 void const *cos_ptr,
+                                 void const *sin_ptr,
+                                 float q_eps,
+                                 float k_eps) {
+  // constexpr int chunk_size = 16 / sizeof(T);
+  constexpr size_t MAX_SEQ_LEN = 512;
+  constexpr size_t KV_CHUNK_SIZE = 64;
+  float const sm_scale = (1.f / sqrt((float)HEAD_DIM));
+  // float const sm_scale = 1.f;
+
+  int warp_idx = warp_id();
+  int idx_in_warp = threadIdx.x % 32;
+
+  size_t num_iterations = (seq_len + KV_CHUNK_SIZE - 1) / KV_CHUNK_SIZE;
+  int curr_iter_len = std::min(seq_len, KV_CHUNK_SIZE);
+  int cp_finished_seq_len = curr_iter_len;
+  int last_seq_len = curr_iter_len;
+
+  const __restrict__ T *d_q = static_cast<T const *>(qkv_ptr);
+  const __restrict__ T *d_k =
+      static_cast<T const *>(qkv_ptr) + HEAD_DIM * NUM_Q_HEADS;
+  const __restrict__ T *d_v =
+      static_cast<T const *>(qkv_ptr) + HEAD_DIM * (NUM_Q_HEADS + NUM_KV_HEADS);
+  T __restrict__ *d_k_cache = static_cast<T *>(k_cache_ptr);
+  T __restrict__ *d_v_cache = static_cast<T *>(v_cache_ptr);
+  T __restrict__ *d_output = static_cast<T *>(output_ptr);
+
+  dmem_row_const<T, NUM_Q_HEADS, 128, 128> q_dmem(d_q); // [4 * 128 * 2B]
+  dmem_row_const<T, 1, 128, 128> k_dmem(d_k); // [1 * 128 * 2B]
+  dmem_row_const<T, 1, 128, 128> v_dmem(d_v); // [1 * 128 * 2B]
+  dmem_row<T, MAX_SEQ_LEN, 128, WEIGHT_STRIDE> k_cache_dmem(d_k_cache);
+  dmem_row<T, MAX_SEQ_LEN, 128, WEIGHT_STRIDE> v_cache_dmem(d_v_cache);
+  dmem_row<T, NUM_Q_HEADS, 128, 128> output_dmem(d_output);
+
+  extern __shared__ char smem[];
+
+  constexpr size_t SHARED_Q_OFFSET = 128;
+
+  constexpr size_t SHARED_K_OFFSET = SHARED_Q_OFFSET + EXTEND_NUM * HEAD_DIM * sizeof(T);
+  constexpr size_t SHARED_K_BUFFER_OFFSET = SHARED_K_OFFSET + KV_CHUNK_SIZE * HEAD_DIM * sizeof(T);
+  constexpr size_t SHARED_V_OFFSET = SHARED_K_BUFFER_OFFSET + KV_CHUNK_SIZE * HEAD_DIM * sizeof(T);
+  constexpr size_t SHARED_V_BUFFER_OFFSET = SHARED_V_OFFSET + KV_CHUNK_SIZE * HEAD_DIM * sizeof(T);
+  
+  constexpr size_t D_OFFSET = SHARED_V_BUFFER_OFFSET + KV_CHUNK_SIZE * HEAD_DIM * sizeof(T);
+  constexpr size_t MAX_OFFSET = D_OFFSET + HEAD_DIM * sizeof(float);
+  constexpr size_t O_OFFSET = MAX_OFFSET + HEAD_DIM * sizeof(float);
+
+  constexpr size_t Q_NORM_SUM_OFFSET = O_OFFSET + HEAD_DIM * 32 * sizeof(float); // TODO: check
+  constexpr size_t K_NORM_SUM_OFFSET = Q_NORM_SUM_OFFSET + HEAD_DIM * sizeof(float);
+  
+  constexpr size_t SHARED_OUTPUT_OFFSET = 128;
+  constexpr size_t ZERO_BUFFER_OFFSET = 0;
+
+  // copy input
+  T *shared_q = (T *)(smem + SHARED_Q_OFFSET); // 1792 bytes (7 * 128 * 2B)
+  // copy weight
+  T *shared_k = (T *)(smem + SHARED_K_OFFSET); // 16384 bytes (64 * 128 * 2B)
+  T *shared_k_buffer = (T *)(smem + SHARED_K_BUFFER_OFFSET); // 16384 bytes (64 * 128 * 2B)
+
+  T *shared_v = (T *)(smem + SHARED_V_OFFSET); // 16384 bytes (64 * 128 * 2B)
+  T *shared_v_buffer = (T *)(smem + SHARED_V_BUFFER_OFFSET); // 16384 bytes (64 * 128 * 2B)
+  // intermidiate
+  T *shared_output = (T *)(smem + SHARED_OUTPUT_OFFSET); // reuse shared_q
+  T *zero_buf = (T *)(smem + ZERO_BUFFER_OFFSET); // 16 bytes (8 * 2B)
+
+  // flashattn metadata
+  float *d_smem = (float *)(smem + D_OFFSET); // 512 bytes (128 * 4B)
+  float *max_smem = (float *)(smem + MAX_OFFSET); // 512 bytes (128 * 4B)
+  float *o_smem = (float *)(smem + O_OFFSET); // 16384 bytes (128 * 32 * 4B)
+
+  float *qnorm_sum = (float *)(smem + Q_NORM_SUM_OFFSET); // 16 bytes (4 * 4B)
+  float *knorm_sum = (float *)(smem + K_NORM_SUM_OFFSET); // 16 bytes (4 * 4B)
+  // define the swizzle mode
+
+  // zero buffer
+  smem_row<T, 1, 1, 1, 1, 8, 8> zero_buffer(zero_buf);
+
+  using QSmem = smem_row<T, 3, 3, 3, NUM_Q_HEADS * EXTEND_NUM, 128, 128>;
+  using KSmem = smem_row<T, 3, 3, 3, KV_CHUNK_SIZE, 128, 128>;
+  using VSmem = smem_row<T, 3, 3, 3, KV_CHUNK_SIZE, 128, 128>;
+  using OSmem = smem_row<T, 3, 3, 3, NUM_Q_HEADS * EXTEND_NUM, 128, 128>;
+  QSmem q_smem(shared_q);
+
+  KSmem k_cache_smem(shared_k); // 16384 bytes (64 * 128 * 2B)
+  KSmem k_cache_smem_buffer(shared_k_buffer); // 16384 bytes (64 * 128 * 2B)
+  VSmem v_cache_smem(shared_v); // 16384 bytes (64 * 128 * 2B)
+  VSmem v_cache_smem_buffer(shared_v_buffer); // 16384 bytes (64 * 128 * 2B)
+  OSmem output_smem(shared_output); // [4 * 128 * 2B]
+
+  // smem_row<T, 3, 3, 3, NUM_Q_HEADS, 128, 128> output_smem(shared_output);
+
+  // todo, add a chunk assigned function
+  for (int i = 0; i < 8; i++) {
+    zero_buffer.at(i) = (bfloat16)0.0f;
+  }
+
+
+  // To be continued...
+
+
+}
+
+} // namespace kernel

--- a/tests/runtime_python/setup.py
+++ b/tests/runtime_python/setup.py
@@ -4,11 +4,23 @@ import os
 
 this_dir = os.path.dirname(os.path.abspath(__file__))
 
+depends = [
+    'include/mirage/persistent_kernel/tasks/argmax.cuh',
+    'include/mirage/persistent_kernel/tasks/embedding.cuh',
+    'include/mirage/persistent_kernel/tasks/linear.cuh',
+    'include/mirage/persistent_kernel/tasks/norm_linear.cuh',
+    'include/mirage/persistent_kernel/tasks/paged_attention.cuh',
+    'include/mirage/persistent_kernel/tasks/reduction.cuh',
+    'include/mirage/persistent_kernel/tasks/silu_mul_linear.cuh',
+    'include/mirage/persistent_kernel/tasks/single_batch_decoding.cuh',
+]
+
 setup(
     name='runtime_kernel',
     ext_modules=[
         CUDAExtension(
             name='runtime_kernel',
+            depends=depends,
             sources=[
                 os.path.join(this_dir, 'runtime_kernel_wrapper.cu'),
             ],

--- a/tests/runtime_python/test_extend_w_norm.py
+++ b/tests/runtime_python/test_extend_w_norm.py
@@ -49,7 +49,7 @@ def rmsnorm(X, W, eps):
     W_fp32 = W.to(torch.float32)
 
     variance = X_fp32.pow(2).mean(-1, keepdim=True)
-    print("torch square sum:", variance)
+    # print("torch square sum:", variance)
     inv_rms = torch.rsqrt(variance + eps)
     X_normed = X_fp32 * inv_rms
     out = X_normed * W_fp32
@@ -139,7 +139,8 @@ def attention_extend(q_tokens, k_new_tokens, v_new_tokens, k_cache, v_cache, val
         token_pos = valid_len - 1 + i
         # mask = torch.arange(total_len, device=scores.device)[None, :] <= token_pos
         # TODO: This is wrong, only to align with problematic cuda implementation
-        mask = torch.arange(total_len, device=scores.device) <= total_len  # [total_len]
+        # mask = torch.arange(total_len, device=scores.device) <= total_len  # [total_len]
+        mask = torch.arange(total_len, device=scores.device) <= token_pos
         # print("mask.shape:", mask.shape)
         
         # Expand mask to match scores shape [q_heads, 1, total_len]
@@ -171,7 +172,7 @@ def test_extend_correctness():
     # extend_nums = [1, 2, 3]
     # extend_nums = [0]
     # extend_nums = [5]
-    extend_nums = [3, 4, 5]
+    extend_nums = [0, 1, 2, 3, 4, 5]
     # test_seq_lens = [10, 50, 100]
     test_seq_lens = [10, 50, 100, 250, 500]
     # test_seq_lens = [10, 100, 250, 500]

--- a/tests/runtime_python/test_extend_w_norm.py
+++ b/tests/runtime_python/test_extend_w_norm.py
@@ -1,0 +1,249 @@
+import torch
+import torch.nn.functional as F
+import runtime_kernel
+import numpy as np
+
+torch.set_printoptions(sci_mode=False)
+
+q_heads = 4
+k_heads = 1
+v_heads = 1
+head_dim = 128
+num_total_heads = q_heads + k_heads + v_heads
+max_seq_len = 512
+
+device = "cuda"
+dtype = torch.bfloat16
+
+
+def rotate_half(x):
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def apply_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
+    q_fp32 = q.to(torch.float32)
+    k_fp32 = k.to(torch.float32)
+    cos_fp32 = cos.to(torch.float32)
+    sin_fp32 = sin.to(torch.float32)
+
+    cos_fp32 = cos_fp32.unsqueeze(unsqueeze_dim)
+    sin_fp32 = sin_fp32.unsqueeze(unsqueeze_dim)
+    q_embed = (q_fp32 * cos_fp32) + (rotate_half(q_fp32) * sin_fp32)
+    k_embed = (k_fp32 * cos_fp32) + (rotate_half(k_fp32) * sin_fp32)
+    return q_embed.to(torch.bfloat16), k_embed.to(torch.bfloat16)
+
+
+def rmsnorm(X, W, eps):
+    X_fp32 = X.to(torch.float32)
+    W_fp32 = W.to(torch.float32)
+
+    variance = X_fp32.pow(2).mean(-1, keepdim=True)
+    inv_rms = torch.rsqrt(variance + eps)
+    X_normed = X_fp32 * inv_rms
+    out = X_normed * W_fp32
+    return out.to(torch.bfloat16)
+
+
+def attention_extend(q_tokens, k_new_tokens, v_new_tokens, k_cache, v_cache, valid_len, extend_num, q_weight, k_weight, eps, cos, sin):
+    """
+    PyTorch reference implementation for extend operation
+    q_tokens: [q_heads, extend_num+1, head_dim] - raw Q tokens (not normalized)
+    k_new_tokens: [extend_num+1, head_dim] - raw K tokens (not normalized)
+    v_new_tokens: [extend_num+1, head_dim] - raw V tokens (not normalized)
+    k_cache: [1, max_seq_len, head_dim] - existing K cache (already normalized)
+    v_cache: [1, max_seq_len, head_dim] - existing V cache (already normalized)
+    valid_len: current valid length before extend
+    extend_num: number of new tokens to extend
+    """
+    # Normalize new Q tokens
+    q_norm = rmsnorm(q_tokens, q_weight, eps)
+    
+    # Normalize new K tokens
+    k_norm = rmsnorm(k_new_tokens, k_weight, eps)
+    
+    # Apply rotary embedding to Q and K
+    cos_extend = cos[valid_len-1:valid_len+extend_num].unsqueeze(1)  # [extend_num+1, 1, head_dim]
+    sin_extend = sin[valid_len-1:valid_len+extend_num].unsqueeze(1)  # [extend_num+1, 1, head_dim]
+    
+    q_rot = []
+    k_rot = []
+    for i in range(extend_num + 1):
+        q_i, k_i = apply_rotary_pos_emb(
+            q_norm[:, i:i+1], k_norm[i:i+1], 
+            cos_extend[i], sin_extend[i], unsqueeze_dim=1
+        )
+        q_rot.append(q_i)
+        k_rot.append(k_i)
+    
+    q_rot = torch.cat(q_rot, dim=1)  # [q_heads, extend_num+1, head_dim]
+    k_rot = torch.cat(k_rot, dim=0)  # [extend_num+1, head_dim]
+    
+    # Update K cache with normalized and rotated K tokens
+    for i in range(extend_num + 1):
+        k_cache[0, valid_len - 1 + i] = k_rot[i]
+    
+    # Update V cache with new V tokens (V doesn't need rotary embedding)
+    for i in range(extend_num + 1):
+        v_cache[0, valid_len - 1 + i] = v_new_tokens[i]
+    
+    # Expand K and V for attention computation
+    total_len = valid_len + extend_num
+    k_all = k_cache[:, :total_len, :].expand(q_heads, -1, -1)  # [q_heads, total_len, head_dim]
+    v_all = v_cache[:, :total_len, :].expand(q_heads, -1, -1)  # [q_heads, total_len, head_dim]
+    
+    # Compute attention for each Q token
+    outputs = []
+    for i in range(extend_num + 1):
+        q_i = q_rot[:, i:i+1]  # [q_heads, 1, head_dim]
+        scores = torch.matmul(q_i, k_all.transpose(-2, -1)) / np.sqrt(head_dim) # [q_heads, 1, total_len]
+        print("first scores.shape:", scores.shape)
+        
+        # Apply causal mask
+        token_pos = valid_len - 1 + i
+        # mask = torch.arange(total_len, device=scores.device)[None, :] <= token_pos
+        # TODO: This is wrong, only to align with problematic cuda implementation
+        mask = torch.arange(total_len, device=scores.device) <= total_len  # [total_len]
+        print("mask.shape:", mask.shape)
+        
+        # Expand mask to match scores shape [q_heads, 1, total_len]
+        mask_expanded = mask.unsqueeze(0).unsqueeze(0).expand(q_heads, 1, -1)  # [q_heads, 1, total_len]
+        scores = scores.masked_fill(~mask_expanded, float("-inf"))
+        print("scores.shape:", scores.shape)
+        
+        attn = F.softmax(scores, dim=-1) # [q_heads, 1, total_len] 
+        print("attn.shape:", attn.shape)
+        print("v_all.shape:", v_all.shape)
+        
+        out = torch.matmul(attn, v_all)  # [q_heads, 1, head_dim]
+        print("out.shape:", out.shape)
+        outputs.append(out.squeeze(1))  # Remove the middle dimension to get [q_heads, head_dim]
+    
+    print("outputs[0].shape:", outputs[0].shape)
+    ret = torch.stack(outputs, dim=1)  # [q_heads, extend_num+1, head_dim]
+    print("ret.shape:", ret.shape)
+    return ret
+
+
+def test_extend_correctness():
+    """Test single_batch_extend with different extend numbers"""
+    # extend_nums = [1, 2, 3]
+    extend_nums = [1]
+    # test_seq_lens = [10, 50, 100]
+    test_seq_lens = [10]
+    
+    k_cache_torch = torch.empty((1, max_seq_len, head_dim), device=device, dtype=dtype)
+    v_cache_torch = torch.empty((1, max_seq_len, head_dim), device=device, dtype=dtype)
+    k_cache_mirage = torch.empty((max_seq_len, head_dim), device=device, dtype=dtype)
+    v_cache_mirage = torch.empty((max_seq_len, head_dim), device=device, dtype=dtype)
+    
+    all_cos = torch.randn((513, head_dim), device=device, dtype=dtype)
+    all_sin = torch.randn((513, head_dim), device=device, dtype=dtype)
+    
+    for seq_len in test_seq_lens:
+        for extend_num in extend_nums:
+            print(f"\nTesting seq_len={seq_len}, extend_num={extend_num}")
+            
+            # Prepare normalization weights first
+            eps = 1e-5
+            qnorm_weight = torch.randn((1, head_dim), device=device, dtype=dtype)
+            knorm_weight = torch.randn((1, head_dim), device=device, dtype=dtype)
+            
+            # Initialize cache with random NORMALIZED data (simulating existing cache)
+            for i in range(seq_len - 1):
+                k_data = torch.randn(head_dim, device=device, dtype=dtype)
+                v_data = torch.randn(head_dim, device=device, dtype=dtype)
+                k_cache_torch[0, i] = k_data
+                v_cache_torch[0, i] = v_data
+                k_cache_mirage[i] = k_data
+                v_cache_mirage[i] = v_data
+            
+            # Create QKV for extend_num + 1 tokens (last token + new tokens)
+            total_extend_heads = q_heads * (extend_num + 1)
+            qkv = torch.randn(extend_num + 1, (q_heads + k_heads + v_heads) * head_dim, device=device, dtype=dtype)
+            
+            # Extract Q, K, V from QKV tensor (these are RAW, not normalized)
+            qkv_reshaped = qkv.view(extend_num + 1, q_heads + k_heads + v_heads, head_dim)
+            
+            # Extract Q tokens for current query (all extend_num + 1 tokens) - RAW
+            q_tokens = qkv_reshaped[:, :q_heads, :].transpose(0, 1)  # [q_heads, extend_num + 1, head_dim]
+            
+            # Extract K, V tokens (only the new tokens) - RAW
+            k_new_tokens = qkv_reshaped[:, q_heads:q_heads+k_heads, :].squeeze(1)  # [extend_num + 1, head_dim]
+            v_new_tokens = qkv_reshaped[:, q_heads+k_heads:, :].squeeze(1)  # [extend_num + 1, head_dim]
+            
+            # NOTE: We DO NOT pre-populate the cache with new K, V tokens
+            # The extend kernel will handle normalization and cache updates internally
+            
+            # PyTorch reference implementation
+            torch_output = attention_extend(
+                q_tokens.clone(),
+                k_new_tokens.clone(),
+                v_new_tokens.clone(),
+                k_cache_torch.clone(),
+                v_cache_torch.clone(),
+                seq_len,
+                extend_num,
+                qnorm_weight,
+                knorm_weight,
+                eps,
+                all_cos,
+                all_sin
+            )
+            # print(torch_output)
+            print(torch_output.shape)
+            # exit()
+            
+            # Mirage implementation
+            total_q_vec_num = q_heads * (extend_num + 1)
+            mirage_output_flat = torch.empty((total_q_vec_num, head_dim), device=device, dtype=dtype)
+            
+            try:
+                runtime_kernel.single_batch_extend(
+                    qkv,
+                    k_cache_mirage,
+                    v_cache_mirage,
+                    mirage_output_flat,
+                    seq_len,
+                    extend_num,
+                    True,  # qk_norm
+                    True,  # rotary_embed
+                    qnorm_weight,
+                    knorm_weight,
+                    all_cos,
+                    all_sin,
+                    eps,
+                    eps,
+                )
+                
+                # Reshape to match PyTorch reference format
+                mirage_output = mirage_output_flat.view(q_heads, extend_num + 1, head_dim)
+                print("Mirage output shape after reshape:", mirage_output.shape)
+                print("Torch output shape:", torch_output.shape)
+                
+                # Compare results
+                diff = mirage_output - torch_output
+                max_diff = diff.abs().max().item()
+                mean_diff = diff.abs().mean().item()
+                
+                print(f"  Max diff: {max_diff:.6f}")
+                print(f"  Mean diff: {mean_diff:.6f}")
+                
+                if max_diff < 0.1:  # bfloat16 tolerance
+                    print("  ✓ Test passed!")
+                else:
+                    print("  ✗ Test failed!")
+                    print(f"  Torch output shape: {torch_output.shape}")
+                    print(f"  Mirage output shape: {mirage_output.shape}")
+                    print(f"  Sample torch output: {torch_output[0, 0, :100]}")
+                    print(f"  Sample mirage output: {mirage_output[0, 0, :100]}")
+                    print(f"  Sample diff: {diff}")
+                    print("ratio:", mirage_output / torch_output)
+                    
+            except Exception as e:
+                print(f"  ✗ Error: {e}")
+
+
+if __name__ == "__main__":
+    test_extend_correctness() 

--- a/tests/runtime_python/test_extend_w_norm.py
+++ b/tests/runtime_python/test_extend_w_norm.py
@@ -3,9 +3,16 @@ import torch.nn.functional as F
 import runtime_kernel
 import numpy as np
 
-torch.set_printoptions(sci_mode=False)
+# Fix random seeds for reproducibility
+torch.manual_seed(42)
+np.random.seed(42)
+torch.cuda.manual_seed(42)
+torch.cuda.manual_seed_all(42)
+
+torch.set_printoptions(sci_mode=False)#, linewidth=10000)
 
 q_heads = 4
+# q_heads = 1
 k_heads = 1
 v_heads = 1
 head_dim = 128
@@ -15,6 +22,8 @@ max_seq_len = 512
 device = "cuda"
 dtype = torch.bfloat16
 
+# print full tensor
+torch.set_printoptions(threshold=float('inf'), sci_mode=False)
 
 def rotate_half(x):
     x1 = x[..., : x.shape[-1] // 2]
@@ -40,6 +49,7 @@ def rmsnorm(X, W, eps):
     W_fp32 = W.to(torch.float32)
 
     variance = X_fp32.pow(2).mean(-1, keepdim=True)
+    print("torch square sum:", variance)
     inv_rms = torch.rsqrt(variance + eps)
     X_normed = X_fp32 * inv_rms
     out = X_normed * W_fp32
@@ -49,16 +59,23 @@ def rmsnorm(X, W, eps):
 def attention_extend(q_tokens, k_new_tokens, v_new_tokens, k_cache, v_cache, valid_len, extend_num, q_weight, k_weight, eps, cos, sin):
     """
     PyTorch reference implementation for extend operation
-    q_tokens: [q_heads, extend_num+1, head_dim] - raw Q tokens (not normalized)
+    q_tokens: [extend_num+1, q_heads, head_dim] - raw Q tokens (not normalized)
     k_new_tokens: [extend_num+1, head_dim] - raw K tokens (not normalized)
     v_new_tokens: [extend_num+1, head_dim] - raw V tokens (not normalized)
     k_cache: [1, max_seq_len, head_dim] - existing K cache (already normalized)
     v_cache: [1, max_seq_len, head_dim] - existing V cache (already normalized)
     valid_len: current valid length before extend
     extend_num: number of new tokens to extend
+    
+    Returns: output, q_norm_debug, k_norm_debug - CUDA compatible format with debug tensors
     """
-    # Normalize new Q tokens
-    q_norm = rmsnorm(q_tokens, q_weight, eps)
+    # Normalize new Q tokens for each token and head
+    q_norm_list = []
+    for i in range(extend_num + 1):
+        q_token_heads = q_tokens[i]  # [q_heads, head_dim]
+        q_norm_token = rmsnorm(q_token_heads.unsqueeze(0), q_weight, eps).squeeze(0)  # [q_heads, head_dim]
+        q_norm_list.append(q_norm_token)
+    q_norm = torch.stack(q_norm_list, dim=0)  # [extend_num+1, q_heads, head_dim]
     
     # Normalize new K tokens
     k_norm = rmsnorm(k_new_tokens, k_weight, eps)
@@ -70,19 +87,36 @@ def attention_extend(q_tokens, k_new_tokens, v_new_tokens, k_cache, v_cache, val
     q_rot = []
     k_rot = []
     for i in range(extend_num + 1):
-        q_i, k_i = apply_rotary_pos_emb(
-            q_norm[:, i:i+1], k_norm[i:i+1], 
+        # For Q: apply RoPE to each head of each token
+        q_heads_rot = []
+        for h in range(q_norm.shape[1]):  # q_heads
+            q_h, k_i = apply_rotary_pos_emb(
+                q_norm[i:i+1, h:h+1], k_norm[i:i+1], 
+                cos_extend[i], sin_extend[i], unsqueeze_dim=1
+            )
+            q_heads_rot.append(q_h.squeeze(0))  # [1, head_dim]
+        q_token_rot = torch.cat(q_heads_rot, dim=0)  # [q_heads, head_dim]
+        q_rot.append(q_token_rot)
+        
+        # For K: only one head per token
+        _, k_i = apply_rotary_pos_emb(
+            q_norm[i:i+1, 0:1], k_norm[i:i+1], 
             cos_extend[i], sin_extend[i], unsqueeze_dim=1
         )
-        q_rot.append(q_i)
-        k_rot.append(k_i)
+        k_rot.append(k_i.squeeze(0))  # [1, head_dim]
     
-    q_rot = torch.cat(q_rot, dim=1)  # [q_heads, extend_num+1, head_dim]
+    q_rot = torch.stack(q_rot, dim=0)  # [extend_num+1, q_heads, head_dim]
     k_rot = torch.cat(k_rot, dim=0)  # [extend_num+1, head_dim]
+    
+    # Save debug info - reshape to match CUDA format
+    q_norm_debug = q_rot.clone()  # [extend_num+1, q_heads, head_dim]
+    # change to [(extend_num+1) * q_heads, head_dim]
+    q_norm_debug = q_norm_debug.reshape((extend_num + 1) * q_heads, head_dim)
+    k_norm_debug = k_rot.clone()  # [extend_num+1, head_dim]
     
     # Update K cache with normalized and rotated K tokens
     for i in range(extend_num + 1):
-        k_cache[0, valid_len - 1 + i] = k_rot[i]
+        k_cache[0, valid_len - 1 + i] = k_rot[i] # [1, head_dim]
     
     # Update V cache with new V tokens (V doesn't need rotary embedding)
     for i in range(extend_num + 1):
@@ -90,48 +124,57 @@ def attention_extend(q_tokens, k_new_tokens, v_new_tokens, k_cache, v_cache, val
     
     # Expand K and V for attention computation
     total_len = valid_len + extend_num
+    print("Pytorch total_len:", total_len)
     k_all = k_cache[:, :total_len, :].expand(q_heads, -1, -1)  # [q_heads, total_len, head_dim]
     v_all = v_cache[:, :total_len, :].expand(q_heads, -1, -1)  # [q_heads, total_len, head_dim]
     
     # Compute attention for each Q token
     outputs = []
     for i in range(extend_num + 1):
-        q_i = q_rot[:, i:i+1]  # [q_heads, 1, head_dim]
+        q_i = q_rot[i:i+1].transpose(0, 1)  # [q_heads, 1, head_dim]
         scores = torch.matmul(q_i, k_all.transpose(-2, -1)) / np.sqrt(head_dim) # [q_heads, 1, total_len]
-        print("first scores.shape:", scores.shape)
+        # print("first scores.shape:", scores.shape)
         
         # Apply causal mask
         token_pos = valid_len - 1 + i
         # mask = torch.arange(total_len, device=scores.device)[None, :] <= token_pos
         # TODO: This is wrong, only to align with problematic cuda implementation
         mask = torch.arange(total_len, device=scores.device) <= total_len  # [total_len]
-        print("mask.shape:", mask.shape)
+        # print("mask.shape:", mask.shape)
         
         # Expand mask to match scores shape [q_heads, 1, total_len]
         mask_expanded = mask.unsqueeze(0).unsqueeze(0).expand(q_heads, 1, -1)  # [q_heads, 1, total_len]
         scores = scores.masked_fill(~mask_expanded, float("-inf"))
-        print("scores.shape:", scores.shape)
+        # print("scores.shape:", scores.shape)
         
         attn = F.softmax(scores, dim=-1) # [q_heads, 1, total_len] 
-        print("attn.shape:", attn.shape)
-        print("v_all.shape:", v_all.shape)
+        # print("attn.shape:", attn.shape)
+        # print("v_all.shape:", v_all.shape)
         
         out = torch.matmul(attn, v_all)  # [q_heads, 1, head_dim]
-        print("out.shape:", out.shape)
-        outputs.append(out.squeeze(1))  # Remove the middle dimension to get [q_heads, head_dim]
+        outputs.append(out.squeeze(1))  # [q_heads, head_dim]
     
-    print("outputs[0].shape:", outputs[0].shape)
-    ret = torch.stack(outputs, dim=1)  # [q_heads, extend_num+1, head_dim]
-    print("ret.shape:", ret.shape)
-    return ret
+    # Convert to CUDA format: [(extend_num+1)*q_heads, head_dim]
+    # Where each token's qheads are adjacent
+    result = []
+    for i in range(extend_num + 1):  # For each token
+        for j in range(q_heads):  # For each qhead of this token
+            result.append(outputs[i][j])  # [head_dim]
+    
+    ret = torch.stack(result, dim=0)  # [(extend_num+1)*q_heads, head_dim]
+    print("PyTorch output shape:", ret.shape)
+    return ret, q_norm_debug, k_norm_debug
 
 
 def test_extend_correctness():
     """Test single_batch_extend with different extend numbers"""
     # extend_nums = [1, 2, 3]
-    extend_nums = [1]
+    # extend_nums = [0]
+    # extend_nums = [5]
+    extend_nums = [3, 4, 5]
     # test_seq_lens = [10, 50, 100]
-    test_seq_lens = [10]
+    test_seq_lens = [10, 50, 100, 250, 500]
+    # test_seq_lens = [10, 100, 250, 500]
     
     k_cache_torch = torch.empty((1, max_seq_len, head_dim), device=device, dtype=dtype)
     v_cache_torch = torch.empty((1, max_seq_len, head_dim), device=device, dtype=dtype)
@@ -146,7 +189,7 @@ def test_extend_correctness():
             print(f"\nTesting seq_len={seq_len}, extend_num={extend_num}")
             
             # Prepare normalization weights first
-            eps = 1e-5
+            eps = 1e-6
             qnorm_weight = torch.randn((1, head_dim), device=device, dtype=dtype)
             knorm_weight = torch.randn((1, head_dim), device=device, dtype=dtype)
             
@@ -167,17 +210,24 @@ def test_extend_correctness():
             qkv_reshaped = qkv.view(extend_num + 1, q_heads + k_heads + v_heads, head_dim)
             
             # Extract Q tokens for current query (all extend_num + 1 tokens) - RAW
-            q_tokens = qkv_reshaped[:, :q_heads, :].transpose(0, 1)  # [q_heads, extend_num + 1, head_dim]
+            q_tokens = qkv_reshaped[:, :q_heads, :]  # [extend_num + 1, q_heads, head_dim]
             
             # Extract K, V tokens (only the new tokens) - RAW
             k_new_tokens = qkv_reshaped[:, q_heads:q_heads+k_heads, :].squeeze(1)  # [extend_num + 1, head_dim]
             v_new_tokens = qkv_reshaped[:, q_heads+k_heads:, :].squeeze(1)  # [extend_num + 1, head_dim]
             
+            # Debug: Print raw input data to verify consistency
+            # print(f"\n=== Raw Input Data (before norm) ===")
+            # print(f"Q tokens shape: {q_tokens.shape}")
+            # print(f"K tokens shape: {k_new_tokens.shape}")
+            # print(f"Q[-1]: {q_tokens[-1,:]}")
+            # print(f"K[0,:5]: {k_new_tokens[0,:5]}")
+            
             # NOTE: We DO NOT pre-populate the cache with new K, V tokens
             # The extend kernel will handle normalization and cache updates internally
             
             # PyTorch reference implementation
-            torch_output = attention_extend(
+            torch_output, q_norm_debug, k_norm_debug = attention_extend(
                 q_tokens.clone(),
                 k_new_tokens.clone(),
                 v_new_tokens.clone(),
@@ -199,6 +249,10 @@ def test_extend_correctness():
             total_q_vec_num = q_heads * (extend_num + 1)
             mirage_output_flat = torch.empty((total_q_vec_num, head_dim), device=device, dtype=dtype)
             
+            # Debug tensors for normalization outputs
+            q_norm_debug_cuda = torch.empty((q_heads * (extend_num + 1), head_dim), device=device, dtype=dtype)
+            k_norm_debug_cuda = torch.empty((extend_num + 1, head_dim), device=device, dtype=dtype)
+            
             try:
                 runtime_kernel.single_batch_extend(
                     qkv,
@@ -215,15 +269,61 @@ def test_extend_correctness():
                     all_sin,
                     eps,
                     eps,
+                    q_norm_debug_cuda,  # Debug Q norm output
+                    k_norm_debug_cuda,  # Debug K norm output
                 )
                 
-                # Reshape to match PyTorch reference format
-                mirage_output = mirage_output_flat.view(q_heads, extend_num + 1, head_dim)
-                print("Mirage output shape after reshape:", mirage_output.shape)
-                print("Torch output shape:", torch_output.shape)
+                # Both outputs are now in same format: [(extend_num+1)*q_heads, head_dim]
+                # print("PyTorch output shape:", torch_output.shape)
+                # print("CUDA output shape:", mirage_output_flat.shape)
                 
-                # Compare results
-                diff = mirage_output - torch_output
+                # Compare normalization results (for debugging)
+                # print("\n=== Normalization Comparison ===")
+                # print("extend_num used:", extend_num)
+                # print("TOTAL_Q_VEC_NUM expected:", q_heads * (extend_num + 1))
+                # print("PyTorch Q norm shape:", q_norm_debug.shape)
+                # print("PyTorch K norm shape:", k_norm_debug.shape)
+                # print("CUDA Q norm shape:", q_norm_debug_cuda.shape)
+                # print("CUDA K norm shape:", k_norm_debug_cuda.shape)
+                
+                # Compare first few elements only
+                # print("\n=== Q Norm Comparison (first few elements) ===")
+                # print("PyTorch Q norm:", q_norm_debug)
+                # print("CUDA Q norm:", q_norm_debug_cuda)
+                # for i in range(q_heads * (extend_num), q_heads * (extend_num + 1)):
+                #     print(f"PyTorch Q norm[{i}]:", q_norm_debug[i][:6])
+                #     print(f"CUDA Q norm[{i}]:", q_norm_debug_cuda[i][:6])
+                # print("Q norm ratio:", (q_norm_debug/ q_norm_debug_cuda)[-5:])
+                # print("Q norm diff:", (q_norm_debug - q_norm_debug_cuda))
+                # exit()
+                
+                # print("\n=== K Norm Comparison (first few elements) ===")
+                # print("PyTorch K norm:", k_norm_debug)
+                # print("CUDA K norm:", k_norm_debug_cuda)
+                # print("K norm ratio:", (k_norm_debug / k_norm_debug_cuda)[-5:])
+                # print("K norm diff:", (k_norm_debug - k_norm_debug_cuda))
+                
+                
+                
+                # Note: CUDA norm tensors are currently empty since kernel doesn't fill them yet
+                # This is just to test the interface
+                # exit()
+                
+                # Additional debugging: print first few elements to verify format
+                # print("\n=== Final Output Comparison ===")
+                # for i in range(q_heads * (extend_num + 1)):
+                #     max_cur_row = torch.max(torch.abs(mirage_output_flat[i] - torch_output[i]))
+                #     print(f"row: {i}, max_cur_row: {max_cur_row}")
+                #     if max_cur_row > 0.1:
+                #         print(f"PyTorch Q norm[{i}]:", mirage_output_flat[i])
+                #         print(f"CUDA Q norm[{i}]:", torch_output[i])
+                # print("torch_output[0:8, 0:5]:")
+                # print(torch_output[:8, :5])
+                # print("mirage_output_flat[0:8, 0:5]:")
+                # print(mirage_output_flat[:8, :5])
+                
+                # Compare results directly
+                diff = mirage_output_flat - torch_output
                 max_diff = diff.abs().max().item()
                 mean_diff = diff.abs().mean().item()
                 
@@ -235,11 +335,13 @@ def test_extend_correctness():
                 else:
                     print("  ✗ Test failed!")
                     print(f"  Torch output shape: {torch_output.shape}")
-                    print(f"  Mirage output shape: {mirage_output.shape}")
-                    print(f"  Sample torch output: {torch_output[0, 0, :100]}")
-                    print(f"  Sample mirage output: {mirage_output[0, 0, :100]}")
-                    print(f"  Sample diff: {diff}")
-                    print("ratio:", mirage_output / torch_output)
+                    print(f"  Mirage output shape: {mirage_output_flat.shape}")
+                    print(f"  Sample torch output: {torch_output[0, :100]}")
+                    print(f"  Sample mirage output: {mirage_output_flat[0, :100]}")
+                    # print(f"  Sample diff: {diff}")
+                    print("ratio:", (mirage_output_flat / torch_output)[-5:])
+                    print("diff:", (mirage_output_flat - torch_output)[-5:])
+                    # 20 22 23 24
                     
             except Exception as e:
                 print(f"  ✗ Error: {e}")


### PR DESCRIPTION
**Description of changes:**
This implementation will be deprecated after @undefined-c0der's paged attention is merged, as its functionality will fully subsume this one. Currently, this implementation serves as a basic demonstration of speculative decoding.

This implementation assumes all new tokens' kv fall in the same chunk of kv (i.e. the loaded 64 token chunk).

This PR includes everything in #384. 

**Related Issues:**

Linked Issues:
- Issue #378 

Issues closed by this PR:
- Closes #


