### PR TITLE
[Bug] Fix MAX_OUTPUT_ATOM_SIZE calculation

### DIFF
--- a/include/mirage/persistent_kernel/runtime_header.h
+++ b/include/mirage/persistent_kernel/runtime_header.h
@@ -27,7 +27,7 @@ constexpr int MAX_SHARE_MEMORY_SIZE = 96 * 1024;
 #elif defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
 constexpr int MAX_SHARE_MEMORY_SIZE = 160 * 1024;
 #else
-constexpr int MAX_SHARE_MEMORY_SIZE = 96 * 1024;
+constexpr int MAX_SHARE_MEMORY_SIZE = 160 * 1024;
 #endif
 
 typedef unsigned long long int TaskId;

--- a/include/mirage/persistent_kernel/tasks/norm_linear.cuh
+++ b/include/mirage/persistent_kernel/tasks/norm_linear.cuh
@@ -43,11 +43,13 @@ __device__ __forceinline__ void
                           void *output_ptr) {
   constexpr int CHUNK_SIZE = 16 / sizeof(T);
 
-  // TODO: Update the formula since norm weight is cut down
-  constexpr int MAX_OUTPUT_ATOM_SIZE = max_power_of_two_le(
-      (mirage::runtime::MAX_SHARE_MEMORY_SIZE - 16 - 16898 * BATCH_SIZE) /
-      (4 * (128 + BATCH_SIZE)));
-
+  constexpr int TILE_SIZE = 128;
+  static constexpr int MAX_OUTPUT_ATOM_SIZE = max_power_of_two_le(
+      (mirage::runtime::MAX_SHARE_MEMORY_SIZE / sizeof(T) -
+       ((REDUCTION_SIZE + 2 * TILE_SIZE + 1) * BATCH_SIZE + REDUCTION_SIZE +
+        8)) /
+      (K_PIPE_MAX * TILE_SIZE +
+       5 * BATCH_SIZE));
   constexpr int OUTPUT_LIMIT = OUTPUT_SIZE <= 128 ? OUTPUT_SIZE : 128;
   constexpr int OUTPUT_ATOM_SIZE = OUTPUT_LIMIT <= MAX_OUTPUT_ATOM_SIZE
                                        ? OUTPUT_LIMIT
@@ -57,7 +59,6 @@ __device__ __forceinline__ void
       OUTPUT_SIZE / OUTPUT_ATOM_SIZE; // Full output atoms
   constexpr int LAST_OUTPUT_ATOM_SIZE = OUTPUT_SIZE % OUTPUT_ATOM_SIZE;
 
-  constexpr int TILE_SIZE = 128;
   constexpr int FORLOOP_RANGE = REDUCTION_SIZE / TILE_SIZE;
   static_assert(REDUCTION_SIZE % TILE_SIZE == 0,
                 "REDUCTION_SIZE must be a multiple of TILE_SIZE.");


### PR DESCRIPTION
**Description of changes:**
1. fix MAX_OUTPUT_ATOM_SIZE calculation
2.Change else branch of smem to 160*1024 for dev on A100


BS=1:
rms_norm_1: 60us
linear: 30us
rms_norm-2: 157us
silu_mul_linear: 91us （已编辑） 

BS=8:
rmsnorm_linear_1: 99us
linear: 41us
rmsnomr_linear_2: 307us
silu_mul_linear: 170us

The reason of the slow down is the wrong formula chooses small OUTPUT_ATOM_SIZE:
BATCH_SIZE: 8, OUTPUT_SIZE: 1600, OUTPUT_ATOM_SIZE: 32, NUM_OUTPUT_ATOMS: 50, LAST_OUTPUT_ATOM_SIZE: 0
After fixing the formula, this is the statistics:
BATCH_SIZE: 8, OUTPUT_SIZE: 1600, OUTPUT_ATOM_SIZE: 128, NUM_OUTPUT_ATOMS: 12, LAST_OUTPUT_ATOM_SIZE: 64
rms_norm_1: 67us
linear: 38us
rms_norm-2: 182us

Note that silu_mul_linear is still slow and also need modifying.


**Related Issues:**

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #


