### PR TITLE
Set rdc flag to false

### DIFF
--- a/python/mirage/persistent_kernel.py
+++ b/python/mirage/persistent_kernel.py
@@ -134,7 +134,7 @@ def get_compile_command(
     flags = [
         "-shared",
         "-std=c++17",
-        "-rdc=true",
+        "-rdc=false",
         "-use_fast_math",
         "-Xcompiler=-fPIC",
         "--expt-relaxed-constexpr",


### PR DESCRIPTION
**Description of changes:**
The ```rdc``` flag is set to true in the case where more than one .cu files exist, in our case we only have one .cu file for mpk, setting ```rdc``` to true prevents compiler from doing some optimizations and would case performance degradation.


**Related Issues:**

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #


