### PR TITLE
force inline some function to avoid register spill

### DIFF
--- a/demo/qwen3/demo.py
+++ b/demo/qwen3/demo.py
@@ -73,6 +73,13 @@ if __name__ == "__main__":
     parser.add_argument(
         "--model", type=str, default='Qwen/Qwen3-8B', help="Model path on hugging face"
     )
+    parser.add_argument(
+        "--no-force-inline",
+        action="store_false",
+        dest="force_inline",
+        default=True,
+        help="Force inline some method to avoid register spill and local memory access",
+    )
     args = parser.parse_args()
     try:
         from mpi4py import MPI
@@ -242,6 +249,7 @@ if __name__ == "__main__":
             profiler_tensor=profiler_tensor,
             trace_name=args.trace_name,
             spec_decode_config=spec_decode_config,
+            force_inline_worker_scheduler_method=args.force_inline,
         )
         
         if spec_decode_config and spec_decode_config.method == "promptlookup":

--- a/include/mirage/persistent_kernel/persistent_kernel.cuh
+++ b/include/mirage/persistent_kernel/persistent_kernel.cuh
@@ -29,6 +29,13 @@
 #include <unistd.h>
 #include <vector>
 
+#ifndef MIRAGE_FORCE_INLINE_METHOD
+// Mirage will use a flag (force_inline_worker_scheduler_method) to control
+// whether force inline the worker/scheduler or not, by default we will inline
+// them.
+#define MIRAGE_FORCE_INLINE_METHOD __forceinline__
+#endif // MIRAGE_FORCE_INLINE_METHOD
+
 using bfloat16 = type::bfloat16_t;
 using namespace mirage::runtime;
 
@@ -331,7 +338,8 @@ __device__ __forceinline__ void
   }
 }
 
-__device__ __forceinline__ void terminate_schedulers(RuntimeConfig config) {
+__device__ MIRAGE_FORCE_INLINE_METHOD void
+    terminate_schedulers(RuntimeConfig config) {
   // Event ID 0 is the termination event
   int num_schedulers =
       config.num_local_schedulers + config.num_remote_schedulers;
@@ -356,7 +364,8 @@ __device__ __forceinline__ void terminate_schedulers(RuntimeConfig config) {
   }
 }
 
-__device__ __forceinline__ void worker_checker(RuntimeConfig config) {
+__device__ MIRAGE_FORCE_INLINE_METHOD void
+    worker_checker(RuntimeConfig config) {
   assert(gridDim.y == 1);
   assert(gridDim.z == 1);
   // Each worker SM serves a single worker
@@ -371,7 +380,8 @@ __device__ __forceinline__ void worker_checker(RuntimeConfig config) {
   assert(sizeof(TaskDesc) % sizeof(int) == 0);
 }
 
-__device__ __forceinline__ void scheduler_checker(RuntimeConfig config) {
+__device__ MIRAGE_FORCE_INLINE_METHOD void
+    scheduler_checker(RuntimeConfig config) {
   assert(gridDim.y == 1);
   assert(gridDim.z == 1);
   // Each worker SM serves a single worker
@@ -385,7 +395,8 @@ __device__ __forceinline__ void scheduler_checker(RuntimeConfig config) {
   assert(sizeof(TaskDesc) % sizeof(int) == 0);
 }
 
-__device__ __forceinline__ void persistent_checker(RuntimeConfig config) {
+__device__ MIRAGE_FORCE_INLINE_METHOD void
+    persistent_checker(RuntimeConfig config) {
   assert(gridDim.y == 1);
   assert(gridDim.z == 1);
   // Each worker SM serves a single worker
@@ -401,7 +412,8 @@ __device__ __forceinline__ void persistent_checker(RuntimeConfig config) {
   assert(blockDim.x >= 128);
 }
 
-__device__ __forceinline__ void execute_worker(RuntimeConfig config) {
+__device__ MIRAGE_FORCE_INLINE_METHOD void
+    execute_worker(RuntimeConfig config) {
   __shared__ TaskId cur_task_id;
   __shared__ TaskDesc task_desc;
 
@@ -665,7 +677,8 @@ __device__ __forceinline__ void execute_worker(RuntimeConfig config) {
 }
 
 // need to alter as there is only one warp per block
-__device__ __forceinline__ void execute_scheduler(RuntimeConfig config, int offset) {
+__device__ MIRAGE_FORCE_INLINE_METHOD void
+    execute_scheduler(RuntimeConfig config, int offset) {
   int num_schedulers =
       config.num_local_schedulers + config.num_remote_schedulers;
   int warp_thread_id = threadIdx.x % 32;

--- a/include/mirage/persistent_kernel/persistent_kernel.cuh
+++ b/include/mirage/persistent_kernel/persistent_kernel.cuh
@@ -331,7 +331,7 @@ __device__ __forceinline__ void
   }
 }
 
-__device__ void terminate_schedulers(RuntimeConfig config) {
+__device__ __forceinline__ void terminate_schedulers(RuntimeConfig config) {
   // Event ID 0 is the termination event
   int num_schedulers =
       config.num_local_schedulers + config.num_remote_schedulers;
@@ -356,7 +356,7 @@ __device__ void terminate_schedulers(RuntimeConfig config) {
   }
 }
 
-__device__ void worker_checker(RuntimeConfig config) {
+__device__ __forceinline__ void worker_checker(RuntimeConfig config) {
   assert(gridDim.y == 1);
   assert(gridDim.z == 1);
   // Each worker SM serves a single worker
@@ -371,7 +371,7 @@ __device__ void worker_checker(RuntimeConfig config) {
   assert(sizeof(TaskDesc) % sizeof(int) == 0);
 }
 
-__device__ void scheduler_checker(RuntimeConfig config) {
+__device__ __forceinline__ void scheduler_checker(RuntimeConfig config) {
   assert(gridDim.y == 1);
   assert(gridDim.z == 1);
   // Each worker SM serves a single worker
@@ -385,7 +385,7 @@ __device__ void scheduler_checker(RuntimeConfig config) {
   assert(sizeof(TaskDesc) % sizeof(int) == 0);
 }
 
-__device__ void persistent_checker(RuntimeConfig config) {
+__device__ __forceinline__ void persistent_checker(RuntimeConfig config) {
   assert(gridDim.y == 1);
   assert(gridDim.z == 1);
   // Each worker SM serves a single worker
@@ -401,7 +401,7 @@ __device__ void persistent_checker(RuntimeConfig config) {
   assert(blockDim.x >= 128);
 }
 
-__device__ void execute_worker(RuntimeConfig config) {
+__device__ __forceinline__ void execute_worker(RuntimeConfig config) {
   __shared__ TaskId cur_task_id;
   __shared__ TaskDesc task_desc;
 
@@ -665,7 +665,7 @@ __device__ void execute_worker(RuntimeConfig config) {
 }
 
 // need to alter as there is only one warp per block
-__device__ void execute_scheduler(RuntimeConfig config, int offset) {
+__device__ __forceinline__ void execute_scheduler(RuntimeConfig config, int offset) {
   int num_schedulers =
       config.num_local_schedulers + config.num_remote_schedulers;
   int warp_thread_id = threadIdx.x % 32;

--- a/python/mirage/persistent_kernel.py
+++ b/python/mirage/persistent_kernel.py
@@ -114,6 +114,7 @@ def get_compile_command(
     num_workers=None,
     num_local_schedulers=None,
     num_remote_schedulers=None,
+    force_inline_worker_scheduler_method=True,
 ):
     max_worker_per_scheduler = 128
     if num_workers != None and num_local_schedulers != None and num_remote_schedulers != None:
@@ -142,6 +143,7 @@ def get_compile_command(
         f"-I{os.path.join(mirage_deps_path, 'cutlass/include')}",
         f"-I{os.path.join(mirage_home_path, 'deps/json/include')}",
         f"-DMAX_WORKER_PER_SCHEDULER={max_worker_per_scheduler}",
+        f"-DMIRAGE_FORCE_INLINE_METHOD={'__forceinline__' if force_inline_worker_scheduler_method else '__noinline__'}",
     ]
 
     flags = [
@@ -223,7 +225,8 @@ class PersistentKernel:
         meta_tensors: dict,
         profiler_tensor: torch.Tensor,
         trace_name: str,
-        spec_decode_config: SpecDecodeConfig
+        spec_decode_config: SpecDecodeConfig,
+        force_inline_worker_scheduler_method: bool
     ):
         self.__finalized__ = False
         self._is_compiled = False
@@ -247,6 +250,7 @@ class PersistentKernel:
         self.trace_name = trace_name
         self.use_nvshmem = True if world_size > 1 else False
         self.spec_decode_config = spec_decode_config
+        self.force_inline_worker_scheduler_method = force_inline_worker_scheduler_method
         self._spec_decode_handlers = {
             "promptlookup": self.prompt_lookup_spec_handler,
         }
@@ -998,6 +1002,7 @@ class PersistentKernel:
             num_workers=self.num_workers,
             num_local_schedulers=self.num_local_schedulers, 
             num_remote_schedulers=self.num_remote_schedulers,
+            force_inline_worker_scheduler_method=self.force_inline_worker_scheduler_method,
         )
         print("Compiling megakernel using the following command line:")
         print(cc_cmd)


### PR DESCRIPTION
**Description of changes:**
This PR try to force inline some function to avoid register spill.

Before:
```
ptxas info    : 1584 bytes gmem
ptxas info    : Compiling entry function '_Z16scheduler_kernelN6mirage7runtime13RuntimeConfigE' for 'sm_80'
ptxas info    : Function properties for _Z16scheduler_kernelN6mirage7runtime13RuntimeConfigE
    96 bytes stack frame, 0 bytes spill stores, 0 bytes spill loads
ptxas info    : Used 72 registers, 632 bytes cmem[0]
ptxas info    : Compiling entry function '_Z13worker_kernelN6mirage7runtime13RuntimeConfigE' for 'sm_80'
ptxas info    : Function properties for _Z13worker_kernelN6mirage7runtime13RuntimeConfigE
    48 bytes stack frame, 20 bytes spill stores, 32 bytes spill loads
ptxas info    : Used 255 registers, 632 bytes cmem[0]
ptxas info    : Compiling entry function '_Z17persistent_kernelN6mirage7runtime13RuntimeConfigE' for 'sm_80'
ptxas info    : Function properties for _Z17persistent_kernelN6mirage7runtime13RuntimeConfigE
    112 bytes stack frame, 0 bytes spill stores, 0 bytes spill loads
ptxas info    : Used 255 registers, 632 bytes cmem[0]
ptxas info    : Compiling entry function '_Z11init_kernelN6mirage7runtime13RuntimeConfigEm' for 'sm_80'
ptxas info    : Function properties for _Z11init_kernelN6mirage7runtime13RuntimeConfigEm
    0 bytes stack frame, 0 bytes spill stores, 0 bytes spill loads
ptxas info    : Used 26 registers, 640 bytes cmem[0]
ptxas info    : Function properties for _Z17execute_schedulerN6mirage7runtime13RuntimeConfigEi
    280 bytes stack frame, 164 bytes spill stores, 164 bytes spill loads
ptxas info    : Function properties for _Z14execute_workerN6mirage7runtime13RuntimeConfigE
    568 bytes stack frame, 540 bytes spill stores, 544 bytes spill loads
ptxas info    : Function properties for _Z18persistent_checkerN6mirage7runtime13RuntimeConfigE
    24 bytes stack frame, 20 bytes spill stores, 20 bytes spill loads
ptxas info    : Function properties for _Z17scheduler_checkerN6mirage7runtime13RuntimeConfigE
    24 bytes stack frame, 20 bytes spill stores, 20 bytes spill loads
ptxas info    : Function properties for _Z14worker_checkerN6mirage7runtime13RuntimeConfigE
    24 bytes stack frame, 20 bytes spill stores, 20 bytes spill loads
ptxas info    : Function properties for _Z20terminate_schedulersN6mirage7runtime13RuntimeConfigE
    8 bytes stack frame, 8 bytes spill stores, 8 bytes spill loads
```

After:
```
ptxas info    : 1584 bytes gmem
ptxas info    : Compiling entry function '_Z16scheduler_kernelN6mirage7runtime13RuntimeConfigE' for 'sm_80'
ptxas info    : Function properties for _Z16scheduler_kernelN6mirage7runtime13RuntimeConfigE
    96 bytes stack frame, 0 bytes spill stores, 0 bytes spill loads
ptxas info    : Used 72 registers, 632 bytes cmem[0]
ptxas info    : Compiling entry function '_Z13worker_kernelN6mirage7runtime13RuntimeConfigE' for 'sm_80'
ptxas info    : Function properties for _Z13worker_kernelN6mirage7runtime13RuntimeConfigE
    16 bytes stack frame, 0 bytes spill stores, 0 bytes spill loads
ptxas info    : Used 234 registers, 632 bytes cmem[0]
ptxas info    : Compiling entry function '_Z17persistent_kernelN6mirage7runtime13RuntimeConfigE' for 'sm_80'
ptxas info    : Function properties for _Z17persistent_kernelN6mirage7runtime13RuntimeConfigE
    96 bytes stack frame, 0 bytes spill stores, 0 bytes spill loads
ptxas info    : Used 243 registers, 632 bytes cmem[0]
ptxas info    : Compiling entry function '_Z11init_kernelN6mirage7runtime13RuntimeConfigEm' for 'sm_80'
ptxas info    : Function properties for _Z11init_kernelN6mirage7runtime13RuntimeConfigEm
    0 bytes stack frame, 0 bytes spill stores, 0 bytes spill loads
ptxas info    : Used 26 registers, 640 bytes cmem[0]
```

**Related Issues:**

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #


