### PR TITLE
fix improper __CUDA_ARCH__ macro usage

### DIFF
--- a/include/mirage/persistent_kernel/runtime_header.h
+++ b/include/mirage/persistent_kernel/runtime_header.h
@@ -20,11 +20,11 @@
 namespace mirage {
 namespace runtime {
 
-#if MIRAGE_TARGET_CC >= 90
+#if MPK_TARGET_CC >= 90
 constexpr int MAX_SHARE_MEMORY_SIZE = 224 * 1024;
-#elif MIRAGE_TARGET_CC >= 86
+#elif MPK_TARGET_CC >= 86
 constexpr int MAX_SHARE_MEMORY_SIZE = 96 * 1024;
-#elif MIRAGE_TARGET_CC >= 80
+#elif MPK_TARGET_CC >= 80
 constexpr int MAX_SHARE_MEMORY_SIZE = 160 * 1024;
 #else
 constexpr int MAX_SHARE_MEMORY_SIZE = 96 * 1024;

--- a/include/mirage/persistent_kernel/runtime_header.h
+++ b/include/mirage/persistent_kernel/runtime_header.h
@@ -20,11 +20,11 @@
 namespace mirage {
 namespace runtime {
 
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+#if MIRAGE_TARGET_CC >= 90
 constexpr int MAX_SHARE_MEMORY_SIZE = 224 * 1024;
-#elif defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 860
+#elif MIRAGE_TARGET_CC >= 86
 constexpr int MAX_SHARE_MEMORY_SIZE = 96 * 1024;
-#elif defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
+#elif MIRAGE_TARGET_CC >= 80
 constexpr int MAX_SHARE_MEMORY_SIZE = 160 * 1024;
 #else
 constexpr int MAX_SHARE_MEMORY_SIZE = 96 * 1024;

--- a/python/mirage/persistent_kernel.py
+++ b/python/mirage/persistent_kernel.py
@@ -141,6 +141,7 @@ def get_compile_command(
         "-o",
         py_so_path,
     ]
+    flags = flags + [f"-DMIRAGE_TARGET_CC={target_cc}"]
 
     if use_nvshmem:
         nvshmem_cmd = [

--- a/python/mirage/persistent_kernel.py
+++ b/python/mirage/persistent_kernel.py
@@ -141,7 +141,7 @@ def get_compile_command(
         "-o",
         py_so_path,
     ]
-    flags = flags + [f"-DMIRAGE_TARGET_CC={target_cc}"]
+    flags = flags + [f"-DMPK_TARGET_CC={target_cc}"]
 
     if use_nvshmem:
         nvshmem_cmd = [


### PR DESCRIPTION
**Description of changes:**
The ```MAX_SHARE_MEMORY_SIZE``` attribute is used in a **host function** ```extern "C" void launch_persistent_kernel() ```, but it is defined by using the macro `__CUDA_ARCH__`, which cannot be correct defined in host function.

This pr passes a compilation flag manually to make host function correctly parse the ```MAX_SHARE_MEMORY_SIZE``` attribute.



**Related Issues:**

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #


