### PR TITLE
Fix bug in setting `MIRAGE_HOME` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The fastest way to try MPK is to install it directly from source:
 git clone --recursive --branch mpk https://www.github.com/mirage-project/mirage
 cd mirage
 pip install -e . -v
-export MIRAGE_HOME=$pwd
+export MIRAGE_HOME=$(pwd)
 ```
 
 > 🔧[2025/06/19] We are working on pre-built binary wheels for MPK and will update the installation instructions once they are available.


### PR DESCRIPTION
**Description of changes:**
Previously, the guidance to set the environment variable is `echo MIRAGE_HOME=$pwd`. However there is no variable called `pwd`, we need to execute the `pwd` instruction to get the path. 

I change it to `echo MIRAGE_HOME=$(pwd)`


**Related Issues:**

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #


