### PR TITLE
set MAX_SHARE_MEMORY_SIZE based off compute capability

### DIFF
--- a/include/mirage/persistent_kernel/runtime_header.h
+++ b/include/mirage/persistent_kernel/runtime_header.h
@@ -20,7 +20,15 @@
 namespace mirage {
 namespace runtime {
 
-constexpr int MAX_SHARE_MEMORY_SIZE = 150 * 1024;
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+constexpr int MAX_SHARE_MEMORY_SIZE = 224 * 1024;
+#elif defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 860
+constexpr int MAX_SHARE_MEMORY_SIZE = 96 * 1024;
+#elif defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
+constexpr int MAX_SHARE_MEMORY_SIZE = 160 * 1024;
+#else
+constexpr int MAX_SHARE_MEMORY_SIZE = 96 * 1024;
+#endif
 
 typedef unsigned long long int TaskId;
 unsigned long long int const TASK_INVALID_ID = 0x7fffffffffffffff;


### PR DESCRIPTION
**Description of changes:**

This is a bugfix for certain GPUs not generating any output tokens. The default MAX_SHARE_MEMORY_SIZE was `150 kb` but this was larger than the max supported shared memory per block for some GPUs. Here we set it based off compute capability. These numbers were found by via a simple cuda program:

```cpp
#include <cuda_runtime.h>
#include <iostream>

auto main() -> int {
    int device;
    cudaDeviceProp prop;
    
    cudaGetDevice(&device);
    cudaGetDeviceProperties(&prop, device);

    std::cout << "Device: " << prop.name << std::endl;
    std::cout << "Compute Capability: " << prop.major << "." << prop.minor << std::endl;
    std::cout << "Shared Memory per Block: " << prop.sharedMemPerBlock << " bytes" << std::endl;
    std::cout << "Shared Memory per Multiprocessor: " << prop.sharedMemPerMultiprocessor << " bytes" << std::endl;
    std::cout << "Max Shared Memory per Block: " << prop.sharedMemPerBlockOptin << " bytes" << std::endl;

    return 0;
}
```

This was run on `A10G`, `L4`, `L40S`, `A100`, `H100`, `H200`, and `B200` GPUs, covering compute capabilities `sm_80`, `sm_86`, `sm_89`, `sm_90`, and `sm_100`. `sm_120` might need to be added later.