### PR TITLE
correct rope offset in paged attention

### DIFF
--- a/include/mirage/persistent_kernel/tasks/multitoken_paged_attention.cuh
+++ b/include/mirage/persistent_kernel/tasks/multitoken_paged_attention.cuh
@@ -328,9 +328,9 @@ __device__ __forceinline__ void multitoken_paged_attention_task_impl(
             token_idx * NUM_QO_PER_KV,
             rope,
             static_cast<T const *>(cos_ptr) +
-                (token_idx + seq_len - num_tokens + 1) * HEAD_DIM,
+                (token_idx + seq_len - num_tokens) * HEAD_DIM,
             static_cast<T const *>(sin_ptr) +
-                (token_idx + seq_len - num_tokens + 1) * HEAD_DIM);
+                (token_idx + seq_len - num_tokens) * HEAD_DIM);
       }
     }
 
@@ -347,9 +347,9 @@ __device__ __forceinline__ void multitoken_paged_attention_task_impl(
             token_idx + curr_iter_len - num_tokens,
             rope,
             static_cast<T const *>(cos_ptr) +
-                (token_idx + seq_len - num_tokens + 1) * HEAD_DIM,
+                (token_idx + seq_len - num_tokens) * HEAD_DIM,
             static_cast<T const *>(sin_ptr) +
-                (token_idx + seq_len - num_tokens + 1) * HEAD_DIM);
+                (token_idx + seq_len - num_tokens) * HEAD_DIM);
       }
     }
     __syncthreads();

--- a/include/mirage/persistent_kernel/tasks/paged_attention.cuh
+++ b/include/mirage/persistent_kernel/tasks/paged_attention.cuh
@@ -280,8 +280,8 @@ __device__ __forceinline__ void
           q_eps,
           0,
           rope,
-          static_cast<T const *>(cos_ptr) + seq_len * HEAD_DIM,
-          static_cast<T const *>(sin_ptr) + seq_len * HEAD_DIM);
+          static_cast<T const *>(cos_ptr) + (seq_len - 1) * HEAD_DIM,
+          static_cast<T const *>(sin_ptr) + (seq_len - 1) * HEAD_DIM);
     }
 
     // K norm
@@ -293,8 +293,8 @@ __device__ __forceinline__ void
           k_eps,
           curr_iter_len - 1,
           rope,
-          static_cast<T const *>(cos_ptr) + seq_len * HEAD_DIM,
-          static_cast<T const *>(sin_ptr) + seq_len * HEAD_DIM);
+          static_cast<T const *>(cos_ptr) + (seq_len - 1) * HEAD_DIM,
+          static_cast<T const *>(sin_ptr) + (seq_len - 1) * HEAD_DIM);
     }
     __syncthreads();
 


### PR DESCRIPTION
**Description of changes:**

modify `cos` and `sin` offset from `seq_len` to `seq_len - 1`


