### PR TITLE
Launch more workers on A100

### DIFF
--- a/include/mirage/persistent_kernel/persistent_kernel.cuh
+++ b/include/mirage/persistent_kernel/persistent_kernel.cuh
@@ -192,7 +192,7 @@ __device__ void worker_checker(RuntimeConfig config) {
   // Each scheduelr SM serves four schedulers
   int num_schedulers =
       config.num_local_schedulers + config.num_remote_schedulers;
-  // assert(num_schedulers % 4 == 0);
+
   assert(gridDim.x == config.num_workers);
   assert(config.num_workers <= MAX_NUM_WORKERS);
   // We will reinterpret TaskDesc as an array of integers to
@@ -207,15 +207,11 @@ __device__ void scheduler_checker(RuntimeConfig config) {
   // Each scheduelr SM serves four schedulers
   int num_schedulers =
       config.num_local_schedulers + config.num_remote_schedulers;
-  // assert(num_schedulers % 4 == 0);
-  // assert(gridDim.x == num_schedulers / 4);
+
   assert(config.num_workers <= MAX_NUM_WORKERS);
   // We will reinterpret TaskDesc as an array of integers to
   // collectively load it from device to shared memory
   assert(sizeof(TaskDesc) % sizeof(int) == 0);
-
-  // assert that we have at least four warps per thread block
-  // assert(blockDim.x >= 128);
 }
 
 __device__ void persistent_checker(RuntimeConfig config) {
@@ -546,12 +542,10 @@ __device__ void execute_worker(RuntimeConfig config) {
 __device__ void execute_scheduler(RuntimeConfig config, int offset) {
   int num_schedulers =
       config.num_local_schedulers + config.num_remote_schedulers;
-  // int warp_id = threadIdx.x / 32;
   int warp_thread_id = threadIdx.x % 32;
 
   // CANNOT use syncthreads below
   if (warp_thread_id == 0) {
-    // int sched_id = blockIdx.x * 4 + warp_id + offset;
     int sched_id = blockIdx.x + offset;
     // if (threadIdx.x == 0) {
     //   int sched_id = (blockIdx.x - config.num_workers);
@@ -562,8 +556,6 @@ __device__ void execute_scheduler(RuntimeConfig config, int offset) {
     sched_queues[0] = config.sched_queues[sched_id];
     sched_queue_ids[0] = sched_id;
     unsigned long long int my_first_worker, my_last_worker;
-    my_first_worker = sched_id;
-    my_last_worker = sched_id + 1;
 
     if (sched_id < config.num_local_schedulers) {
       // local schedulers also (collectively) process events from
@@ -571,17 +563,17 @@ __device__ void execute_scheduler(RuntimeConfig config, int offset) {
       sched_queues[num_sched_queues] = config.sched_queues[num_schedulers];
       sched_queue_ids[num_sched_queues] = num_schedulers;
       num_sched_queues++;
-      // get_first_last_ids(config.num_workers,
-      //                    config.num_local_schedulers,
-      //                    sched_id,
-      //                    &my_first_worker,
-      //                    &my_last_worker);
+      get_first_last_ids(config.num_workers,
+                         config.num_local_schedulers,
+                         sched_id,
+                         &my_first_worker,
+                         &my_last_worker);
     } else {
-      // get_first_last_ids(config.num_workers,
-      //                    config.num_remote_schedulers,
-      //                    sched_id - config.num_local_schedulers,
-      //                    &my_first_worker,
-      //                    &my_last_worker);
+      get_first_last_ids(config.num_workers,
+                         config.num_remote_schedulers,
+                         sched_id - config.num_local_schedulers,
+                         &my_first_worker,
+                         &my_last_worker);
       // Remote schedulers send tasks to remove worker queue
       // whose ids start from config.num_workers
       my_first_worker += config.num_workers;
@@ -1037,12 +1029,6 @@ extern "C" void launch_persistent_kernel() {
     // The split kernel does not support NVSHMEM because
     // nvshmemx_collective_launch launches kernels sequentially, which blocks
     // the interaction between the worker kernel and the scheduler kernel
-    // scheduler_kernel<<<
-    //     dim3(global_runtime_config.num_local_schedulers / 4, 1, 1),
-    //     dim3(128, 1, 1),
-    //     MAX_SHARE_MEMORY_SIZE /*smem*/,
-    //     scheduler_stream>>>(global_runtime_config);
-
     worker_kernel<<<dim3(global_runtime_config.num_workers, 1, 1),
                     dim3(128, 1, 1),
                     MAX_SHARE_MEMORY_SIZE /*smem*/,

--- a/include/mirage/persistent_kernel/persistent_kernel.cuh
+++ b/include/mirage/persistent_kernel/persistent_kernel.cuh
@@ -192,7 +192,7 @@ __device__ void worker_checker(RuntimeConfig config) {
   // Each scheduelr SM serves four schedulers
   int num_schedulers =
       config.num_local_schedulers + config.num_remote_schedulers;
-  assert(num_schedulers % 4 == 0);
+  // assert(num_schedulers % 4 == 0);
   assert(gridDim.x == config.num_workers);
   assert(config.num_workers <= MAX_NUM_WORKERS);
   // We will reinterpret TaskDesc as an array of integers to
@@ -207,15 +207,15 @@ __device__ void scheduler_checker(RuntimeConfig config) {
   // Each scheduelr SM serves four schedulers
   int num_schedulers =
       config.num_local_schedulers + config.num_remote_schedulers;
-  assert(num_schedulers % 4 == 0);
-  assert(gridDim.x == num_schedulers / 4);
+  // assert(num_schedulers % 4 == 0);
+  // assert(gridDim.x == num_schedulers / 4);
   assert(config.num_workers <= MAX_NUM_WORKERS);
   // We will reinterpret TaskDesc as an array of integers to
   // collectively load it from device to shared memory
   assert(sizeof(TaskDesc) % sizeof(int) == 0);
 
   // assert that we have at least four warps per thread block
-  assert(blockDim.x >= 128);
+  // assert(blockDim.x >= 128);
 }
 
 __device__ void persistent_checker(RuntimeConfig config) {
@@ -542,15 +542,17 @@ __device__ void execute_worker(RuntimeConfig config) {
   }
 }
 
+// need to alter as there is only one warp per block
 __device__ void execute_scheduler(RuntimeConfig config, int offset) {
   int num_schedulers =
       config.num_local_schedulers + config.num_remote_schedulers;
-  int warp_id = threadIdx.x / 32;
+  // int warp_id = threadIdx.x / 32;
   int warp_thread_id = threadIdx.x % 32;
 
   // CANNOT use syncthreads below
-  if (warp_id < 4 && warp_thread_id == 0) {
-    int sched_id = blockIdx.x * 4 + warp_id + offset;
+  if (warp_thread_id == 0) {
+    // int sched_id = blockIdx.x * 4 + warp_id + offset;
+    int sched_id = blockIdx.x + offset;
     // if (threadIdx.x == 0) {
     //   int sched_id = (blockIdx.x - config.num_workers);
     int num_sched_queues = 1;
@@ -560,23 +562,26 @@ __device__ void execute_scheduler(RuntimeConfig config, int offset) {
     sched_queues[0] = config.sched_queues[sched_id];
     sched_queue_ids[0] = sched_id;
     unsigned long long int my_first_worker, my_last_worker;
+    my_first_worker = sched_id;
+    my_last_worker = sched_id + 1;
+
     if (sched_id < config.num_local_schedulers) {
       // local schedulers also (collectively) process events from
       // the global queue
       sched_queues[num_sched_queues] = config.sched_queues[num_schedulers];
       sched_queue_ids[num_sched_queues] = num_schedulers;
       num_sched_queues++;
-      get_first_last_ids(config.num_workers,
-                         config.num_local_schedulers,
-                         sched_id,
-                         &my_first_worker,
-                         &my_last_worker);
+      // get_first_last_ids(config.num_workers,
+      //                    config.num_local_schedulers,
+      //                    sched_id,
+      //                    &my_first_worker,
+      //                    &my_last_worker);
     } else {
-      get_first_last_ids(config.num_workers,
-                         config.num_remote_schedulers,
-                         sched_id - config.num_local_schedulers,
-                         &my_first_worker,
-                         &my_last_worker);
+      // get_first_last_ids(config.num_workers,
+      //                    config.num_remote_schedulers,
+      //                    sched_id - config.num_local_schedulers,
+      //                    &my_first_worker,
+      //                    &my_last_worker);
       // Remote schedulers send tasks to remove worker queue
       // whose ids start from config.num_workers
       my_first_worker += config.num_workers;
@@ -1007,6 +1012,7 @@ extern "C" void init_persistent_kernel(std::vector<void *> meta_tensors,
 }
 
 // Entry point for C/C++
+// TODO: change launch config
 extern "C" void launch_persistent_kernel() {
   int device;
   cudaGetDevice(&device);
@@ -1031,16 +1037,21 @@ extern "C" void launch_persistent_kernel() {
     // The split kernel does not support NVSHMEM because
     // nvshmemx_collective_launch launches kernels sequentially, which blocks
     // the interaction between the worker kernel and the scheduler kernel
-    scheduler_kernel<<<
-        dim3(global_runtime_config.num_local_schedulers / 4, 1, 1),
-        dim3(128, 1, 1),
-        MAX_SHARE_MEMORY_SIZE /*smem*/,
-        scheduler_stream>>>(global_runtime_config);
+    // scheduler_kernel<<<
+    //     dim3(global_runtime_config.num_local_schedulers / 4, 1, 1),
+    //     dim3(128, 1, 1),
+    //     MAX_SHARE_MEMORY_SIZE /*smem*/,
+    //     scheduler_stream>>>(global_runtime_config);
 
     worker_kernel<<<dim3(global_runtime_config.num_workers, 1, 1),
                     dim3(128, 1, 1),
                     MAX_SHARE_MEMORY_SIZE /*smem*/,
                     worker_stream>>>(global_runtime_config);
+
+    scheduler_kernel<<<dim3(global_runtime_config.num_local_schedulers, 1, 1),
+                       dim3(32, 1, 1),
+                       0 /*smem*/,
+                       scheduler_stream>>>(global_runtime_config);
 
     cudaError_t err = cudaDeviceSynchronize();
     if (err != cudaSuccess) {

--- a/include/mirage/persistent_kernel/tasks/norm_linear.cuh
+++ b/include/mirage/persistent_kernel/tasks/norm_linear.cuh
@@ -27,8 +27,6 @@ namespace kernel {
 
 using bfloat16 = type::bfloat16_t;
 
-
-
 template <typename T,
           int BATCH_SIZE,
           int OUTPUT_SIZE,
@@ -73,11 +71,16 @@ __device__ __forceinline__ void
 
   // using SM80_16x8x16_F16F16F16F16_TNX2 = 16X16X16
   constexpr int NUM_WARPS_N =
-      ((OUTPUT_ATOM_SIZE + 15) / 16 == 3) ? 4 :
-      ((OUTPUT_ATOM_SIZE + 15) / 16 <= 4 ? (OUTPUT_ATOM_SIZE + 15) / 16 : 4);
+      ((OUTPUT_ATOM_SIZE + 15) / 16 == 3)
+          ? 4
+          : ((OUTPUT_ATOM_SIZE + 15) / 16 <= 4 ? (OUTPUT_ATOM_SIZE + 15) / 16
+                                               : 4);
   constexpr int LAST_NUM_WARPS_N =
-      ((LAST_OUTPUT_ATOM_SIZE + 15) / 16 == 3) ? 4 :
-      ((LAST_OUTPUT_ATOM_SIZE + 15) / 16 <= 4 ? (LAST_OUTPUT_ATOM_SIZE + 15) / 16 : 4);
+      ((LAST_OUTPUT_ATOM_SIZE + 15) / 16 == 3)
+          ? 4
+          : ((LAST_OUTPUT_ATOM_SIZE + 15) / 16 <= 4
+                 ? (LAST_OUTPUT_ATOM_SIZE + 15) / 16
+                 : 4);
 
   constexpr int NUM_WARPS_K = 4 / NUM_WARPS_N;
   constexpr int LAST_NUM_WARPS_K =

--- a/include/mirage/persistent_kernel/tasks/rotary_embedding.cuh
+++ b/include/mirage/persistent_kernel/tasks/rotary_embedding.cuh
@@ -64,6 +64,6 @@ __device__ __forceinline__ void rotary_embedding(InputSmem smem_input,
       }
     }
   }
-  }
+}
 
 } // namespace kernel

--- a/include/mirage/persistent_kernel/tasks/utils.cuh
+++ b/include/mirage/persistent_kernel/tasks/utils.cuh
@@ -96,25 +96,27 @@ static __device__ __forceinline__ void clear_8_floats(float *buffer) {
 }
 
 // Vectorized zero initialization struct
-template<typename T, int N>
+template <typename T, int N>
 struct vec_zero_t {
-    static __device__ __forceinline__ void fill_zero(T* ptr) {
-        // Ensure sizeof(T) * N is a multiple of 16 bytes
-        static_assert((sizeof(T) * N) % 16 == 0, "sizeof(T) * N must be a multiple of 16 bytes for proper vectorized operations");
+  static __device__ __forceinline__ void fill_zero(T *ptr) {
+    // Ensure sizeof(T) * N is a multiple of 16 bytes
+    static_assert((sizeof(T) * N) % 16 == 0,
+                  "sizeof(T) * N must be a multiple of 16 bytes for proper "
+                  "vectorized operations");
 
-        constexpr int total_bytes = sizeof(T) * N;
-        constexpr int num_chunks = total_bytes / sizeof(__uint128_t);
-        __uint128_t* vec_ptr = reinterpret_cast<__uint128_t*>(ptr);
-        constexpr int max_iters = (num_chunks + NUM_THREADS - 1) / NUM_THREADS;
+    constexpr int total_bytes = sizeof(T) * N;
+    constexpr int num_chunks = total_bytes / sizeof(__uint128_t);
+    __uint128_t *vec_ptr = reinterpret_cast<__uint128_t *>(ptr);
+    constexpr int max_iters = (num_chunks + NUM_THREADS - 1) / NUM_THREADS;
 
-        #pragma unroll
-        for (int i = 0; i < max_iters; ++i) {
-            int idx = i * blockDim.x + threadIdx.x;
-            if (idx < num_chunks) {
-                vec_ptr[idx] = 0ul;
-            }
-        }
+#pragma unroll
+    for (int i = 0; i < max_iters; ++i) {
+      int idx = i * blockDim.x + threadIdx.x;
+      if (idx < num_chunks) {
+        vec_ptr[idx] = 0ul;
+      }
     }
+  }
 };
 
 } // namespace kernel

--- a/python/mirage/utils.py
+++ b/python/mirage/utils.py
@@ -24,7 +24,7 @@ def get_shared_memory_capacity(target_cc):
 
 def get_scheduler(sm_cnt, worker):
     if sm_cnt == 108:
-        return 108
+        return 27
 
     scheduler = 4 * (sm_cnt - worker)
     assert scheduler > 0, "worker count is not compatible with sm count on"

--- a/python/mirage/utils.py
+++ b/python/mirage/utils.py
@@ -23,6 +23,9 @@ def get_shared_memory_capacity(target_cc):
 
 
 def get_scheduler(sm_cnt, worker):
+    if sm_cnt == 108:
+        return 108
+
     scheduler = 4 * (sm_cnt - worker)
     assert scheduler > 0, "worker count is not compatible with sm count on"
     "the GPU"
@@ -41,7 +44,7 @@ def get_configurations_from_gpu(rank):
     elif sm_cnt >= 132:
         worker = 128
     elif sm_cnt >= 108:
-        worker = 96
+        worker = 108
     elif sm_cnt >= 68:
         worker = 64
     elif sm_cnt >= 40:


### PR DESCRIPTION
**Description of changes:**
Launch 108 worker kernels instead of 96 on the A100 GPU, and launch 27 scheduler kernels simultaneously. This allows the megakernel to have more workers to perform tasks.


**Related Issues:**

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #


