### PR TITLE
Change linear_hopper partitioning strategy

### DIFF
--- a/demo/qwen3/demo_hopper.py
+++ b/demo/qwen3/demo_hopper.py
@@ -115,7 +115,8 @@ if __name__ == "__main__":
             model = Qwen3ForCausalLM.from_pretrained(model_name, world_size=1, max_num_pages=args.max_num_pages, page_size=args.page_size).to("cuda")
             tokenizer = AutoTokenizer.from_pretrained(model_name)
 
-    total_num_requests = 4
+    # total_num_requests = 4
+    total_num_requests = args.max_num_batched_requests
     # get all model weight tensors
     tokens = torch.full((total_num_requests, args.max_seq_length), 0, dtype=torch.long, device="cuda")
 
@@ -370,7 +371,7 @@ if __name__ == "__main__":
                 spec_decode_config = spec_decode_config, 
                 tokens = all_tokens,
                 grid_dim=(96, 1, 1),
-                block_dim=(128, 1, 1),
+                block_dim=(256, 1, 1),
             )
             x = spec_tokens
         # Add Embed
@@ -384,7 +385,7 @@ if __name__ == "__main__":
             output=y, 
             # grid_dim=(max_factor_leq_n(hidden_size, 96 // args.max_num_batched_tokens), total_tokens_per_iter, 1), 
             grid_dim=(1, 1, 1), 
-            block_dim=(128, 1, 1),
+            block_dim=(256, 1, 1),
             input_source=1,
         )
         x = y
@@ -416,14 +417,15 @@ if __name__ == "__main__":
                 weight=w_norm,
                 output=rmsnorm_out,
                 grid_dim=(mpk.max_num_batched_tokens, 1, 1),
-                block_dim=(128, 1, 1),
+                block_dim=(256, 1, 1),
             )
             mpk.linear_layer(
                 input=rmsnorm_out,
                 weight=w_qkv,
                 output=attn_in,
-                grid_dim=(grid_for_rmsnorm_linear_layer(w_qkv.dim(0)), 1, 1),
-                block_dim=(128, 1, 1),
+                # grid_dim=(grid_for_rmsnorm_linear_layer(w_qkv.dim(0)), 1, 1),
+                grid_dim=(w_qkv.dim(0) // 64, 1, 1),
+                block_dim=(256, 1, 1),
             )
             #mpk.rmsnorm_linear_layer(
             #    input=x,
@@ -431,7 +433,7 @@ if __name__ == "__main__":
             #    weight_linear=w_qkv,
             #    output=attn_in,
             #    grid_dim=(grid_for_rmsnorm_linear_layer(w_qkv.dim(0)), 1, 1),
-            #    block_dim=(128, 1, 1),
+            #    block_dim=(256, 1, 1),
             #)
             # add attention
             w_q_norm = mpk.attach_input(
@@ -458,7 +460,7 @@ if __name__ == "__main__":
                     sin_pos_embed=sin_pos_embed,
                     output=attn_out,
                     grid_dim=(1, num_local_kv_heads, 1), #TODO: further divide across batch dim
-                    block_dim=(128, 1, 1),
+                    block_dim=(256, 1, 1),
                 )
             else:
                 mpk.paged_attention_layer(
@@ -471,7 +473,7 @@ if __name__ == "__main__":
                     sin_pos_embed=sin_pos_embed,
                     output=attn_out,
                     grid_dim=(mpk.max_num_batched_requests, num_local_kv_heads, 1),
-                    block_dim=(128, 1, 1),
+                    block_dim=(256, 1, 1),
                 )
             # add linear w/ residual
             w = mpk.attach_input(
@@ -483,8 +485,9 @@ if __name__ == "__main__":
                 weight=w,
                 residual=x,
                 output=attn_proj_out,
-                grid_dim=(hidden_size // 128, 1, 1),
-                block_dim=(128, 1, 1),
+                # grid_dim=(hidden_size // 128, 1, 1),
+                grid_dim=(hidden_size // 64, 1, 1),
+                block_dim=(256, 1, 1),
             )
             # reset residual input as x
             x = attn_proj_out
@@ -495,7 +498,7 @@ if __name__ == "__main__":
                     buffer=allreduce_buf,
                     output=attn_allreduce_out,
                     grid_dim=(hidden_size // 64, 1, 1),
-                    block_dim=(128, 1, 1),
+                    block_dim=(256, 1, 1),
                 )
                 x = attn_allreduce_out
             # add rmsnorm_linear layer
@@ -510,6 +513,7 @@ if __name__ == "__main__":
                 torch_tensor=layer.mlp.up_proj.weight, name=f"layer_{i}_up_proj"
             )
             rmsnorm_num_tasks = grid_for_rmsnorm_linear_layer(w_gate_proj.dim(0) + w_up_proj.dim(0))
+            # rmsnorm_num_tasks = (w_gate_proj.dim(0) + w_up_proj.dim(0)) // 64
             w_gatedup = mpk.shuffle_tensors(
                 inputs=[w_gate_proj, w_up_proj],
                 shuffled_dim=0,
@@ -521,13 +525,15 @@ if __name__ == "__main__":
                 weight=w_norm,
                 output=rmsnorm_out,
                 grid_dim=(mpk.max_num_batched_tokens, 1, 1),
-                block_dim=(128, 1, 1),
+                block_dim=(256, 1, 1),
             )
+            print("rmsnorm_num_tasks", rmsnorm_num_tasks, w_gate_proj.dim(0) + w_up_proj.dim(0))
             mpk.linear_layer(
                 input=rmsnorm_out,
                 weight=w_gatedup,
                 output=mlp_mid,
-                grid_dim=(rmsnorm_num_tasks, 1, 1),
+                # grid_dim=(rmsnorm_num_tasks, 1, 1),
+                grid_dim=((w_gate_proj.dim(0) + w_up_proj.dim(0)) // 64, 1, 1),
                 block_dim=(256, 1, 1),
             )
             #mpk.rmsnorm_linear_layer(
@@ -536,13 +542,13 @@ if __name__ == "__main__":
             #    weight_linear=w_gatedup,
             #    output=mlp_mid,
             #    grid_dim=(rmsnorm_num_tasks, 1, 1),
-            #    block_dim=(128, 1, 1),
+            #    block_dim=(256, 1, 1),
             #)
             mpk.silu_mul_layer(
                 input=mlp_mid,
                 output=silu_mul_out,
                 grid_dim=(rmsnorm_num_tasks//2, 1, 1),
-                block_dim=(128, 1, 1),
+                block_dim=(256, 1, 1),
             )
             # add silu_mul_linear layer
             w = mpk.attach_input(
@@ -553,8 +559,9 @@ if __name__ == "__main__":
                 weight=w,
                 residual=x,
                 output=mlp_out,
-                grid_dim=(hidden_size // 128, 1, 1),
-                block_dim=(128, 1, 1),
+                # grid_dim=(hidden_size // 128, 1, 1),
+                grid_dim=(hidden_size // 64, 1, 1),
+                block_dim=(256, 1, 1),
             )
             # reset residual input as x
             x = mlp_out
@@ -564,7 +571,7 @@ if __name__ == "__main__":
                     buffer=allreduce_buf,
                     output=mlp_final,
                     grid_dim=(hidden_size // 64, 1, 1),
-                    block_dim=(128, 1, 1),
+                    block_dim=(256, 1, 1),
                 )
                 x = mlp_final
 
@@ -578,14 +585,14 @@ if __name__ == "__main__":
             weight=w_norm,
             output=rmsnorm_out_2,
             grid_dim=(mpk.max_num_batched_tokens, 1, 1),
-            block_dim=(128, 1, 1),
+            block_dim=(256, 1, 1),
         )
         mpk.linear_layer(
             input=rmsnorm_out_2,
             weight=w_proj,
             output=argmax_in,
-            grid_dim=(75, 1, 1),
-            block_dim=(128, 1, 1),
+            grid_dim=(vocab_size // 256, 1, 1),
+            block_dim=(256, 1, 1),
         )
         # mpk.rmsnorm_linear_layer(
         #     input=x,
@@ -593,7 +600,7 @@ if __name__ == "__main__":
         #     weight_linear=w_proj,
         #     output=argmax_in,
         #     grid_dim=(grid_for_rmsnorm_linear_layer(w_proj.dim(0)), 1, 1),
-        #     block_dim=(128, 1, 1),
+        #     block_dim=(256, 1, 1),
         # )
         # add argmax layer
         if spec_decode_config and spec_decode_config.method == "promptlookup":
@@ -608,13 +615,13 @@ if __name__ == "__main__":
             input=argmax_in,
             output=(argmax_part_value, argmax_part_index),
             grid_dim=argmax_partial_grid_dim,
-            block_dim=(128, 1, 1),
+            block_dim=(256, 1, 1),
         )
         mpk.argmax_reduce_layer(
             input=(argmax_part_value, argmax_part_index),
             output=argmax_out,
             grid_dim=argmax_reduce_grid_dim,
-            block_dim=(128, 1, 1),
+            block_dim=(256, 1, 1),
         )
         if spec_decode_config:
             verify_out = mpk.verify_layer_dispatcher(

--- a/demo/qwen3/demo_hopper.py
+++ b/demo/qwen3/demo_hopper.py
@@ -513,7 +513,6 @@ if __name__ == "__main__":
                 torch_tensor=layer.mlp.up_proj.weight, name=f"layer_{i}_up_proj"
             )
             rmsnorm_num_tasks = grid_for_rmsnorm_linear_layer(w_gate_proj.dim(0) + w_up_proj.dim(0))
-            # rmsnorm_num_tasks = (w_gate_proj.dim(0) + w_up_proj.dim(0)) // 64
             w_gatedup = mpk.shuffle_tensors(
                 inputs=[w_gate_proj, w_up_proj],
                 shuffled_dim=0,
@@ -527,7 +526,6 @@ if __name__ == "__main__":
                 grid_dim=(mpk.max_num_batched_tokens, 1, 1),
                 block_dim=(256, 1, 1),
             )
-            print("rmsnorm_num_tasks", rmsnorm_num_tasks, w_gate_proj.dim(0) + w_up_proj.dim(0))
             mpk.linear_layer(
                 input=rmsnorm_out,
                 weight=w_gatedup,

--- a/python/mirage/persistent_kernel.py
+++ b/python/mirage/persistent_kernel.py
@@ -609,9 +609,7 @@ class PersistentKernel:
         tb_graph.new_input(weight, (0, -1, -1), 1, True)
         tb_graph.new_input(output, (1, -1, -1), -1, True)
         self.kn_graph.customized([input, weight, output], tb_graph)
-        hopper_linear_kernel = "linear_hopper" if output.dim(0) / grid_dim[0] >= 256 else "linear_swapAB_hopper"
-        print(f"hopper_linear_kernel: {hopper_linear_kernel}")
-        self.kn_graph.register_task(tb_graph, hopper_linear_kernel if self.target_cc == 90 else "linear")
+        self.kn_graph.register_task(tb_graph, "linear_swapAB_hopper" if self.target_cc == 90 else "linear")
 
     def linear_with_residual_layer(
         self,

--- a/python/mirage/persistent_kernel.py
+++ b/python/mirage/persistent_kernel.py
@@ -609,7 +609,9 @@ class PersistentKernel:
         tb_graph.new_input(weight, (0, -1, -1), 1, True)
         tb_graph.new_input(output, (1, -1, -1), -1, True)
         self.kn_graph.customized([input, weight, output], tb_graph)
-        self.kn_graph.register_task(tb_graph, "linear_swapAB_hopper" if self.target_cc == 90 else "linear")
+        hopper_linear_kernel = "linear_hopper" if output.dim(0) / grid_dim[0] >= 256 else "linear_swapAB_hopper"
+        print(f"hopper_linear_kernel: {hopper_linear_kernel}")
+        self.kn_graph.register_task(tb_graph, hopper_linear_kernel if self.target_cc == 90 else "linear")
 
     def linear_with_residual_layer(
         self,

--- a/src/kernel/task_register.cc
+++ b/src/kernel/task_register.cc
@@ -709,7 +709,7 @@ int TaskRegister::register_linear_hopper_task(threadblock::Graph const &bgraph,
   constexpr int S = 3;
   constexpr int TMA_CP_ASYNC_SIZE = 64;
   constexpr int TILE_SIZE = 128;
-  const int Kstages = output_size >= 256 ? 3 : 6;
+  int const Kstages = output_size >= 256 ? 3 : 6;
   int const SMEM_M_SIZE = batch_size;
   // int const SMEM_M_SIZE = 64;
   int const output_tma_cp_size = output_size < 64 ? output_size : 64;

--- a/src/kernel/task_register.cc
+++ b/src/kernel/task_register.cc
@@ -709,7 +709,7 @@ int TaskRegister::register_linear_hopper_task(threadblock::Graph const &bgraph,
   constexpr int S = 3;
   constexpr int TMA_CP_ASYNC_SIZE = 64;
   constexpr int TILE_SIZE = 128;
-  constexpr int Kstages = 2;
+  const int Kstages = output_size >= 256 ? 3 : 6;
   int const SMEM_M_SIZE = batch_size;
   // int const SMEM_M_SIZE = 64;
   int const output_tma_cp_size = output_size < 64 ? output_size : 64;

--- a/tests/runtime_python/hopper/runtime_kernel_wrapper_hopper.cu
+++ b/tests/runtime_python/hopper/runtime_kernel_wrapper_hopper.cu
@@ -12,851 +12,849 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- #include "bfloat16.h"
- #include "hopper/linear_hopper.cuh"
- #include "hopper/linear_swapAB_hopper.cuh"
- #include "hopper/multitoken_paged_attention_hopper.cuh"
- #include "hopper/norm_linear_hopper.cuh"
- #include <cuda_runtime.h>
- #include <torch/extension.h>
- 
- using kernel::linear_kernel_hopper;
- using kernel::linear_swapAB_kernel_hopper;
- using kernel::multitoken_paged_attention_hopper_impl;
- using kernel::norm_linear_kernel_hopper;
- using bfloat16 = type::bfloat16_t;
- 
- template <typename T,
-           int BATCH_SIZE,
-           int OUTPUT_SIZE,
-           int REDUCTION_SIZE,
-           typename TMA_A,
-           typename TMA_B,
-           typename TMA_RESIDUAL,
-           typename TMA_OUT,
-           int Kstages = 4>
- __global__ __launch_bounds__(256, 1) void linear_kernel_swapAB_hopper_wrapper(
-     const __grid_constant__ TMA_A tma_a,
-     const __grid_constant__ TMA_B tma_b,
-     const __grid_constant__ TMA_RESIDUAL tma_residual,
-     const __grid_constant__ TMA_OUT tma_out) {
- 
-   linear_swapAB_kernel_hopper<T,
-                               BATCH_SIZE,
-                               OUTPUT_SIZE,
-                               REDUCTION_SIZE,
-                               Kstages,
-                               TMA_A,
-                               TMA_B,
-                               TMA_OUT>(tma_a, tma_b, tma_out, &tma_residual);
- }
- 
- template <typename T,
-           int BATCH_SIZE,
-           int OUTPUT_SIZE,
-           int REDUCTION_SIZE,
-           typename TMA_A,
-           typename TMA_B,
-           typename TMA_OUT,
-           int Kstages = 2>
- __global__
-     __launch_bounds__(256, 1) void linear_kernel_swapAB_no_residual_hopper_wrapper(
-         const __grid_constant__ TMA_A tma_a,
-         const __grid_constant__ TMA_B tma_b,
-         const __grid_constant__ TMA_OUT tma_out) {
- 
-   linear_swapAB_kernel_hopper<T,
-                               BATCH_SIZE,
-                               OUTPUT_SIZE,
-                               REDUCTION_SIZE,
-                               Kstages,
-                               TMA_A,
-                               TMA_B,
-                               TMA_OUT,
-                               void>(tma_a, tma_b, tma_out, nullptr);
- }
- 
- template <typename T, int BATCH_SIZE, int OUTPUT_SIZE, int REDUCTION_SIZE>
- void launch_linear_swapAB(void *input_ptr,
-                           void *weight_ptr,
-                           void *residual_ptr,
-                           void *output_ptr = nullptr) {
- 
-   constexpr int B = 3;
-   constexpr int M = 3;
-   constexpr int S = 3;
- 
-   constexpr int TMA_CP_ASYNC_SIZE =
-       64; // note that if swizzle 128 is used, 64 is maximal cp size
-   constexpr int TILE_SIZE =
-       128; // we should modify this param if we want larger tile size
-   constexpr int TMA_CP_ASYNC_REPEAT_COL =
-       (TILE_SIZE + TMA_CP_ASYNC_SIZE - 1) / TMA_CP_ASYNC_SIZE;
- 
-   constexpr int OUTPUT_ATOM_SIZE = 64; // this is padded
-   constexpr int OUTPUT_TMA_CP_SIZE = OUTPUT_SIZE < 64 ? OUTPUT_SIZE : 64;
-   constexpr int OUTPUT_ATOM_REPEAT_COL = 1;
- 
-   constexpr int SMEM_M_SIZE = 16;
-   using TMA_B =
-       kernel::tma::tma_2d<bfloat16,
-                           B,
-                           M,
-                           S,
-                           BATCH_SIZE,                      /*GMEM_ROW_*/
-                           REDUCTION_SIZE,                  /*GMEM_COL_*/
-                           BATCH_SIZE,                      /*SMEM_ROW_*/
-                           TMA_CP_ASYNC_SIZE,               /*SMEM_COL_*/
-                           REDUCTION_SIZE,                  /*GMEM_STRIDE_ROW_*/
-                           1,                               /*GMEM_STRIDE_COL_*/
-                           1,                               /*SMEM_REPEAT_ROW_*/
-                           TMA_CP_ASYNC_REPEAT_COL,         /*SMEM_REPEAT_COL_*/
-                           SMEM_M_SIZE * TMA_CP_ASYNC_SIZE, /*SMEM_STRIDE_*/
-                           true>;
-   using TMA_A =
-       kernel::tma::tma_2d<bfloat16,
-                           B,
-                           M,
-                           S,
-                           OUTPUT_SIZE,             /*GMEM_ROW_*/
-                           REDUCTION_SIZE,          /*GMEM_COL_*/
-                           OUTPUT_ATOM_SIZE,        /*SMEM_ROW_*/
-                           TMA_CP_ASYNC_SIZE,       /*SMEM_COL_*/
-                           REDUCTION_SIZE,          /*GMEM_STRIDE_ROW_*/
-                           1,                       /*GMEM_STRIDE_COL_*/
-                           1,                       /*SMEM_REPEAT_ROW_*/
-                           TMA_CP_ASYNC_REPEAT_COL, /*SMEM_REPEAT_COL_*/
-                           OUTPUT_ATOM_SIZE * TMA_CP_ASYNC_SIZE, /*SMEM_STRIDE_*/
-                           true>;
-   using TMA_RESIDUAL = kernel::tma::tma_2d<bfloat16,
-                                            0,
-                                            0,
-                                            0,
-                                            BATCH_SIZE,
-                                            OUTPUT_SIZE,
-                                            BATCH_SIZE,
-                                            OUTPUT_TMA_CP_SIZE,
-                                            OUTPUT_SIZE,
-                                            1,
-                                            1,
-                                            OUTPUT_ATOM_REPEAT_COL,
-                                            SMEM_M_SIZE * OUTPUT_TMA_CP_SIZE,
-                                            true>;
- 
-   using TMA_OUT = kernel::tma::tma_2d<bfloat16,
-                                       B,
-                                       M,
-                                       S,
-                                       BATCH_SIZE,
-                                       OUTPUT_SIZE,
-                                       BATCH_SIZE,
-                                       OUTPUT_TMA_CP_SIZE,
-                                       OUTPUT_SIZE,
-                                       1,
-                                       1,
-                                       OUTPUT_ATOM_REPEAT_COL,
-                                       SMEM_M_SIZE * TMA_CP_ASYNC_SIZE,
-                                       true>;
-   TMA_A tma_a(weight_ptr);
-   TMA_B tma_b(input_ptr);
-   TMA_RESIDUAL tma_residual(residual_ptr);
-   TMA_OUT tma_out(output_ptr);
- 
-   dim3 grid_dim(1, 1, 1);
-   dim3 block_dim(256, 1, 1);
-   size_t smem_size = 224 * 1024;
- 
-   if (residual_ptr != nullptr) {
-     cudaFuncSetAttribute(linear_kernel_swapAB_hopper_wrapper<T,
-                                                              BATCH_SIZE,
-                                                              OUTPUT_SIZE,
-                                                              REDUCTION_SIZE,
-                                                              TMA_A,
-                                                              TMA_B,
-                                                              TMA_RESIDUAL,
-                                                              TMA_OUT>,
-                          cudaFuncAttributeMaxDynamicSharedMemorySize,
-                          smem_size);
- 
-   } else {
- 
-     cudaFuncSetAttribute(
-         linear_kernel_swapAB_no_residual_hopper_wrapper<T,
-                                                         BATCH_SIZE,
-                                                         OUTPUT_SIZE,
-                                                         REDUCTION_SIZE,
-                                                         TMA_A,
-                                                         TMA_B,
-                                                         TMA_OUT>,
-         cudaFuncAttributeMaxDynamicSharedMemorySize,
-         smem_size);
-   }
- 
- #ifndef MIRAGE_PROFILE_HOPPER
-   if (residual_ptr != nullptr) {
- 
-     linear_kernel_swapAB_hopper_wrapper<T,
-                                         BATCH_SIZE,
-                                         OUTPUT_SIZE,
-                                         REDUCTION_SIZE,
-                                         TMA_A,
-                                         TMA_B,
-                                         TMA_RESIDUAL,
-                                         TMA_OUT>
-         <<<grid_dim, block_dim, smem_size>>>(
-             tma_a, tma_b, tma_residual, tma_out);
-   } else {
- 
-     linear_kernel_swapAB_no_residual_hopper_wrapper<T,
-                                                     BATCH_SIZE,
-                                                     OUTPUT_SIZE,
-                                                     REDUCTION_SIZE,
-                                                     TMA_A,
-                                                     TMA_B,
-                                                     TMA_OUT>
-         <<<grid_dim, block_dim, smem_size>>>(tma_a, tma_b, tma_out);
-   }
- #else
- 
-   cudaEvent_t start, stop;
-   cudaEventCreate(&start);
-   cudaEventCreate(&stop);
- 
-   constexpr int WARMUP_RUNS = 16;
-   constexpr int BENCHMARK_RUNS = 1000;
- 
-   printf("=== Kernel Performance Profiling ===\n");
- 
-   for (int i = 0; i < WARMUP_RUNS; i++) {
-     if (residual_ptr != nullptr) {
-       linear_kernel_swapAB_hopper_wrapper<T,
+#include "bfloat16.h"
+#include "hopper/linear_hopper.cuh"
+#include "hopper/linear_swapAB_hopper.cuh"
+#include "hopper/multitoken_paged_attention_hopper.cuh"
+#include "hopper/norm_linear_hopper.cuh"
+#include <cuda_runtime.h>
+#include <torch/extension.h>
+
+using kernel::linear_kernel_hopper;
+using kernel::linear_swapAB_kernel_hopper;
+using kernel::multitoken_paged_attention_hopper_impl;
+using kernel::norm_linear_kernel_hopper;
+using bfloat16 = type::bfloat16_t;
+
+template <typename T,
+          int BATCH_SIZE,
+          int OUTPUT_SIZE,
+          int REDUCTION_SIZE,
+          typename TMA_A,
+          typename TMA_B,
+          typename TMA_RESIDUAL,
+          typename TMA_OUT,
+          int Kstages = 4>
+__global__ __launch_bounds__(256, 1) void linear_kernel_swapAB_hopper_wrapper(
+    const __grid_constant__ TMA_A tma_a,
+    const __grid_constant__ TMA_B tma_b,
+    const __grid_constant__ TMA_RESIDUAL tma_residual,
+    const __grid_constant__ TMA_OUT tma_out) {
+
+  linear_swapAB_kernel_hopper<T,
+                              BATCH_SIZE,
+                              OUTPUT_SIZE,
+                              REDUCTION_SIZE,
+                              Kstages,
+                              TMA_A,
+                              TMA_B,
+                              TMA_OUT>(tma_a, tma_b, tma_out, &tma_residual);
+}
+
+template <typename T,
+          int BATCH_SIZE,
+          int OUTPUT_SIZE,
+          int REDUCTION_SIZE,
+          typename TMA_A,
+          typename TMA_B,
+          typename TMA_OUT,
+          int Kstages = 2>
+__global__
+    __launch_bounds__(256, 1) void linear_kernel_swapAB_no_residual_hopper_wrapper(
+        const __grid_constant__ TMA_A tma_a,
+        const __grid_constant__ TMA_B tma_b,
+        const __grid_constant__ TMA_OUT tma_out) {
+
+  linear_swapAB_kernel_hopper<T,
+                              BATCH_SIZE,
+                              OUTPUT_SIZE,
+                              REDUCTION_SIZE,
+                              Kstages,
+                              TMA_A,
+                              TMA_B,
+                              TMA_OUT,
+                              void>(tma_a, tma_b, tma_out, nullptr);
+}
+
+template <typename T, int BATCH_SIZE, int OUTPUT_SIZE, int REDUCTION_SIZE>
+void launch_linear_swapAB(void *input_ptr,
+                          void *weight_ptr,
+                          void *residual_ptr,
+                          void *output_ptr = nullptr) {
+
+  constexpr int B = 3;
+  constexpr int M = 3;
+  constexpr int S = 3;
+
+  constexpr int TMA_CP_ASYNC_SIZE =
+      64; // note that if swizzle 128 is used, 64 is maximal cp size
+  constexpr int TILE_SIZE =
+      128; // we should modify this param if we want larger tile size
+  constexpr int TMA_CP_ASYNC_REPEAT_COL =
+      (TILE_SIZE + TMA_CP_ASYNC_SIZE - 1) / TMA_CP_ASYNC_SIZE;
+
+  constexpr int OUTPUT_ATOM_SIZE = 64; // this is padded
+  constexpr int OUTPUT_TMA_CP_SIZE = OUTPUT_SIZE < 64 ? OUTPUT_SIZE : 64;
+  constexpr int OUTPUT_ATOM_REPEAT_COL = 1;
+
+  constexpr int SMEM_M_SIZE = 16;
+  using TMA_B =
+      kernel::tma::tma_2d<bfloat16,
+                          B,
+                          M,
+                          S,
+                          BATCH_SIZE,                      /*GMEM_ROW_*/
+                          REDUCTION_SIZE,                  /*GMEM_COL_*/
+                          BATCH_SIZE,                      /*SMEM_ROW_*/
+                          TMA_CP_ASYNC_SIZE,               /*SMEM_COL_*/
+                          REDUCTION_SIZE,                  /*GMEM_STRIDE_ROW_*/
+                          1,                               /*GMEM_STRIDE_COL_*/
+                          1,                               /*SMEM_REPEAT_ROW_*/
+                          TMA_CP_ASYNC_REPEAT_COL,         /*SMEM_REPEAT_COL_*/
+                          SMEM_M_SIZE * TMA_CP_ASYNC_SIZE, /*SMEM_STRIDE_*/
+                          true>;
+  using TMA_A =
+      kernel::tma::tma_2d<bfloat16,
+                          B,
+                          M,
+                          S,
+                          OUTPUT_SIZE,             /*GMEM_ROW_*/
+                          REDUCTION_SIZE,          /*GMEM_COL_*/
+                          OUTPUT_ATOM_SIZE,        /*SMEM_ROW_*/
+                          TMA_CP_ASYNC_SIZE,       /*SMEM_COL_*/
+                          REDUCTION_SIZE,          /*GMEM_STRIDE_ROW_*/
+                          1,                       /*GMEM_STRIDE_COL_*/
+                          1,                       /*SMEM_REPEAT_ROW_*/
+                          TMA_CP_ASYNC_REPEAT_COL, /*SMEM_REPEAT_COL_*/
+                          OUTPUT_ATOM_SIZE * TMA_CP_ASYNC_SIZE, /*SMEM_STRIDE_*/
+                          true>;
+  using TMA_RESIDUAL = kernel::tma::tma_2d<bfloat16,
+                                           0,
+                                           0,
+                                           0,
                                            BATCH_SIZE,
                                            OUTPUT_SIZE,
-                                           REDUCTION_SIZE,
-                                           TMA_A,
-                                           TMA_B,
-                                           TMA_RESIDUAL,
-                                           TMA_OUT>
-           <<<grid_dim, block_dim, smem_size>>>(
-               tma_a, tma_b, tma_residual, tma_out);
-     } else {
-       linear_kernel_swapAB_no_residual_hopper_wrapper<T,
-                                                       BATCH_SIZE,
-                                                       OUTPUT_SIZE,
-                                                       REDUCTION_SIZE,
-                                                       TMA_A,
-                                                       TMA_B,
-                                                       TMA_OUT>
-           <<<grid_dim, block_dim, smem_size>>>(tma_a, tma_b, tma_out);
-     }
-   }
-   cudaDeviceSynchronize(); // Wait for all warmup runs to complete
- 
-   printf("Running %d benchmark iterations...\n", BENCHMARK_RUNS);
- 
-   float *iteration_times = new float[BENCHMARK_RUNS];
-   float total_time_ms = 0.0f;
- 
-   for (int i = 0; i < BENCHMARK_RUNS; i++) {
-     cudaEventRecord(start);
-     if (residual_ptr != nullptr) {
-       linear_kernel_swapAB_hopper_wrapper<T,
+                                           BATCH_SIZE,
+                                           OUTPUT_TMA_CP_SIZE,
+                                           OUTPUT_SIZE,
+                                           1,
+                                           1,
+                                           OUTPUT_ATOM_REPEAT_COL,
+                                           SMEM_M_SIZE * OUTPUT_TMA_CP_SIZE,
+                                           true>;
+
+  using TMA_OUT = kernel::tma::tma_2d<bfloat16,
+                                      B,
+                                      M,
+                                      S,
+                                      BATCH_SIZE,
+                                      OUTPUT_SIZE,
+                                      BATCH_SIZE,
+                                      OUTPUT_TMA_CP_SIZE,
+                                      OUTPUT_SIZE,
+                                      1,
+                                      1,
+                                      OUTPUT_ATOM_REPEAT_COL,
+                                      SMEM_M_SIZE * TMA_CP_ASYNC_SIZE,
+                                      true>;
+  TMA_A tma_a(weight_ptr);
+  TMA_B tma_b(input_ptr);
+  TMA_RESIDUAL tma_residual(residual_ptr);
+  TMA_OUT tma_out(output_ptr);
+
+  dim3 grid_dim(1, 1, 1);
+  dim3 block_dim(256, 1, 1);
+  size_t smem_size = 224 * 1024;
+
+  if (residual_ptr != nullptr) {
+    cudaFuncSetAttribute(linear_kernel_swapAB_hopper_wrapper<T,
+                                                             BATCH_SIZE,
+                                                             OUTPUT_SIZE,
+                                                             REDUCTION_SIZE,
+                                                             TMA_A,
+                                                             TMA_B,
+                                                             TMA_RESIDUAL,
+                                                             TMA_OUT>,
+                         cudaFuncAttributeMaxDynamicSharedMemorySize,
+                         smem_size);
+
+  } else {
+
+    cudaFuncSetAttribute(
+        linear_kernel_swapAB_no_residual_hopper_wrapper<T,
+                                                        BATCH_SIZE,
+                                                        OUTPUT_SIZE,
+                                                        REDUCTION_SIZE,
+                                                        TMA_A,
+                                                        TMA_B,
+                                                        TMA_OUT>,
+        cudaFuncAttributeMaxDynamicSharedMemorySize,
+        smem_size);
+  }
+
+#ifndef MIRAGE_PROFILE_HOPPER
+  if (residual_ptr != nullptr) {
+
+    linear_kernel_swapAB_hopper_wrapper<T,
+                                        BATCH_SIZE,
+                                        OUTPUT_SIZE,
+                                        REDUCTION_SIZE,
+                                        TMA_A,
+                                        TMA_B,
+                                        TMA_RESIDUAL,
+                                        TMA_OUT>
+        <<<grid_dim, block_dim, smem_size>>>(
+            tma_a, tma_b, tma_residual, tma_out);
+  } else {
+
+    linear_kernel_swapAB_no_residual_hopper_wrapper<T,
+                                                    BATCH_SIZE,
+                                                    OUTPUT_SIZE,
+                                                    REDUCTION_SIZE,
+                                                    TMA_A,
+                                                    TMA_B,
+                                                    TMA_OUT>
+        <<<grid_dim, block_dim, smem_size>>>(tma_a, tma_b, tma_out);
+  }
+#else
+
+  cudaEvent_t start, stop;
+  cudaEventCreate(&start);
+  cudaEventCreate(&stop);
+
+  constexpr int WARMUP_RUNS = 16;
+  constexpr int BENCHMARK_RUNS = 1000;
+
+  printf("=== Kernel Performance Profiling ===\n");
+
+  for (int i = 0; i < WARMUP_RUNS; i++) {
+    if (residual_ptr != nullptr) {
+      linear_kernel_swapAB_hopper_wrapper<T,
+                                          BATCH_SIZE,
+                                          OUTPUT_SIZE,
+                                          REDUCTION_SIZE,
+                                          TMA_A,
+                                          TMA_B,
+                                          TMA_RESIDUAL,
+                                          TMA_OUT>
+          <<<grid_dim, block_dim, smem_size>>>(
+              tma_a, tma_b, tma_residual, tma_out);
+    } else {
+      linear_kernel_swapAB_no_residual_hopper_wrapper<T,
+                                                      BATCH_SIZE,
+                                                      OUTPUT_SIZE,
+                                                      REDUCTION_SIZE,
+                                                      TMA_A,
+                                                      TMA_B,
+                                                      TMA_OUT>
+          <<<grid_dim, block_dim, smem_size>>>(tma_a, tma_b, tma_out);
+    }
+  }
+  cudaDeviceSynchronize(); // Wait for all warmup runs to complete
+
+  printf("Running %d benchmark iterations...\n", BENCHMARK_RUNS);
+
+  float *iteration_times = new float[BENCHMARK_RUNS];
+  float total_time_ms = 0.0f;
+
+  for (int i = 0; i < BENCHMARK_RUNS; i++) {
+    cudaEventRecord(start);
+    if (residual_ptr != nullptr) {
+      linear_kernel_swapAB_hopper_wrapper<T,
+                                          BATCH_SIZE,
+                                          OUTPUT_SIZE,
+                                          REDUCTION_SIZE,
+                                          TMA_A,
+                                          TMA_B,
+                                          TMA_RESIDUAL,
+                                          TMA_OUT>
+          <<<grid_dim, block_dim, smem_size>>>(
+              tma_a, tma_b, tma_residual, tma_out);
+    } else {
+      linear_kernel_swapAB_no_residual_hopper_wrapper<T,
+                                                      BATCH_SIZE,
+                                                      OUTPUT_SIZE,
+                                                      REDUCTION_SIZE,
+                                                      TMA_A,
+                                                      TMA_B,
+                                                      TMA_OUT>
+          <<<grid_dim, block_dim, smem_size>>>(tma_a, tma_b, tma_out);
+    }
+    cudaEventRecord(stop);
+    cudaEventSynchronize(stop);
+
+    float iteration_time_ms;
+    cudaEventElapsedTime(&iteration_time_ms, start, stop);
+
+    total_time_ms += iteration_time_ms;
+  }
+
+  float avg_time_ms = total_time_ms / BENCHMARK_RUNS;
+
+  printf("\n=== Performance Results ===\n");
+  printf("Configuration:\n");
+  printf("  BATCH_SIZE=%d, OUTPUT_SIZE=%d, REDUCTION_SIZE=%d\n",
+         BATCH_SIZE,
+         OUTPUT_SIZE,
+         REDUCTION_SIZE);
+  printf(" TILE SIZE: %d\n", TILE_SIZE);
+  printf("  Average: %.3f ms\n", avg_time_ms);
+
+  printf("===============================\n");
+
+  delete[] iteration_times;
+  cudaEventDestroy(start);
+  cudaEventDestroy(stop);
+#endif
+}
+
+#define DISPATCH_LINEAR_SWAPAB_REDUCTION_SIZE_CASE(                            \
+    BATCH_SIZE, OUTPUT_SIZE, REDUCTION_SIZE)                                   \
+  case REDUCTION_SIZE:                                                         \
+    launch_linear_swapAB<bfloat16, BATCH_SIZE, OUTPUT_SIZE, REDUCTION_SIZE>(   \
+        input_ptr, weight_ptr, residual_ptr, output_ptr);                      \
+    break;
+
+#define DISPATCH_LINEAR_SWAPAB_REDUCTION_SIZE(BATCH_SIZE, OUTPUT_SIZE)         \
+  switch (input.size(1)) {                                                     \
+    /*                                                                         \
+    DISPATCH_LINEAR_SWAPAB_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, 64)    \
+    DISPATCH_LINEAR_SWAPAB_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, 128)   \
+    DISPATCH_LINEAR_SWAPAB_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, 256)   \
+    DISPATCH_LINEAR_SWAPAB_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, 512)   \
+    DISPATCH_LINEAR_SWAPAB_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, 3072)  \
+    */                                                                         \
+    DISPATCH_LINEAR_SWAPAB_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, 12288) \
+    DISPATCH_LINEAR_SWAPAB_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, 4096)  \
+    default:                                                                   \
+      printf("Unsupported reduction size in test: %zu\n", input.size(1));      \
+      break;                                                                   \
+  }
+
+#define DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE)       \
+  case OUTPUT_SIZE:                                                            \
+    DISPATCH_LINEAR_SWAPAB_REDUCTION_SIZE(BATCH_SIZE, OUTPUT_SIZE)             \
+    break;
+
+#define DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE(BATCH_SIZE)                         \
+  switch (output.size(1)) {                                                    \
+    DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE_CASE(BATCH_SIZE, 48)                    \
+    DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE_CASE(BATCH_SIZE, 64)                    \
+    DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE_CASE(BATCH_SIZE, 128)                   \
+    DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE_CASE(BATCH_SIZE, 256)                   \
+    DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE_CASE(BATCH_SIZE, 2048)                  \
+    /*                                                                         \
+    DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE_CASE(BATCH_SIZE, 192)                   \
+    DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE_CASE(BATCH_SIZE, 16)                    \
+    DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE_CASE(BATCH_SIZE, 1600)                  \
+    DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE_CASE(BATCH_SIZE, 32)                    \
+    DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE_CASE(BATCH_SIZE, 512)                   \
+    DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE_CASE(BATCH_SIZE, 1024)                  \
+    */                                                                         \
+    default:                                                                   \
+      printf("Unsupported output size in test: %zu\n", output.size(1));        \
+      break;                                                                   \
+  }
+
+#define DISPATCH_LINEAR_SWAPAB_BATCH_SIZE_CASE(BATCH_SIZE)                     \
+  case BATCH_SIZE:                                                             \
+    DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE(BATCH_SIZE)                             \
+    break;
+
+void linear_swapAB_kernel(torch::Tensor input,
+                          torch::Tensor weight,
+                          c10::optional<at::Tensor> residual,
+                          torch::Tensor output) {
+
+  void *input_ptr = input.data_ptr();
+  void *weight_ptr = weight.data_ptr();
+  bool has_residual = residual.has_value();
+  void *residual_ptr = has_residual ? residual->data_ptr() : nullptr;
+  void *output_ptr = output.data_ptr();
+
+  switch (input.size(0)) {
+    DISPATCH_LINEAR_SWAPAB_BATCH_SIZE_CASE(8)
+    DISPATCH_LINEAR_SWAPAB_BATCH_SIZE_CASE(16)
+    default:
+      printf("Unsupported batch size in test: %zu\n", output.size(0));
+      break;
+  }
+
+  cudaError_t err = cudaDeviceSynchronize();
+  if (err != cudaSuccess) {
+    printf("CUDA kernel launch error: %s\n", cudaGetErrorString(err));
+  }
+}
+
+template <typename T,
+          int BATCH_SIZE,
+          int OUTPUT_SIZE,
+          int REDUCTION_SIZE,
+          typename TMA_A,
+          typename TMA_B,
+          typename TMA_RESIDUAL,
+          typename TMA_OUT,
+          int Kstages = 3>
+__global__ __launch_bounds__(256, 1) void linear_kernel_hopper_wrapper(
+    const __grid_constant__ TMA_A tma_a,
+    const __grid_constant__ TMA_B tma_b,
+    const __grid_constant__ TMA_RESIDUAL tma_residual,
+    const __grid_constant__ TMA_OUT tma_out) {
+
+  linear_kernel_hopper<T,
+                       BATCH_SIZE,
+                       OUTPUT_SIZE,
+                       REDUCTION_SIZE,
+                       Kstages,
+                       TMA_A,
+                       TMA_B,
+                       TMA_OUT>(tma_a, tma_b, tma_out, &tma_residual);
+}
+
+template <typename T,
+          int BATCH_SIZE,
+          int OUTPUT_SIZE,
+          int REDUCTION_SIZE,
+          typename TMA_A,
+          typename TMA_B,
+          typename TMA_OUT,
+          int Kstages = 3>
+__global__
+    __launch_bounds__(256, 1) void linear_kernel_hopper_no_residual_wrapper(
+        const __grid_constant__ TMA_A tma_a,
+        const __grid_constant__ TMA_B tma_b,
+        const __grid_constant__ TMA_OUT tma_out) {
+
+  linear_kernel_hopper<T,
+                       BATCH_SIZE,
+                       OUTPUT_SIZE,
+                       REDUCTION_SIZE,
+                       Kstages,
+                       TMA_A,
+                       TMA_B,
+                       TMA_OUT,
+                       void>(tma_a, tma_b, tma_out, nullptr);
+}
+
+template <typename T, int BATCH_SIZE, int OUTPUT_SIZE, int REDUCTION_SIZE>
+void launch_linear_hopper(void *input_ptr,
+                          void *weight_ptr,
+                          void *residual_ptr,
+                          void *output_ptr) {
+
+  constexpr int B = 3;
+  constexpr int M = 3;
+  constexpr int S = 3;
+
+  constexpr int TMA_CP_ASYNC_SIZE =
+      64; // note that if swizzle 128 is used, 64 is maximal cp size
+  constexpr int TILE_SIZE =
+      128; // we should modify this param if we want larger tile size
+  constexpr int TMA_CP_ASYNC_REPEAT_COL =
+      (TILE_SIZE + TMA_CP_ASYNC_SIZE - 1) / TMA_CP_ASYNC_SIZE;
+
+  constexpr int OUTPUT_ATOM_SIZE = (OUTPUT_SIZE >= 256)   ? 256
+                                   : (OUTPUT_SIZE >= 128) ? 128
+                                   : (OUTPUT_SIZE >= 64)  ? 64
+                                   : (OUTPUT_SIZE >= 32)  ? 32
+                                                          : 16;
+  constexpr int OUTPUT_ATOM_REPEAT_COL =
+      (OUTPUT_ATOM_SIZE + TMA_CP_ASYNC_SIZE - 1) / TMA_CP_ASYNC_SIZE;
+
+  constexpr int OUTPUT_TMA_CP_SIZE = OUTPUT_SIZE < 64 ? OUTPUT_SIZE : 64;
+  constexpr int SMEM_M_SIZE = BATCH_SIZE;
+  using TMA_A =
+      kernel::tma::tma_2d<bfloat16,
+                          B,
+                          M,
+                          S,
+                          BATCH_SIZE,        /*GMEM_ROW_*/
+                          REDUCTION_SIZE,    /*GMEM_COL_*/
+                          BATCH_SIZE,        /*SMEM_ROW_*/
+                          TMA_CP_ASYNC_SIZE, /*SMEM_COL_*/
+                          REDUCTION_SIZE,
+                          /*GMEM_STRIDE_ROW_*/ 1,
+                          /*GMEM_STRIDE_COL_*/ 1,          /*SMEM_REPEAT_ROW_*/
+                          TMA_CP_ASYNC_REPEAT_COL,         /*SMEM_REPEAT_COL_*/
+                          SMEM_M_SIZE * TMA_CP_ASYNC_SIZE, /*SMEM_STRIDE_*/
+                          true>;
+  using TMA_B =
+      kernel::tma::tma_2d<bfloat16,
+                          B,
+                          M,
+                          S,
+                          OUTPUT_SIZE,             /*GMEM_ROW_*/
+                          REDUCTION_SIZE,          /*GMEM_COL_*/
+                          OUTPUT_ATOM_SIZE,        /*SMEM_ROW_*/
+                          TMA_CP_ASYNC_SIZE,       /*SMEM_COL_*/
+                          REDUCTION_SIZE,          /*GMEM_STRIDE_ROW_*/
+                          1,                       /*GMEM_STRIDE_COL_*/
+                          1,                       /*SMEM_REPEAT_ROW_*/
+                          TMA_CP_ASYNC_REPEAT_COL, /*SMEM_REPEAT_COL_*/
+                          OUTPUT_ATOM_SIZE * TMA_CP_ASYNC_SIZE,
+                          /*SMEM_STRIDE_*/ true>;
+  using TMA_RESIDUAL = kernel::tma::tma_2d<bfloat16,
+                                           B,
+                                           M,
+                                           S,
                                            BATCH_SIZE,
                                            OUTPUT_SIZE,
-                                           REDUCTION_SIZE,
-                                           TMA_A,
-                                           TMA_B,
-                                           TMA_RESIDUAL,
-                                           TMA_OUT>
-           <<<grid_dim, block_dim, smem_size>>>(
-               tma_a, tma_b, tma_residual, tma_out);
-     } else {
-       linear_kernel_swapAB_no_residual_hopper_wrapper<T,
-                                                       BATCH_SIZE,
-                                                       OUTPUT_SIZE,
-                                                       REDUCTION_SIZE,
-                                                       TMA_A,
-                                                       TMA_B,
-                                                       TMA_OUT>
-           <<<grid_dim, block_dim, smem_size>>>(tma_a, tma_b, tma_out);
-     }
-     cudaEventRecord(stop);
-     cudaEventSynchronize(stop);
- 
-     float iteration_time_ms;
-     cudaEventElapsedTime(&iteration_time_ms, start, stop);
- 
-     total_time_ms += iteration_time_ms;
-   }
- 
-   float avg_time_ms = total_time_ms / BENCHMARK_RUNS;
- 
-   printf("\n=== Performance Results ===\n");
-   printf("Configuration:\n");
-   printf("  BATCH_SIZE=%d, OUTPUT_SIZE=%d, REDUCTION_SIZE=%d\n",
-          BATCH_SIZE,
-          OUTPUT_SIZE,
-          REDUCTION_SIZE);
-   printf(" TILE SIZE: %d\n", TILE_SIZE);
-   printf("  Average: %.3f ms\n", avg_time_ms);
- 
-   printf("===============================\n");
- 
-   delete[] iteration_times;
-   cudaEventDestroy(start);
-   cudaEventDestroy(stop);
- #endif
- }
- 
- #define DISPATCH_LINEAR_SWAPAB_REDUCTION_SIZE_CASE(                            \
-     BATCH_SIZE, OUTPUT_SIZE, REDUCTION_SIZE)                                   \
-   case REDUCTION_SIZE:                                                         \
-     launch_linear_swapAB<bfloat16, BATCH_SIZE, OUTPUT_SIZE, REDUCTION_SIZE>(   \
-         input_ptr, weight_ptr, residual_ptr, output_ptr);                      \
-     break;
- 
- #define DISPATCH_LINEAR_SWAPAB_REDUCTION_SIZE(BATCH_SIZE, OUTPUT_SIZE)         \
-   switch (input.size(1)) {                                                     \
-     /*                                                                         \
-     DISPATCH_LINEAR_SWAPAB_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, 64)    \
-     DISPATCH_LINEAR_SWAPAB_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, 128)   \
-     DISPATCH_LINEAR_SWAPAB_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, 256)   \
-     DISPATCH_LINEAR_SWAPAB_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, 512)   \
-     DISPATCH_LINEAR_SWAPAB_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, 3072)  \
-     */                                                                         \
-     DISPATCH_LINEAR_SWAPAB_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, 12288) \
-     DISPATCH_LINEAR_SWAPAB_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, 4096)  \
-     default:                                                                   \
-       printf("Unsupported reduction size in test: %zu\n", input.size(1));      \
-       break;                                                                   \
-   }
- 
- #define DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE)       \
-   case OUTPUT_SIZE:                                                            \
-     DISPATCH_LINEAR_SWAPAB_REDUCTION_SIZE(BATCH_SIZE, OUTPUT_SIZE)             \
-     break;
- 
- #define DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE(BATCH_SIZE)                         \
-   switch (output.size(1)) {                                                    \
-     DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE_CASE(BATCH_SIZE, 48)                    \
-     DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE_CASE(BATCH_SIZE, 64)                    \
-     DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE_CASE(BATCH_SIZE, 128)                   \
-     DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE_CASE(BATCH_SIZE, 256)                   \
-     DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE_CASE(BATCH_SIZE, 2048)                  \
-     /*                                                                         \
-     DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE_CASE(BATCH_SIZE, 192)                   \
-     DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE_CASE(BATCH_SIZE, 16)                    \
-     DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE_CASE(BATCH_SIZE, 1600)                  \
-     DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE_CASE(BATCH_SIZE, 32)                    \
-     DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE_CASE(BATCH_SIZE, 512)                   \
-     DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE_CASE(BATCH_SIZE, 1024)                  \
-     */                                                                         \
-     default:                                                                   \
-       printf("Unsupported output size in test: %zu\n", output.size(1));        \
-       break;                                                                   \
-   }
- 
- #define DISPATCH_LINEAR_SWAPAB_BATCH_SIZE_CASE(BATCH_SIZE)                     \
-   case BATCH_SIZE:                                                             \
-     DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE(BATCH_SIZE)                             \
-     break;
- 
- void linear_swapAB_kernel(torch::Tensor input,
-                           torch::Tensor weight,
-                           c10::optional<at::Tensor> residual,
-                           torch::Tensor output) {
- 
-   void *input_ptr = input.data_ptr();
-   void *weight_ptr = weight.data_ptr();
-   bool has_residual = residual.has_value();
-   void *residual_ptr = has_residual ? residual->data_ptr() : nullptr;
-   void *output_ptr = output.data_ptr();
- 
-   switch (input.size(0)) {
-     DISPATCH_LINEAR_SWAPAB_BATCH_SIZE_CASE(8)
-     DISPATCH_LINEAR_SWAPAB_BATCH_SIZE_CASE(16)
-     default:
-       printf("Unsupported batch size in test: %zu\n", output.size(0));
-       break;
-   }
- 
-   cudaError_t err = cudaDeviceSynchronize();
-   if (err != cudaSuccess) {
-     printf("CUDA kernel launch error: %s\n", cudaGetErrorString(err));
-   }
- }
- 
- template <typename T,
-           int BATCH_SIZE,
-           int OUTPUT_SIZE,
-           int REDUCTION_SIZE,
-           typename TMA_A,
-           typename TMA_B,
-           typename TMA_RESIDUAL,
-           typename TMA_OUT,
-           int Kstages = 3>
- __global__ __launch_bounds__(256, 1) void linear_kernel_hopper_wrapper(
-     const __grid_constant__ TMA_A tma_a,
-     const __grid_constant__ TMA_B tma_b,
-     const __grid_constant__ TMA_RESIDUAL tma_residual,
-     const __grid_constant__ TMA_OUT tma_out) {
- 
-   linear_kernel_hopper<T,
-                        BATCH_SIZE,
-                        OUTPUT_SIZE,
-                        REDUCTION_SIZE,
-                        Kstages,
-                        TMA_A,
-                        TMA_B,
-                        TMA_OUT>(tma_a, tma_b, tma_out, &tma_residual);
- }
- 
- template <typename T,
-           int BATCH_SIZE,
-           int OUTPUT_SIZE,
-           int REDUCTION_SIZE,
-           typename TMA_A,
-           typename TMA_B,
-           typename TMA_OUT,
-           int Kstages = 3>
- __global__
-     __launch_bounds__(256, 1) void linear_kernel_hopper_no_residual_wrapper(
-         const __grid_constant__ TMA_A tma_a,
-         const __grid_constant__ TMA_B tma_b,
-         const __grid_constant__ TMA_OUT tma_out) {
- 
-   linear_kernel_hopper<T,
-                        BATCH_SIZE,
-                        OUTPUT_SIZE,
-                        REDUCTION_SIZE,
-                        Kstages,
-                        TMA_A,
-                        TMA_B,
-                        TMA_OUT,
-                        void>(tma_a, tma_b, tma_out, nullptr);
- }
- 
- template <typename T, int BATCH_SIZE, int OUTPUT_SIZE, int REDUCTION_SIZE>
- void launch_linear_hopper(void *input_ptr,
-                           void *weight_ptr,
-                           void *residual_ptr,
-                           void *output_ptr) {
- 
-   constexpr int B = 3;
-   constexpr int M = 3;
-   constexpr int S = 3;
- 
-   constexpr int TMA_CP_ASYNC_SIZE =
-       64; // note that if swizzle 128 is used, 64 is maximal cp size
-   constexpr int TILE_SIZE =
-       128; // we should modify this param if we want larger tile size
-   constexpr int TMA_CP_ASYNC_REPEAT_COL =
-       (TILE_SIZE + TMA_CP_ASYNC_SIZE - 1) / TMA_CP_ASYNC_SIZE;
- 
-   constexpr int OUTPUT_ATOM_SIZE = (OUTPUT_SIZE >= 256)   ? 256
-                                    : (OUTPUT_SIZE >= 128) ? 128
-                                    : (OUTPUT_SIZE >= 64)  ? 64
-                                    : (OUTPUT_SIZE >= 32)  ? 32
-                                                           : 16;
-   constexpr int OUTPUT_ATOM_REPEAT_COL =
-       (OUTPUT_ATOM_SIZE + TMA_CP_ASYNC_SIZE - 1) / TMA_CP_ASYNC_SIZE;
- 
-   constexpr int OUTPUT_TMA_CP_SIZE = OUTPUT_SIZE < 64 ? OUTPUT_SIZE : 64;
-   constexpr int SMEM_M_SIZE = BATCH_SIZE;
-   using TMA_A =
-       kernel::tma::tma_2d<bfloat16,
-                           B,
-                           M,
-                           S,
-                           BATCH_SIZE,                      /*GMEM_ROW_*/
-                           REDUCTION_SIZE,                  /*GMEM_COL_*/
-                           BATCH_SIZE,                      /*SMEM_ROW_*/
-                           TMA_CP_ASYNC_SIZE,               /*SMEM_COL_*/
-                           REDUCTION_SIZE, /*GMEM_STRIDE_ROW_*/ 1,
-                           /*GMEM_STRIDE_COL_*/ 1, /*SMEM_REPEAT_ROW_*/
-                           TMA_CP_ASYNC_REPEAT_COL, /*SMEM_REPEAT_COL_*/
-                           SMEM_M_SIZE * TMA_CP_ASYNC_SIZE, /*SMEM_STRIDE_*/
-                           true>;
-   using TMA_B =
-       kernel::tma::tma_2d<bfloat16,
-                           B,
-                           M,
-                           S,
-                           OUTPUT_SIZE,             /*GMEM_ROW_*/
-                           REDUCTION_SIZE,          /*GMEM_COL_*/
-                           OUTPUT_ATOM_SIZE,        /*SMEM_ROW_*/
-                           TMA_CP_ASYNC_SIZE,       /*SMEM_COL_*/
-                           REDUCTION_SIZE,          /*GMEM_STRIDE_ROW_*/
-                           1,                       /*GMEM_STRIDE_COL_*/
-                           1,                       /*SMEM_REPEAT_ROW_*/
-                           TMA_CP_ASYNC_REPEAT_COL, /*SMEM_REPEAT_COL_*/
-                           OUTPUT_ATOM_SIZE * TMA_CP_ASYNC_SIZE,
-                           /*SMEM_STRIDE_*/ true>;
-   using TMA_RESIDUAL = kernel::tma::tma_2d<bfloat16,
-                                            B,
-                                            M,
-                                            S,
-                                            BATCH_SIZE,
-                                            OUTPUT_SIZE,
-                                            BATCH_SIZE,
-                                            OUTPUT_TMA_CP_SIZE,
-                                            OUTPUT_SIZE,
-                                            1,
-                                            1,
-                                            OUTPUT_ATOM_REPEAT_COL,
-                                            SMEM_M_SIZE * TMA_CP_ASYNC_SIZE,
-                                            true>;
- 
-   using TMA_OUT = kernel::tma::tma_2d<bfloat16,
-                                       B,
-                                       M,
-                                       S,
-                                       BATCH_SIZE,
-                                       OUTPUT_SIZE,
-                                       BATCH_SIZE,
-                                       OUTPUT_TMA_CP_SIZE,
-                                       OUTPUT_SIZE,
-                                       1,
-                                       1,
-                                       OUTPUT_ATOM_REPEAT_COL,
-                                       SMEM_M_SIZE * TMA_CP_ASYNC_SIZE,
-                                       true>;
-   TMA_A tma_a(input_ptr);
-   TMA_B tma_b(weight_ptr);
-   TMA_RESIDUAL tma_residual(residual_ptr);
-   TMA_OUT tma_out(output_ptr);
- 
-   dim3 grid_dim(1, 1, 1);
-   dim3 block_dim(256, 1, 1);
-   size_t smem_size = 224 * 1024;
- 
-   if (residual_ptr != nullptr) {
-     cudaFuncSetAttribute(linear_kernel_hopper_wrapper<T,
-                                                       BATCH_SIZE,
-                                                       OUTPUT_SIZE,
-                                                       REDUCTION_SIZE,
-                                                       TMA_A,
-                                                       TMA_B,
-                                                       TMA_RESIDUAL,
-                                                       TMA_OUT>,
-                          cudaFuncAttributeMaxDynamicSharedMemorySize,
-                          smem_size);
- 
-   } else {
- 
-     cudaFuncSetAttribute(
-         linear_kernel_hopper_no_residual_wrapper<T,
-                                                  BATCH_SIZE,
-                                                  OUTPUT_SIZE,
-                                                  REDUCTION_SIZE,
-                                                  TMA_A,
-                                                  TMA_B,
-                                                  TMA_OUT>,
-         cudaFuncAttributeMaxDynamicSharedMemorySize,
-         smem_size);
-   }
- 
- #ifndef MIRAGE_PROFILE_HOPPER
-   if (residual_ptr != nullptr) {
- 
-     linear_kernel_hopper_wrapper<T,
-                                  BATCH_SIZE,
-                                  OUTPUT_SIZE,
-                                  REDUCTION_SIZE,
-                                  TMA_A,
-                                  TMA_B,
-                                  TMA_RESIDUAL,
-                                  TMA_OUT><<<grid_dim, block_dim,
-                                  smem_size>>>(
-         tma_a, tma_b, tma_residual, tma_out);
-   } else {
- 
-     linear_kernel_hopper_no_residual_wrapper<T,
-                                              BATCH_SIZE,
-                                              OUTPUT_SIZE,
-                                              REDUCTION_SIZE,
-                                              TMA_A,
-                                              TMA_B,
-                                              TMA_OUT>
-         <<<grid_dim, block_dim, smem_size>>>(tma_a, tma_b, tma_out);
-   }
- #else
- 
-   cudaEvent_t start, stop;
-   cudaEventCreate(&start);
-   cudaEventCreate(&stop);
- 
-   constexpr int WARMUP_RUNS = 16;
-   constexpr int BENCHMARK_RUNS = 1000;
- 
-   printf("=== Kernel Performance Profiling ===\n");
- 
-   for (int i = 0; i < WARMUP_RUNS; i++) {
-     if (residual_ptr != nullptr) {
-       linear_kernel_hopper_wrapper<T,
-                                    BATCH_SIZE,
-                                    OUTPUT_SIZE,
-                                    REDUCTION_SIZE,
-                                    TMA_A,
-                                    TMA_B,
-                                    TMA_RESIDUAL,
-                                    TMA_OUT><<<grid_dim, block_dim,
-                                    smem_size>>>(
-           tma_a, tma_b, tma_residual, tma_out);
-     } else {
-       linear_kernel_hopper_no_residual_wrapper<T,
-                                                BATCH_SIZE,
-                                                OUTPUT_SIZE,
-                                                REDUCTION_SIZE,
-                                                TMA_A,
-                                                TMA_B,
-                                                TMA_OUT>
-           <<<grid_dim, block_dim, smem_size>>>(tma_a, tma_b, tma_out);
-     }
-   }
-   cudaDeviceSynchronize(); // Wait for all warmup runs to complete
- 
-   printf("Running %d benchmark iterations...\n", BENCHMARK_RUNS);
- 
-   float *iteration_times = new float[BENCHMARK_RUNS];
-   float total_time_ms = 0.0f;
- 
-   for (int i = 0; i < BENCHMARK_RUNS; i++) {
-     cudaEventRecord(start);
-     if (residual_ptr != nullptr) {
-       linear_kernel_hopper_wrapper<T,
-                                    BATCH_SIZE,
-                                    OUTPUT_SIZE,
-                                    REDUCTION_SIZE,
-                                    TMA_A,
-                                    TMA_B,
-                                    TMA_RESIDUAL,
-                                    TMA_OUT><<<grid_dim, block_dim,
-                                    smem_size>>>(
-           tma_a, tma_b, tma_residual, tma_out);
-     } else {
-       linear_kernel_hopper_no_residual_wrapper<T,
-                                                BATCH_SIZE,
-                                                OUTPUT_SIZE,
-                                                REDUCTION_SIZE,
-                                                TMA_A,
-                                                TMA_B,
-                                                TMA_OUT>
-           <<<grid_dim, block_dim, smem_size>>>(tma_a, tma_b, tma_out);
-     }
-     cudaEventRecord(stop);
-     cudaEventSynchronize(stop);
- 
-     float iteration_time_ms;
-     cudaEventElapsedTime(&iteration_time_ms, start, stop);
- 
-     total_time_ms += iteration_time_ms;
-   }
- 
-   float avg_time_ms = total_time_ms / BENCHMARK_RUNS;
- 
-   printf("\n=== Performance Results ===\n");
-   printf("Configuration:\n");
-   printf("  BATCH_SIZE=%d, OUTPUT_SIZE=%d, REDUCTION_SIZE=%d\n",
-          BATCH_SIZE,
-          OUTPUT_SIZE,
-          REDUCTION_SIZE);
-   printf(" TILE SIZE: %d\n", TILE_SIZE);
-   printf("  Average: %.3f ms\n", avg_time_ms);
- 
-   printf("===============================\n");
- 
-   delete[] iteration_times;
-   cudaEventDestroy(start);
-   cudaEventDestroy(stop);
- #endif
- }
- 
- #define DISPATCH_LINEAR_HOPPER_REDUCTION_SIZE_CASE(                            \
-     BATCH_SIZE, OUTPUT_SIZE, REDUCTION_SIZE)                                   \
-   case REDUCTION_SIZE:                                                         \
-     launch_linear_hopper<bfloat16, BATCH_SIZE, OUTPUT_SIZE, REDUCTION_SIZE>(   \
-         input_ptr, weight_ptr, residual_ptr, output_ptr);                      \
-     break;
- 
- #define DISPATCH_LINEAR_HOPPER_REDUCTION_SIZE(BATCH_SIZE, OUTPUT_SIZE)         \
-   switch (input.size(1)) {                                                     \
-     /*                                                                         \
-     DISPATCH_LINEAR_HOPPER_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, 64)    \
-     DISPATCH_LINEAR_HOPPER_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, 128)   \
-     DISPATCH_LINEAR_HOPPER_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, 256)   \
-     DISPATCH_LINEAR_HOPPER_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, 512)   \
-     DISPATCH_LINEAR_HOPPER_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, 3072)  \
-     */                                                                             \
-     DISPATCH_LINEAR_HOPPER_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, 4096)  \
-     DISPATCH_LINEAR_HOPPER_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, 12288) \
-     default:                                                                   \
-       printf("Unsupported reduction size in test: %zu\n", input.size(1));      \
-       break;                                                                   \
-   }
- 
- #define DISPATCH_LINEAR_HOPPER_OUTPUT_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE)       \
-   case OUTPUT_SIZE:                                                            \
-     DISPATCH_LINEAR_HOPPER_REDUCTION_SIZE(BATCH_SIZE, OUTPUT_SIZE)             \
-     break;
- 
- #define DISPATCH_LINEAR_HOPPER_OUTPUT_SIZE(BATCH_SIZE)                         \
-   switch (output.size(1)) {                                                    \
-     DISPATCH_LINEAR_HOPPER_OUTPUT_SIZE_CASE(BATCH_SIZE, 64)                    \
-     DISPATCH_LINEAR_HOPPER_OUTPUT_SIZE_CASE(BATCH_SIZE, 128)                   \
-     DISPATCH_LINEAR_HOPPER_OUTPUT_SIZE_CASE(BATCH_SIZE, 256)                   \
-     /*                                                                         \
-     DISPATCH_LINEAR_HOPPER_OUTPUT_SIZE_CASE(BATCH_SIZE, 1600)                  \
-     DISPATCH_LINEAR_HOPPER_OUTPUT_SIZE_CASE(BATCH_SIZE, 32)                    \
-     DISPATCH_LINEAR_HOPPER_OUTPUT_SIZE_CASE(BATCH_SIZE, 512)                   \
-     DISPATCH_LINEAR_HOPPER_OUTPUT_SIZE_CASE(BATCH_SIZE, 1024)                  \
-     DISPATCH_LINEAR_HOPPER_OUTPUT_SIZE_CASE(BATCH_SIZE, 2048)                  \
-     */                                                                         \
-     default:                                                                   \
-       printf("Unsupported output size in test: %zu\n", output.size(1));        \
-       break;                                                                   \
-   }
- 
- #define DISPATCH_LINEAR_HOPPER_BATCH_SIZE_CASE(BATCH_SIZE)                     \
-   case BATCH_SIZE:                                                             \
-     DISPATCH_LINEAR_HOPPER_OUTPUT_SIZE(BATCH_SIZE)                             \
-     break;
- 
- void linear_kernel(torch::Tensor input,
-                    torch::Tensor weight,
-                    c10::optional<at::Tensor> residual,
-                    torch::Tensor output) {
- 
-   void *input_ptr = input.data_ptr();
-   void *weight_ptr = weight.data_ptr();
-   bool has_residual = residual.has_value();
-   void *residual_ptr = has_residual ? residual->data_ptr() : nullptr;
-   void *output_ptr = output.data_ptr();
- 
-   switch (input.size(0)) {
-     DISPATCH_LINEAR_HOPPER_BATCH_SIZE_CASE(8)
-     /* \
-     DISPATCH_LINEAR_HOPPER_BATCH_SIZE_CASE(1)
-     DISPATCH_LINEAR_HOPPER_BATCH_SIZE_CASE(64)
-     */
-     default:
-       printf("Unsupported batch size in test: %zu\n", output.size(0));
-       break;
-   }
- 
-   cudaError_t err = cudaDeviceSynchronize();
-   if (err != cudaSuccess) {
-     printf("CUDA kernel launch error: %s\n", cudaGetErrorString(err));
-   }
- }
- 
- // norm linear
- // template <typename T,
- //           int BATCH_SIZE,
- //           int OUTPUT_SIZE,
- //           int REDUCTION_SIZE,
- //           typename TMA_INPUT,
- //           typename TMA_NORM_WEIGHT,
- //           typename TMA_LINEAR_WEIGHT,
- //           typename TMA_OUT,
- //           int Kstages = 2>
- // __global__ __launch_bounds__(256, 1) void norm_linear_kernel_hopper_wrapper(
- //     const __grid_constant__ TMA_INPUT tma_input,
- //     const __grid_constant__ TMA_NORM_WEIGHT tma_norm_weight,
- //     const __grid_constant__ TMA_LINEAR_WEIGHT tma_linear_weight,
- //     const __grid_constant__ TMA_OUT tma_out,
- //     float eps) {
- //   norm_linear_kernel_hopper<T,
- //                             BATCH_SIZE,
- //                             OUTPUT_SIZE,
- //                             REDUCTION_SIZE,
- //                             Kstages,
- //                             TMA_INPUT,
- //                             TMA_NORM_WEIGHT,
- //                             TMA_LINEAR_WEIGHT,
- //                             TMA_OUT>(
- //       tma_input, tma_norm_weight, tma_linear_weight, tma_out, eps);
- // }
- 
- // template <typename T, int BATCH_SIZE, int OUTPUT_SIZE, int REDUCTION_SIZE>
- // void launch_norm_linear_hopper(void *input_ptr,
- //                                void *norm_weight_ptr,
- //                                void *weight_ptr,
- //                                void *output_ptr,
- //                                float eps) {
- 
- //   constexpr int B = 3;
- //   constexpr int M = 3;
- //   constexpr int S = 3;
- 
- //   constexpr int TILE_SIZE = 64;
- 
- //   using TMA_INPUT = kernel::tma::tma_2d<bfloat16,
- //                                         B,
- //                                         M,
- //                                         S,
- //                                         BATCH_SIZE,
- //                                         REDUCTION_SIZE,
- //                                         BATCH_SIZE,
- //                                         TILE_SIZE>;
- //   using TMA_NORM_WEIGHT = kernel::tma::tma_2d<bfloat16,
- //                                               B,
- //                                               M,
- //                                               S,
- //                                               BATCH_SIZE,
- //                                               REDUCTION_SIZE,
- //                                               BATCH_SIZE,
- //                                               TILE_SIZE>;
- //   using TMA_LINEAR_WEIGHT = kernel::tma::tma_2d<bfloat16,
- //                                                 B,
- //                                                 M,
- //                                                 S,
- //                                                 OUTPUT_SIZE,
- //                                                 REDUCTION_SIZE,
- //                                                 OUTPUT_SIZE,
- //                                                 TILE_SIZE>;
- 
- //   using TMA_OUT = kernel::tma::tma_2d<bfloat16,
- //                                       0,
- //                                       0,
- //                                       0,
- //                                       BATCH_SIZE,
- //                                       OUTPUT_SIZE,
- //                                       BATCH_SIZE,
- //                                       OUTPUT_SIZE>;
- 
- //   TMA_INPUT tma_input(input_ptr);
- //   TMA_NORM_WEIGHT tma_norm_weight(norm_weight_ptr);
- //   TMA_LINEAR_WEIGHT tma_linear_weight(weight_ptr);
- //   TMA_OUT tma_out(output_ptr);
- 
- //   dim3 grid_dim(1, 1, 1);
- //   dim3 block_dim(256, 1, 1);
- //   size_t smem_size = 88888;
- //   cudaFuncSetAttribute(norm_linear_kernel_hopper_wrapper<T,
- //                                                          BATCH_SIZE,
- //                                                          OUTPUT_SIZE,
- //                                                          REDUCTION_SIZE,
- //                                                          TMA_INPUT,
- //                                                          TMA_NORM_WEIGHT,
- //                                                          TMA_LINEAR_WEIGHT,
- //                                                          TMA_OUT>,
- //                        cudaFuncAttributeMaxDynamicSharedMemorySize,
- //                        smem_size);
- 
- //   norm_linear_kernel_hopper_wrapper<T,
- //                                     BATCH_SIZE,
- //                                     OUTPUT_SIZE,
- //                                     REDUCTION_SIZE,
- //                                     TMA_INPUT,
- //                                     TMA_NORM_WEIGHT,
- //                                     TMA_LINEAR_WEIGHT,
- //                                     TMA_OUT>
- //       <<<grid_dim, block_dim, smem_size>>>(
- //           tma_input, tma_norm_weight, tma_linear_weight, tma_out, eps);
- // }
- 
- // #define DISPATCH_NORM_LINEAR_HOPPER_REDUCTION_SIZE_CASE(                       \
+                                           BATCH_SIZE,
+                                           OUTPUT_TMA_CP_SIZE,
+                                           OUTPUT_SIZE,
+                                           1,
+                                           1,
+                                           OUTPUT_ATOM_REPEAT_COL,
+                                           SMEM_M_SIZE * TMA_CP_ASYNC_SIZE,
+                                           true>;
+
+  using TMA_OUT = kernel::tma::tma_2d<bfloat16,
+                                      B,
+                                      M,
+                                      S,
+                                      BATCH_SIZE,
+                                      OUTPUT_SIZE,
+                                      BATCH_SIZE,
+                                      OUTPUT_TMA_CP_SIZE,
+                                      OUTPUT_SIZE,
+                                      1,
+                                      1,
+                                      OUTPUT_ATOM_REPEAT_COL,
+                                      SMEM_M_SIZE * TMA_CP_ASYNC_SIZE,
+                                      true>;
+  TMA_A tma_a(input_ptr);
+  TMA_B tma_b(weight_ptr);
+  TMA_RESIDUAL tma_residual(residual_ptr);
+  TMA_OUT tma_out(output_ptr);
+
+  dim3 grid_dim(1, 1, 1);
+  dim3 block_dim(256, 1, 1);
+  size_t smem_size = 224 * 1024;
+
+  if (residual_ptr != nullptr) {
+    cudaFuncSetAttribute(linear_kernel_hopper_wrapper<T,
+                                                      BATCH_SIZE,
+                                                      OUTPUT_SIZE,
+                                                      REDUCTION_SIZE,
+                                                      TMA_A,
+                                                      TMA_B,
+                                                      TMA_RESIDUAL,
+                                                      TMA_OUT>,
+                         cudaFuncAttributeMaxDynamicSharedMemorySize,
+                         smem_size);
+
+  } else {
+
+    cudaFuncSetAttribute(
+        linear_kernel_hopper_no_residual_wrapper<T,
+                                                 BATCH_SIZE,
+                                                 OUTPUT_SIZE,
+                                                 REDUCTION_SIZE,
+                                                 TMA_A,
+                                                 TMA_B,
+                                                 TMA_OUT>,
+        cudaFuncAttributeMaxDynamicSharedMemorySize,
+        smem_size);
+  }
+
+#ifndef MIRAGE_PROFILE_HOPPER
+  if (residual_ptr != nullptr) {
+
+    linear_kernel_hopper_wrapper<T,
+                                 BATCH_SIZE,
+                                 OUTPUT_SIZE,
+                                 REDUCTION_SIZE,
+                                 TMA_A,
+                                 TMA_B,
+                                 TMA_RESIDUAL,
+                                 TMA_OUT><<<grid_dim, block_dim, smem_size>>>(
+        tma_a, tma_b, tma_residual, tma_out);
+  } else {
+
+    linear_kernel_hopper_no_residual_wrapper<T,
+                                             BATCH_SIZE,
+                                             OUTPUT_SIZE,
+                                             REDUCTION_SIZE,
+                                             TMA_A,
+                                             TMA_B,
+                                             TMA_OUT>
+        <<<grid_dim, block_dim, smem_size>>>(tma_a, tma_b, tma_out);
+  }
+#else
+
+  cudaEvent_t start, stop;
+  cudaEventCreate(&start);
+  cudaEventCreate(&stop);
+
+  constexpr int WARMUP_RUNS = 16;
+  constexpr int BENCHMARK_RUNS = 1000;
+
+  printf("=== Kernel Performance Profiling ===\n");
+
+  for (int i = 0; i < WARMUP_RUNS; i++) {
+    if (residual_ptr != nullptr) {
+      linear_kernel_hopper_wrapper<T,
+                                   BATCH_SIZE,
+                                   OUTPUT_SIZE,
+                                   REDUCTION_SIZE,
+                                   TMA_A,
+                                   TMA_B,
+                                   TMA_RESIDUAL,
+                                   TMA_OUT><<<grid_dim, block_dim, smem_size>>>(
+          tma_a, tma_b, tma_residual, tma_out);
+    } else {
+      linear_kernel_hopper_no_residual_wrapper<T,
+                                               BATCH_SIZE,
+                                               OUTPUT_SIZE,
+                                               REDUCTION_SIZE,
+                                               TMA_A,
+                                               TMA_B,
+                                               TMA_OUT>
+          <<<grid_dim, block_dim, smem_size>>>(tma_a, tma_b, tma_out);
+    }
+  }
+  cudaDeviceSynchronize(); // Wait for all warmup runs to complete
+
+  printf("Running %d benchmark iterations...\n", BENCHMARK_RUNS);
+
+  float *iteration_times = new float[BENCHMARK_RUNS];
+  float total_time_ms = 0.0f;
+
+  for (int i = 0; i < BENCHMARK_RUNS; i++) {
+    cudaEventRecord(start);
+    if (residual_ptr != nullptr) {
+      linear_kernel_hopper_wrapper<T,
+                                   BATCH_SIZE,
+                                   OUTPUT_SIZE,
+                                   REDUCTION_SIZE,
+                                   TMA_A,
+                                   TMA_B,
+                                   TMA_RESIDUAL,
+                                   TMA_OUT><<<grid_dim, block_dim, smem_size>>>(
+          tma_a, tma_b, tma_residual, tma_out);
+    } else {
+      linear_kernel_hopper_no_residual_wrapper<T,
+                                               BATCH_SIZE,
+                                               OUTPUT_SIZE,
+                                               REDUCTION_SIZE,
+                                               TMA_A,
+                                               TMA_B,
+                                               TMA_OUT>
+          <<<grid_dim, block_dim, smem_size>>>(tma_a, tma_b, tma_out);
+    }
+    cudaEventRecord(stop);
+    cudaEventSynchronize(stop);
+
+    float iteration_time_ms;
+    cudaEventElapsedTime(&iteration_time_ms, start, stop);
+
+    total_time_ms += iteration_time_ms;
+  }
+
+  float avg_time_ms = total_time_ms / BENCHMARK_RUNS;
+
+  printf("\n=== Performance Results ===\n");
+  printf("Configuration:\n");
+  printf("  BATCH_SIZE=%d, OUTPUT_SIZE=%d, REDUCTION_SIZE=%d\n",
+         BATCH_SIZE,
+         OUTPUT_SIZE,
+         REDUCTION_SIZE);
+  printf(" TILE SIZE: %d\n", TILE_SIZE);
+  printf("  Average: %.3f ms\n", avg_time_ms);
+
+  printf("===============================\n");
+
+  delete[] iteration_times;
+  cudaEventDestroy(start);
+  cudaEventDestroy(stop);
+#endif
+}
+
+#define DISPATCH_LINEAR_HOPPER_REDUCTION_SIZE_CASE(                            \
+    BATCH_SIZE, OUTPUT_SIZE, REDUCTION_SIZE)                                   \
+  case REDUCTION_SIZE:                                                         \
+    launch_linear_hopper<bfloat16, BATCH_SIZE, OUTPUT_SIZE, REDUCTION_SIZE>(   \
+        input_ptr, weight_ptr, residual_ptr, output_ptr);                      \
+    break;
+
+#define DISPATCH_LINEAR_HOPPER_REDUCTION_SIZE(BATCH_SIZE, OUTPUT_SIZE)         \
+  switch (input.size(1)) {                                                     \
+    /*                                                                         \
+    DISPATCH_LINEAR_HOPPER_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, 64)    \
+    DISPATCH_LINEAR_HOPPER_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, 128)   \
+    DISPATCH_LINEAR_HOPPER_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, 256)   \
+    DISPATCH_LINEAR_HOPPER_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, 512)   \
+    DISPATCH_LINEAR_HOPPER_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, 3072)  \
+    */                                                                         \
+    DISPATCH_LINEAR_HOPPER_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, 4096)  \
+    DISPATCH_LINEAR_HOPPER_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, 12288) \
+    default:                                                                   \
+      printf("Unsupported reduction size in test: %zu\n", input.size(1));      \
+      break;                                                                   \
+  }
+
+#define DISPATCH_LINEAR_HOPPER_OUTPUT_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE)       \
+  case OUTPUT_SIZE:                                                            \
+    DISPATCH_LINEAR_HOPPER_REDUCTION_SIZE(BATCH_SIZE, OUTPUT_SIZE)             \
+    break;
+
+#define DISPATCH_LINEAR_HOPPER_OUTPUT_SIZE(BATCH_SIZE)                         \
+  switch (output.size(1)) {                                                    \
+    DISPATCH_LINEAR_HOPPER_OUTPUT_SIZE_CASE(BATCH_SIZE, 64)                    \
+    DISPATCH_LINEAR_HOPPER_OUTPUT_SIZE_CASE(BATCH_SIZE, 128)                   \
+    DISPATCH_LINEAR_HOPPER_OUTPUT_SIZE_CASE(BATCH_SIZE, 256)                   \
+    /*                                                                         \
+    DISPATCH_LINEAR_HOPPER_OUTPUT_SIZE_CASE(BATCH_SIZE, 1600)                  \
+    DISPATCH_LINEAR_HOPPER_OUTPUT_SIZE_CASE(BATCH_SIZE, 32)                    \
+    DISPATCH_LINEAR_HOPPER_OUTPUT_SIZE_CASE(BATCH_SIZE, 512)                   \
+    DISPATCH_LINEAR_HOPPER_OUTPUT_SIZE_CASE(BATCH_SIZE, 1024)                  \
+    DISPATCH_LINEAR_HOPPER_OUTPUT_SIZE_CASE(BATCH_SIZE, 2048)                  \
+    */                                                                         \
+    default:                                                                   \
+      printf("Unsupported output size in test: %zu\n", output.size(1));        \
+      break;                                                                   \
+  }
+
+#define DISPATCH_LINEAR_HOPPER_BATCH_SIZE_CASE(BATCH_SIZE)                     \
+  case BATCH_SIZE:                                                             \
+    DISPATCH_LINEAR_HOPPER_OUTPUT_SIZE(BATCH_SIZE)                             \
+    break;
+
+void linear_kernel(torch::Tensor input,
+                   torch::Tensor weight,
+                   c10::optional<at::Tensor> residual,
+                   torch::Tensor output) {
+
+  void *input_ptr = input.data_ptr();
+  void *weight_ptr = weight.data_ptr();
+  bool has_residual = residual.has_value();
+  void *residual_ptr = has_residual ? residual->data_ptr() : nullptr;
+  void *output_ptr = output.data_ptr();
+
+  switch (input.size(0)) {
+    DISPATCH_LINEAR_HOPPER_BATCH_SIZE_CASE(8)
+    /* \
+    DISPATCH_LINEAR_HOPPER_BATCH_SIZE_CASE(1)
+    DISPATCH_LINEAR_HOPPER_BATCH_SIZE_CASE(64)
+    */
+    default:
+      printf("Unsupported batch size in test: %zu\n", output.size(0));
+      break;
+  }
+
+  cudaError_t err = cudaDeviceSynchronize();
+  if (err != cudaSuccess) {
+    printf("CUDA kernel launch error: %s\n", cudaGetErrorString(err));
+  }
+}
+
+// norm linear
+// template <typename T,
+//           int BATCH_SIZE,
+//           int OUTPUT_SIZE,
+//           int REDUCTION_SIZE,
+//           typename TMA_INPUT,
+//           typename TMA_NORM_WEIGHT,
+//           typename TMA_LINEAR_WEIGHT,
+//           typename TMA_OUT,
+//           int Kstages = 2>
+// __global__ __launch_bounds__(256, 1) void norm_linear_kernel_hopper_wrapper(
+//     const __grid_constant__ TMA_INPUT tma_input,
+//     const __grid_constant__ TMA_NORM_WEIGHT tma_norm_weight,
+//     const __grid_constant__ TMA_LINEAR_WEIGHT tma_linear_weight,
+//     const __grid_constant__ TMA_OUT tma_out,
+//     float eps) {
+//   norm_linear_kernel_hopper<T,
+//                             BATCH_SIZE,
+//                             OUTPUT_SIZE,
+//                             REDUCTION_SIZE,
+//                             Kstages,
+//                             TMA_INPUT,
+//                             TMA_NORM_WEIGHT,
+//                             TMA_LINEAR_WEIGHT,
+//                             TMA_OUT>(
+//       tma_input, tma_norm_weight, tma_linear_weight, tma_out, eps);
+// }
+
+// template <typename T, int BATCH_SIZE, int OUTPUT_SIZE, int REDUCTION_SIZE>
+// void launch_norm_linear_hopper(void *input_ptr,
+//                                void *norm_weight_ptr,
+//                                void *weight_ptr,
+//                                void *output_ptr,
+//                                float eps) {
+
+//   constexpr int B = 3;
+//   constexpr int M = 3;
+//   constexpr int S = 3;
+
+//   constexpr int TILE_SIZE = 64;
+
+//   using TMA_INPUT = kernel::tma::tma_2d<bfloat16,
+//                                         B,
+//                                         M,
+//                                         S,
+//                                         BATCH_SIZE,
+//                                         REDUCTION_SIZE,
+//                                         BATCH_SIZE,
+//                                         TILE_SIZE>;
+//   using TMA_NORM_WEIGHT = kernel::tma::tma_2d<bfloat16,
+//                                               B,
+//                                               M,
+//                                               S,
+//                                               BATCH_SIZE,
+//                                               REDUCTION_SIZE,
+//                                               BATCH_SIZE,
+//                                               TILE_SIZE>;
+//   using TMA_LINEAR_WEIGHT = kernel::tma::tma_2d<bfloat16,
+//                                                 B,
+//                                                 M,
+//                                                 S,
+//                                                 OUTPUT_SIZE,
+//                                                 REDUCTION_SIZE,
+//                                                 OUTPUT_SIZE,
+//                                                 TILE_SIZE>;
+
+//   using TMA_OUT = kernel::tma::tma_2d<bfloat16,
+//                                       0,
+//                                       0,
+//                                       0,
+//                                       BATCH_SIZE,
+//                                       OUTPUT_SIZE,
+//                                       BATCH_SIZE,
+//                                       OUTPUT_SIZE>;
+
+//   TMA_INPUT tma_input(input_ptr);
+//   TMA_NORM_WEIGHT tma_norm_weight(norm_weight_ptr);
+//   TMA_LINEAR_WEIGHT tma_linear_weight(weight_ptr);
+//   TMA_OUT tma_out(output_ptr);
+
+//   dim3 grid_dim(1, 1, 1);
+//   dim3 block_dim(256, 1, 1);
+//   size_t smem_size = 88888;
+//   cudaFuncSetAttribute(norm_linear_kernel_hopper_wrapper<T,
+//                                                          BATCH_SIZE,
+//                                                          OUTPUT_SIZE,
+//                                                          REDUCTION_SIZE,
+//                                                          TMA_INPUT,
+//                                                          TMA_NORM_WEIGHT,
+//                                                          TMA_LINEAR_WEIGHT,
+//                                                          TMA_OUT>,
+//                        cudaFuncAttributeMaxDynamicSharedMemorySize,
+//                        smem_size);
+
+//   norm_linear_kernel_hopper_wrapper<T,
+//                                     BATCH_SIZE,
+//                                     OUTPUT_SIZE,
+//                                     REDUCTION_SIZE,
+//                                     TMA_INPUT,
+//                                     TMA_NORM_WEIGHT,
+//                                     TMA_LINEAR_WEIGHT,
+//                                     TMA_OUT>
+//       <<<grid_dim, block_dim, smem_size>>>(
+//           tma_input, tma_norm_weight, tma_linear_weight, tma_out, eps);
+// }
+
+// #define DISPATCH_NORM_LINEAR_HOPPER_REDUCTION_SIZE_CASE(                       \
   //     BATCH_SIZE, OUTPUT_SIZE, REDUCTION_SIZE)                                   \
   //   case REDUCTION_SIZE:                                                         \
   //     launch_norm_linear_hopper<bfloat16,                                        \
@@ -865,8 +863,8 @@
   //                               REDUCTION_SIZE>(                                 \
   //         input_ptr, norm_weight_ptr, weight_ptr, output_ptr, eps);              \
   //     break;
- 
- // #define DISPATCH_NORM_LINEAR_HOPPER_REDUCTION_SIZE(BATCH_SIZE, OUTPUT_SIZE)    \
+
+// #define DISPATCH_NORM_LINEAR_HOPPER_REDUCTION_SIZE(BATCH_SIZE, OUTPUT_SIZE)    \
   //   switch (input.size(1)) {                                                     \
   //     /*DISPATCH_NORM_LINEAR_HOPPER_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, \
   //     128) DISPATCH_NORM_LINEAR_HOPPER_REDUCTION_SIZE_CASE(BATCH_SIZE,           \
@@ -880,13 +878,13 @@
   //       printf("Unsupported reduction size in test: %zu\n", input.size(1));      \
   //       break;                                                                   \
   //   }
- 
- // #define DISPATCH_NORM_LINEAR_HOPPER_OUTPUT_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE)  \
+
+// #define DISPATCH_NORM_LINEAR_HOPPER_OUTPUT_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE)  \
   //   case OUTPUT_SIZE:                                                            \
   //     DISPATCH_NORM_LINEAR_HOPPER_REDUCTION_SIZE(BATCH_SIZE, OUTPUT_SIZE)        \
   //     break;
- 
- // #define DISPATCH_NORM_LINEAR_HOPPER_OUTPUT_SIZE(BATCH_SIZE)                    \
+
+// #define DISPATCH_NORM_LINEAR_HOPPER_OUTPUT_SIZE(BATCH_SIZE)                    \
   //   switch (output.size(1)) {                                                    \
   //     DISPATCH_NORM_LINEAR_HOPPER_OUTPUT_SIZE_CASE(BATCH_SIZE, 16)               \
   //     DISPATCH_NORM_LINEAR_HOPPER_OUTPUT_SIZE_CASE(BATCH_SIZE, 32)               \
@@ -895,505 +893,505 @@
   //       printf("Unsupported output size in test: %zu\n", output.size(1));        \
   //       break;                                                                   \
   //   }
- 
- // #define DISPATCH_NORM_LINEAR_HOPPER_BATCH_SIZE_CASE(BATCH_SIZE)                \
+
+// #define DISPATCH_NORM_LINEAR_HOPPER_BATCH_SIZE_CASE(BATCH_SIZE)                \
   //   case BATCH_SIZE:                                                             \
   //     DISPATCH_NORM_LINEAR_HOPPER_OUTPUT_SIZE(BATCH_SIZE)                        \
   //     break;
- 
- // void norm_linear_kernel(torch::Tensor input,
- //                         torch::Tensor norm_weight,
- //                         torch::Tensor weight,
- //                         torch::Tensor output,
- //                         float eps) {
- 
- //   void *input_ptr = input.data_ptr();
- //   void *norm_weight_ptr = norm_weight.data_ptr();
- //   void *weight_ptr = weight.data_ptr();
- //   void *output_ptr = output.data_ptr();
- 
- //   switch (input.size(0)) {
- //     // DISPATCH_NORM_LINEAR_HOPPER_BATCH_SIZE_CASE(64)
- //     default:
- //       printf("Unsupported output size in test: %zu\n", output.size(0));
- //       break;
- //   }
- 
- //   cudaError_t err = cudaDeviceSynchronize();
- //   if (err != cudaSuccess) {
- //     printf("CUDA kernel launch error: %s\n", cudaGetErrorString(err));
- //   }
- // }
- 
- // Multitoken Paged Attention
- // template <typename T,
- //           int NUM_QO_HEADS,
- //           int NUM_KV_HEADS,
- //           int KV_CACHE_STRIDE,
- //           int QKV_STRIDE,
- //           int O_STRIDE,
- //           int HEAD_DIM,
- //           int MAX_SEQ_LEN,
- //           int PAGE_SIZE,
- //           typename TMA_Q,
- //           typename TMA_KV,
- //           typename TMA_PAGED_KV,
- //           typename TMA_OUTPUT,
- //           int MAX_TOKENS = 8>
- // __global__ void multitoken_paged_attention_wrapper_hopper(
- //     const __grid_constant__ TMA_Q tma_q,
- //     const __grid_constant__ TMA_KV tma_k,
- //     const __grid_constant__ TMA_KV tma_v,
- //     const __grid_constant__ TMA_PAGED_KV tma_paged_k_cache,
- //     const __grid_constant__ TMA_PAGED_KV tma_paged_v_cache,
- //     const __grid_constant__ TMA_OUTPUT tma_output,
- //     void *paged_k_cache_ptr,
- //     void *paged_v_cache_ptr,
- //     int const *qo_indptr_buffer_ptr,
- //     int const *paged_kv_indptr_buffer_ptr,
- //     int const *paged_kv_indices_buffer_ptr,
- //     int const *paged_kv_last_page_len_buffer_ptr,
- //     int request_id,
- //     bool qk_norm,
- //     bool rope,
- //     void const *q_norm_weight_ptr,
- //     void const *k_norm_weight_ptr,
- //     void const *cos_ptr,
- //     void const *sin_ptr,
- //     float q_eps,
- //     float k_eps,
- //     void *output_ptr,
- //     void *qkv_ptr) {
- 
- //   multitoken_paged_attention_hopper_impl<T,
- //                                          NUM_QO_HEADS,
- //                                          NUM_KV_HEADS,
- //                                          KV_CACHE_STRIDE,
- //                                          QKV_STRIDE,
- //                                          O_STRIDE,
- //                                          HEAD_DIM,
- //                                          MAX_SEQ_LEN,
- //                                          PAGE_SIZE,
- //                                          TMA_Q,
- //                                          TMA_KV,
- //                                          TMA_PAGED_KV,
- //                                          TMA_OUTPUT,
- //                                          MAX_TOKENS>(
- //       tma_q,
- //       tma_k,
- //       tma_v,
- //       tma_paged_k_cache,
- //       tma_paged_v_cache,
- //       tma_output,
- //       paged_k_cache_ptr,
- //       paged_v_cache_ptr,
- //       qo_indptr_buffer_ptr,
- //       paged_kv_indptr_buffer_ptr,
- //       paged_kv_indices_buffer_ptr,
- //       paged_kv_last_page_len_buffer_ptr,
- //       request_id,
- //       qk_norm,
- //       rope,
- //       q_norm_weight_ptr,
- //       k_norm_weight_ptr,
- //       cos_ptr,
- //       sin_ptr,
- //       q_eps,
- //       k_eps,
- //       output_ptr,
- //       qkv_ptr);
- // }
- 
- // template <typename T,
- //           int NUM_QO_HEADS,
- //           int NUM_KV_HEADS,
- //           int KV_CACHE_STRIDE,
- //           int QKV_STRIDE,
- //           int O_STRIDE,
- //           int HEAD_DIM,
- //           int MAX_SEQ_LEN,
- //           int PAGE_SIZE,
- //           int MAX_TOKENS = 8>
- // void launch_multitoken_paged_attention_hopper(
- //     void *qkv_ptr,
- //     void *paged_k_cache_ptr,
- //     void *paged_v_cache_ptr,
- //     void *output_ptr,
- //     int const *qo_indptr_buffer_ptr,
- //     int const *paged_kv_indptr_buffer_ptr,
- //     int const *paged_kv_indices_buffer_ptr,
- //     int const *paged_kv_last_page_len_buffer_ptr,
- //     int request_id,
- //     bool qk_norm,
- //     bool rope,
- //     void const *q_norm_weight_ptr,
- //     void const *k_norm_weight_ptr,
- //     void const *cos_ptr,
- //     void const *sin_ptr,
- //     float q_eps,
- //     float k_eps) {
- //   dim3 grid_dim(1, 1, 1);
- //   dim3 block_dim(256, 1, 1);
- //   size_t smem_size = 224 * 1024;
- 
- //   constexpr int B = 3;
- //   constexpr int M = 3;
- //   constexpr int S = 3;
- //   constexpr int TMA_CP_SIZE = 64;
- //   constexpr int KV_TILE_SIZE = 64;
- //   constexpr int prompt_len = 8;
- //   constexpr int num_tokens = 8;
- 
- //   constexpr int NUM_PAGES = 100;
- //   constexpr int TAIL_PAGE_SIZE = prompt_len % PAGE_SIZE;
- 
- //   using TMA_Q =
- //       kernel::tma::tma_3d<bfloat16,
- //                           B,
- //                           M,
- //                           S,
- //                           num_tokens,
- //                           (NUM_QO_HEADS + 2 * NUM_KV_HEADS),
- //                           HEAD_DIM,
- //                           num_tokens,
- //                           NUM_QO_HEADS,
- //                           TMA_CP_SIZE,
- //                           (NUM_QO_HEADS + 2 * NUM_KV_HEADS) * HEAD_DIM,
- //                           HEAD_DIM,
- //                           1,
- //                           1,
- //                           (HEAD_DIM + TMA_CP_SIZE - 1) / TMA_CP_SIZE,
- //                           num_tokens * NUM_QO_HEADS * TMA_CP_SIZE,
- //                           true>;
- 
- //   using TMA_KV =
- //       kernel::tma::tma_3d<bfloat16,
- //                           B,
- //                           M,
- //                           S,
- //                           num_tokens,
- //                           (NUM_QO_HEADS + 2 * NUM_KV_HEADS),
- //                           HEAD_DIM,
- //                           num_tokens,
- //                           NUM_KV_HEADS,
- //                           TMA_CP_SIZE,
- //                           (NUM_QO_HEADS + 2 * NUM_KV_HEADS) * HEAD_DIM,
- //                           HEAD_DIM,
- //                           1,
- //                           1,
- //                           (HEAD_DIM + TMA_CP_SIZE - 1) / TMA_CP_SIZE,
- //                           num_tokens * NUM_KV_HEADS *
- //                               TMA_CP_SIZE, // skip number of rows between
- //                                            // current 64 cols and next 64
- //                                            cols
- //                           true>;
- 
- //   using TMA_PAGED_KV_CACHE =
- //       kernel::tma::tma_3d<bfloat16,
- //                           B,
- //                           M,
- //                           S,
- //                           NUM_PAGES,
- //                           PAGE_SIZE,
- //                           HEAD_DIM,
- //                           1,
- //                           KV_TILE_SIZE,
- //                           TMA_CP_SIZE,
- //                           PAGE_SIZE * HEAD_DIM,
- //                           HEAD_DIM,
- //                           1,
- //                           1,
- //                           (HEAD_DIM + TMA_CP_SIZE - 1) / TMA_CP_SIZE,
- //                           KV_TILE_SIZE * TMA_CP_SIZE,
- //                           true>;
- 
- //   using TMA_OUTPUT =
- //       kernel::tma::tma_2d<bfloat16,
- //                           3,
- //                           3,
- //                           3,
- //                           num_tokens * NUM_QO_HEADS,
- //                           HEAD_DIM,
- //                           num_tokens * NUM_QO_HEADS,
- //                           TMA_CP_SIZE,
- //                           HEAD_DIM,
- //                           1,
- //                           1,
- //                           (HEAD_DIM + TMA_CP_SIZE - 1) / TMA_CP_SIZE,
- //                           num_tokens * NUM_QO_HEADS * TMA_CP_SIZE,
- //                           true>;
- 
- //   // bfloat16 *__restrict__ qkv_ptr_bf16 = static_cast<bfloat16 *>(qkv_ptr);
- 
- //   TMA_Q tma_q(qkv_ptr);
- //   TMA_KV tma_k(qkv_ptr);
- //   TMA_KV tma_v(qkv_ptr);
- //   TMA_PAGED_KV_CACHE tma_paged_k_cache(paged_k_cache_ptr);
- //   TMA_PAGED_KV_CACHE tma_paged_v_cache(paged_v_cache_ptr);
- //   TMA_OUTPUT tma_output(output_ptr);
- 
- //   cudaFuncSetAttribute(
- //       multitoken_paged_attention_wrapper_hopper<T,
- //                                                 NUM_QO_HEADS,
- //                                                 NUM_KV_HEADS,
- //                                                 KV_CACHE_STRIDE,
- //                                                 QKV_STRIDE,
- //                                                 O_STRIDE,
- //                                                 HEAD_DIM,
- //                                                 MAX_SEQ_LEN,
- //                                                 PAGE_SIZE,
- //                                                 TMA_Q,
- //                                                 TMA_KV,
- //                                                 TMA_PAGED_KV_CACHE,
- //                                                 TMA_OUTPUT,
- //                                                 num_tokens>,
- //       cudaFuncAttributeMaxDynamicSharedMemorySize,
- //       smem_size);
- 
- // #ifndef MIRAGE_PROFILE_HOPPER
- //   multitoken_paged_attention_wrapper_hopper<T,
- //                                             NUM_QO_HEADS,
- //                                             NUM_KV_HEADS,
- //                                             KV_CACHE_STRIDE,
- //                                             QKV_STRIDE,
- //                                             O_STRIDE,
- //                                             HEAD_DIM,
- //                                             MAX_SEQ_LEN,
- //                                             PAGE_SIZE,
- //                                             TMA_Q,
- //                                             TMA_KV,
- //                                             TMA_PAGED_KV_CACHE,
- //                                             TMA_OUTPUT,
- //                                             num_tokens>
- //       <<<grid_dim, block_dim, smem_size>>>(tma_q,
- //                                            tma_k,
- //                                            tma_v,
- //                                            tma_paged_k_cache,
- //                                            tma_paged_v_cache,
- //                                            tma_output,
- //                                            paged_k_cache_ptr,
- //                                            paged_v_cache_ptr,
- //                                            qo_indptr_buffer_ptr,
- //                                            paged_kv_indptr_buffer_ptr,
- //                                            paged_kv_indices_buffer_ptr,
- //                                            paged_kv_last_page_len_buffer_ptr,
- //                                            request_id,
- //                                            qk_norm,
- //                                            rope,
- //                                            q_norm_weight_ptr,
- //                                            k_norm_weight_ptr,
- //                                            cos_ptr,
- //                                            sin_ptr,
- //                                            q_eps,
- //                                            k_eps,
- //                                            output_ptr,
- //                                            qkv_ptr);
- // #else
- 
- //   cudaEvent_t start, stop;
- //   cudaEventCreate(&start);
- //   cudaEventCreate(&stop);
- 
- //   constexpr int WARMUP_RUNS = 16;
- //   constexpr int BENCHMARK_RUNS = 1000;
- 
- //   printf("=== Multitoken Paged Attention Kernel Performance Profiling
- //   ===\n");
- 
- //   for (int i = 0; i < WARMUP_RUNS; i++) {
- //     multitoken_paged_attention_wrapper_hopper<T,
- //                                               NUM_QO_HEADS,
- //                                               NUM_KV_HEADS,
- //                                               KV_CACHE_STRIDE,
- //                                               QKV_STRIDE,
- //                                               O_STRIDE,
- //                                               HEAD_DIM,
- //                                               MAX_SEQ_LEN,
- //                                               PAGE_SIZE,
- //                                               TMA_Q,
- //                                               TMA_KV,
- //                                               TMA_PAGED_KV_CACHE,
- //                                               TMA_OUTPUT,
- //                                               num_tokens>
- //         <<<grid_dim, block_dim, smem_size>>>(tma_q,
- //                                              tma_k,
- //                                              tma_v,
- //                                              tma_paged_k_cache,
- //                                              tma_paged_v_cache,
- //                                              tma_output,
- //                                              paged_k_cache_ptr,
- //                                              paged_v_cache_ptr,
- //                                              qo_indptr_buffer_ptr,
- //                                              paged_kv_indptr_buffer_ptr,
- //                                              paged_kv_indices_buffer_ptr,
- //                                              paged_kv_last_page_len_buffer_ptr,
- //                                              request_id,
- //                                              qk_norm,
- //                                              rope,
- //                                              q_norm_weight_ptr,
- //                                              k_norm_weight_ptr,
- //                                              cos_ptr,
- //                                              sin_ptr,
- //                                              q_eps,
- //                                              k_eps);
- //   }
- //   cudaDeviceSynchronize();
- 
- //   printf("Running %d benchmark iterations...\n", BENCHMARK_RUNS);
- 
- //   float *iteration_times = new float[BENCHMARK_RUNS];
- //   float total_time_ms = 0.0f;
- 
- //   for (int i = 0; i < BENCHMARK_RUNS; i++) {
- //     cudaEventRecord(start);
- //     multitoken_paged_attention_wrapper_hopper<T,
- //                                               NUM_QO_HEADS,
- //                                               NUM_KV_HEADS,
- //                                               KV_CACHE_STRIDE,
- //                                               QKV_STRIDE,
- //                                               O_STRIDE,
- //                                               HEAD_DIM,
- //                                               MAX_SEQ_LEN,
- //                                               PAGE_SIZE,
- //                                               TMA_Q,
- //                                               TMA_KV,
- //                                               TMA_PAGED_KV_CACHE,
- //                                               TMA_OUTPUT,
- //                                               num_tokens>
- //         <<<grid_dim, block_dim, smem_size>>>(tma_q,
- //                                              tma_k,
- //                                              tma_v,
- //                                              tma_paged_k_cache,
- //                                              tma_paged_v_cache,
- //                                              tma_output,
- //                                              paged_k_cache_ptr,
- //                                              paged_v_cache_ptr,
- //                                              qo_indptr_buffer_ptr,
- //                                              paged_kv_indptr_buffer_ptr,
- //                                              paged_kv_indices_buffer_ptr,
- //                                              paged_kv_last_page_len_buffer_ptr,
- //                                              request_id,
- //                                              qk_norm,
- //                                              rope,
- //                                              q_norm_weight_ptr,
- //                                              k_norm_weight_ptr,
- //                                              cos_ptr,
- //                                              sin_ptr,
- //                                              q_eps,
- //                                              k_eps);
- //     cudaEventRecord(stop);
- //     cudaEventSynchronize(stop);
- 
- //     float iteration_time_ms;
- //     cudaEventElapsedTime(&iteration_time_ms, start, stop);
- 
- //     iteration_times[i] = iteration_time_ms;
- //     total_time_ms += iteration_time_ms;
- //   }
- 
- //   float avg_time_ms = total_time_ms / BENCHMARK_RUNS;
- 
- //   printf("\n=== Multitoken Paged Attention Performance Results ===\n");
- //   printf("Configuration:\n");
- //   printf("  NUM_QO_HEADS=%d, NUM_KV_HEADS=%d, HEAD_DIM=%d\n",
- //          NUM_QO_HEADS,
- //          NUM_KV_HEADS,
- //          HEAD_DIM);
- //   printf("  MAX_SEQ_LEN=%d, PAGE_SIZE=%d, MAX_TOKENS=%d\n",
- //          MAX_SEQ_LEN,
- //          PAGE_SIZE,
- //          MAX_TOKENS);
- //   printf("  Average: %.3f ms\n", avg_time_ms);
- 
- //   printf("===============================\n");
- 
- //   delete[] iteration_times;
- //   cudaEventDestroy(start);
- //   cudaEventDestroy(stop);
- // #endif
- // }
- 
- // void multitoken_paged_attention_hopper(
- //     torch::Tensor qkv,
- //     torch::Tensor paged_k_cache,
- //     torch::Tensor paged_v_cache,
- //     torch::Tensor output,
- //     torch::Tensor qo_indptr_buffer,
- //     torch::Tensor paged_kv_indptr_buffer,
- //     torch::Tensor paged_kv_indices_buffer,
- //     torch::Tensor paged_kv_last_page_len_buffer,
- //     int request_id,
- //     bool qk_norm,
- //     bool rope,
- //     torch::optional<torch::Tensor> q_norm_weight = torch::nullopt,
- //     torch::optional<torch::Tensor> k_norm_weight = torch::nullopt,
- //     torch::optional<torch::Tensor> cos = torch::nullopt,
- //     torch::optional<torch::Tensor> sin = torch::nullopt,
- //     float q_eps = 0.0f,
- //     float k_eps = 0.0f) {
- //   void *qkv_ptr = qkv.data_ptr();
- //   void *paged_k_cache_ptr = paged_k_cache.data_ptr();
- //   void *paged_v_cache_ptr = paged_v_cache.data_ptr();
- //   void *output_ptr = output.data_ptr();
- //   int const *qo_indptr_buffer_ptr = qo_indptr_buffer.data_ptr<int>();
- //   int const *paged_kv_indptr_buffer_ptr =
- //       paged_kv_indptr_buffer.data_ptr<int>();
- //   int const *paged_kv_indices_buffer_ptr =
- //       paged_kv_indices_buffer.data_ptr<int>();
- //   int const *paged_kv_last_page_len_buffer_ptr =
- //       paged_kv_last_page_len_buffer.data_ptr<int>();
- 
- //   void const *q_norm_weight_ptr = qk_norm ? q_norm_weight->data_ptr() :
- //   nullptr; void const *k_norm_weight_ptr = qk_norm ?
- //   k_norm_weight->data_ptr() : nullptr; void const *cos_ptr = rope ?
- //   cos->data_ptr() : nullptr; void const *sin_ptr = rope ? sin->data_ptr() :
- //   nullptr; int const qo_heads = 4; int const kv_heads = 1; int const head_dim
- //   = 128; int const qkv_stride = (qo_heads + 2 * kv_heads) * head_dim;
- //   assert(qkv_stride == qkv.stride(0));
- //   int const kv_stride = head_dim * kv_heads;
- //   assert(kv_stride == paged_k_cache.stride(1));
- //   int const o_stride = head_dim * qo_heads;
- //   int const page_size = 4096;
- //   int const max_seq_len = 512;
- 
- //   launch_multitoken_paged_attention_hopper<bfloat16,
- //                                            qo_heads,
- //                                            kv_heads,
- //                                            kv_stride,
- //                                            qkv_stride,
- //                                            o_stride,
- //                                            head_dim,
- //                                            max_seq_len,
- //                                            page_size>(
- //       qkv_ptr,
- //       paged_k_cache_ptr,
- //       paged_v_cache_ptr,
- //       output_ptr,
- //       qo_indptr_buffer_ptr,
- //       paged_kv_indptr_buffer_ptr,
- //       paged_kv_indices_buffer_ptr,
- //       paged_kv_last_page_len_buffer_ptr,
- //       request_id,
- //       qk_norm,
- //       rope,
- //       q_norm_weight_ptr,
- //       k_norm_weight_ptr,
- //       cos_ptr,
- //       sin_ptr,
- //       q_eps,
- //       k_eps);
- 
- //   cudaError_t err = cudaDeviceSynchronize();
- //   if (err != cudaSuccess) {
- //     printf("CUDA kernel launch error: %s\n", cudaGetErrorString(err));
- //   }
- // }
- 
- PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-    m.def("linear", &linear_kernel, "Linear kernel");
-   m.def("linear_swapAB", &linear_swapAB_kernel, "Linear swapAB kernel");
-   // m.def("norm_linear", &norm_linear_kernel, "NormLinear kernel");
-   // m.def("multitoken_paged_attention",
-   //       &multitoken_paged_attention_hopper,
-   //       "Multitoken paged attention for Grace Hopper GPU");
- }
+
+// void norm_linear_kernel(torch::Tensor input,
+//                         torch::Tensor norm_weight,
+//                         torch::Tensor weight,
+//                         torch::Tensor output,
+//                         float eps) {
+
+//   void *input_ptr = input.data_ptr();
+//   void *norm_weight_ptr = norm_weight.data_ptr();
+//   void *weight_ptr = weight.data_ptr();
+//   void *output_ptr = output.data_ptr();
+
+//   switch (input.size(0)) {
+//     // DISPATCH_NORM_LINEAR_HOPPER_BATCH_SIZE_CASE(64)
+//     default:
+//       printf("Unsupported output size in test: %zu\n", output.size(0));
+//       break;
+//   }
+
+//   cudaError_t err = cudaDeviceSynchronize();
+//   if (err != cudaSuccess) {
+//     printf("CUDA kernel launch error: %s\n", cudaGetErrorString(err));
+//   }
+// }
+
+// Multitoken Paged Attention
+// template <typename T,
+//           int NUM_QO_HEADS,
+//           int NUM_KV_HEADS,
+//           int KV_CACHE_STRIDE,
+//           int QKV_STRIDE,
+//           int O_STRIDE,
+//           int HEAD_DIM,
+//           int MAX_SEQ_LEN,
+//           int PAGE_SIZE,
+//           typename TMA_Q,
+//           typename TMA_KV,
+//           typename TMA_PAGED_KV,
+//           typename TMA_OUTPUT,
+//           int MAX_TOKENS = 8>
+// __global__ void multitoken_paged_attention_wrapper_hopper(
+//     const __grid_constant__ TMA_Q tma_q,
+//     const __grid_constant__ TMA_KV tma_k,
+//     const __grid_constant__ TMA_KV tma_v,
+//     const __grid_constant__ TMA_PAGED_KV tma_paged_k_cache,
+//     const __grid_constant__ TMA_PAGED_KV tma_paged_v_cache,
+//     const __grid_constant__ TMA_OUTPUT tma_output,
+//     void *paged_k_cache_ptr,
+//     void *paged_v_cache_ptr,
+//     int const *qo_indptr_buffer_ptr,
+//     int const *paged_kv_indptr_buffer_ptr,
+//     int const *paged_kv_indices_buffer_ptr,
+//     int const *paged_kv_last_page_len_buffer_ptr,
+//     int request_id,
+//     bool qk_norm,
+//     bool rope,
+//     void const *q_norm_weight_ptr,
+//     void const *k_norm_weight_ptr,
+//     void const *cos_ptr,
+//     void const *sin_ptr,
+//     float q_eps,
+//     float k_eps,
+//     void *output_ptr,
+//     void *qkv_ptr) {
+
+//   multitoken_paged_attention_hopper_impl<T,
+//                                          NUM_QO_HEADS,
+//                                          NUM_KV_HEADS,
+//                                          KV_CACHE_STRIDE,
+//                                          QKV_STRIDE,
+//                                          O_STRIDE,
+//                                          HEAD_DIM,
+//                                          MAX_SEQ_LEN,
+//                                          PAGE_SIZE,
+//                                          TMA_Q,
+//                                          TMA_KV,
+//                                          TMA_PAGED_KV,
+//                                          TMA_OUTPUT,
+//                                          MAX_TOKENS>(
+//       tma_q,
+//       tma_k,
+//       tma_v,
+//       tma_paged_k_cache,
+//       tma_paged_v_cache,
+//       tma_output,
+//       paged_k_cache_ptr,
+//       paged_v_cache_ptr,
+//       qo_indptr_buffer_ptr,
+//       paged_kv_indptr_buffer_ptr,
+//       paged_kv_indices_buffer_ptr,
+//       paged_kv_last_page_len_buffer_ptr,
+//       request_id,
+//       qk_norm,
+//       rope,
+//       q_norm_weight_ptr,
+//       k_norm_weight_ptr,
+//       cos_ptr,
+//       sin_ptr,
+//       q_eps,
+//       k_eps,
+//       output_ptr,
+//       qkv_ptr);
+// }
+
+// template <typename T,
+//           int NUM_QO_HEADS,
+//           int NUM_KV_HEADS,
+//           int KV_CACHE_STRIDE,
+//           int QKV_STRIDE,
+//           int O_STRIDE,
+//           int HEAD_DIM,
+//           int MAX_SEQ_LEN,
+//           int PAGE_SIZE,
+//           int MAX_TOKENS = 8>
+// void launch_multitoken_paged_attention_hopper(
+//     void *qkv_ptr,
+//     void *paged_k_cache_ptr,
+//     void *paged_v_cache_ptr,
+//     void *output_ptr,
+//     int const *qo_indptr_buffer_ptr,
+//     int const *paged_kv_indptr_buffer_ptr,
+//     int const *paged_kv_indices_buffer_ptr,
+//     int const *paged_kv_last_page_len_buffer_ptr,
+//     int request_id,
+//     bool qk_norm,
+//     bool rope,
+//     void const *q_norm_weight_ptr,
+//     void const *k_norm_weight_ptr,
+//     void const *cos_ptr,
+//     void const *sin_ptr,
+//     float q_eps,
+//     float k_eps) {
+//   dim3 grid_dim(1, 1, 1);
+//   dim3 block_dim(256, 1, 1);
+//   size_t smem_size = 224 * 1024;
+
+//   constexpr int B = 3;
+//   constexpr int M = 3;
+//   constexpr int S = 3;
+//   constexpr int TMA_CP_SIZE = 64;
+//   constexpr int KV_TILE_SIZE = 64;
+//   constexpr int prompt_len = 8;
+//   constexpr int num_tokens = 8;
+
+//   constexpr int NUM_PAGES = 100;
+//   constexpr int TAIL_PAGE_SIZE = prompt_len % PAGE_SIZE;
+
+//   using TMA_Q =
+//       kernel::tma::tma_3d<bfloat16,
+//                           B,
+//                           M,
+//                           S,
+//                           num_tokens,
+//                           (NUM_QO_HEADS + 2 * NUM_KV_HEADS),
+//                           HEAD_DIM,
+//                           num_tokens,
+//                           NUM_QO_HEADS,
+//                           TMA_CP_SIZE,
+//                           (NUM_QO_HEADS + 2 * NUM_KV_HEADS) * HEAD_DIM,
+//                           HEAD_DIM,
+//                           1,
+//                           1,
+//                           (HEAD_DIM + TMA_CP_SIZE - 1) / TMA_CP_SIZE,
+//                           num_tokens * NUM_QO_HEADS * TMA_CP_SIZE,
+//                           true>;
+
+//   using TMA_KV =
+//       kernel::tma::tma_3d<bfloat16,
+//                           B,
+//                           M,
+//                           S,
+//                           num_tokens,
+//                           (NUM_QO_HEADS + 2 * NUM_KV_HEADS),
+//                           HEAD_DIM,
+//                           num_tokens,
+//                           NUM_KV_HEADS,
+//                           TMA_CP_SIZE,
+//                           (NUM_QO_HEADS + 2 * NUM_KV_HEADS) * HEAD_DIM,
+//                           HEAD_DIM,
+//                           1,
+//                           1,
+//                           (HEAD_DIM + TMA_CP_SIZE - 1) / TMA_CP_SIZE,
+//                           num_tokens * NUM_KV_HEADS *
+//                               TMA_CP_SIZE, // skip number of rows between
+//                                            // current 64 cols and next 64
+//                                            cols
+//                           true>;
+
+//   using TMA_PAGED_KV_CACHE =
+//       kernel::tma::tma_3d<bfloat16,
+//                           B,
+//                           M,
+//                           S,
+//                           NUM_PAGES,
+//                           PAGE_SIZE,
+//                           HEAD_DIM,
+//                           1,
+//                           KV_TILE_SIZE,
+//                           TMA_CP_SIZE,
+//                           PAGE_SIZE * HEAD_DIM,
+//                           HEAD_DIM,
+//                           1,
+//                           1,
+//                           (HEAD_DIM + TMA_CP_SIZE - 1) / TMA_CP_SIZE,
+//                           KV_TILE_SIZE * TMA_CP_SIZE,
+//                           true>;
+
+//   using TMA_OUTPUT =
+//       kernel::tma::tma_2d<bfloat16,
+//                           3,
+//                           3,
+//                           3,
+//                           num_tokens * NUM_QO_HEADS,
+//                           HEAD_DIM,
+//                           num_tokens * NUM_QO_HEADS,
+//                           TMA_CP_SIZE,
+//                           HEAD_DIM,
+//                           1,
+//                           1,
+//                           (HEAD_DIM + TMA_CP_SIZE - 1) / TMA_CP_SIZE,
+//                           num_tokens * NUM_QO_HEADS * TMA_CP_SIZE,
+//                           true>;
+
+//   // bfloat16 *__restrict__ qkv_ptr_bf16 = static_cast<bfloat16 *>(qkv_ptr);
+
+//   TMA_Q tma_q(qkv_ptr);
+//   TMA_KV tma_k(qkv_ptr);
+//   TMA_KV tma_v(qkv_ptr);
+//   TMA_PAGED_KV_CACHE tma_paged_k_cache(paged_k_cache_ptr);
+//   TMA_PAGED_KV_CACHE tma_paged_v_cache(paged_v_cache_ptr);
+//   TMA_OUTPUT tma_output(output_ptr);
+
+//   cudaFuncSetAttribute(
+//       multitoken_paged_attention_wrapper_hopper<T,
+//                                                 NUM_QO_HEADS,
+//                                                 NUM_KV_HEADS,
+//                                                 KV_CACHE_STRIDE,
+//                                                 QKV_STRIDE,
+//                                                 O_STRIDE,
+//                                                 HEAD_DIM,
+//                                                 MAX_SEQ_LEN,
+//                                                 PAGE_SIZE,
+//                                                 TMA_Q,
+//                                                 TMA_KV,
+//                                                 TMA_PAGED_KV_CACHE,
+//                                                 TMA_OUTPUT,
+//                                                 num_tokens>,
+//       cudaFuncAttributeMaxDynamicSharedMemorySize,
+//       smem_size);
+
+// #ifndef MIRAGE_PROFILE_HOPPER
+//   multitoken_paged_attention_wrapper_hopper<T,
+//                                             NUM_QO_HEADS,
+//                                             NUM_KV_HEADS,
+//                                             KV_CACHE_STRIDE,
+//                                             QKV_STRIDE,
+//                                             O_STRIDE,
+//                                             HEAD_DIM,
+//                                             MAX_SEQ_LEN,
+//                                             PAGE_SIZE,
+//                                             TMA_Q,
+//                                             TMA_KV,
+//                                             TMA_PAGED_KV_CACHE,
+//                                             TMA_OUTPUT,
+//                                             num_tokens>
+//       <<<grid_dim, block_dim, smem_size>>>(tma_q,
+//                                            tma_k,
+//                                            tma_v,
+//                                            tma_paged_k_cache,
+//                                            tma_paged_v_cache,
+//                                            tma_output,
+//                                            paged_k_cache_ptr,
+//                                            paged_v_cache_ptr,
+//                                            qo_indptr_buffer_ptr,
+//                                            paged_kv_indptr_buffer_ptr,
+//                                            paged_kv_indices_buffer_ptr,
+//                                            paged_kv_last_page_len_buffer_ptr,
+//                                            request_id,
+//                                            qk_norm,
+//                                            rope,
+//                                            q_norm_weight_ptr,
+//                                            k_norm_weight_ptr,
+//                                            cos_ptr,
+//                                            sin_ptr,
+//                                            q_eps,
+//                                            k_eps,
+//                                            output_ptr,
+//                                            qkv_ptr);
+// #else
+
+//   cudaEvent_t start, stop;
+//   cudaEventCreate(&start);
+//   cudaEventCreate(&stop);
+
+//   constexpr int WARMUP_RUNS = 16;
+//   constexpr int BENCHMARK_RUNS = 1000;
+
+//   printf("=== Multitoken Paged Attention Kernel Performance Profiling
+//   ===\n");
+
+//   for (int i = 0; i < WARMUP_RUNS; i++) {
+//     multitoken_paged_attention_wrapper_hopper<T,
+//                                               NUM_QO_HEADS,
+//                                               NUM_KV_HEADS,
+//                                               KV_CACHE_STRIDE,
+//                                               QKV_STRIDE,
+//                                               O_STRIDE,
+//                                               HEAD_DIM,
+//                                               MAX_SEQ_LEN,
+//                                               PAGE_SIZE,
+//                                               TMA_Q,
+//                                               TMA_KV,
+//                                               TMA_PAGED_KV_CACHE,
+//                                               TMA_OUTPUT,
+//                                               num_tokens>
+//         <<<grid_dim, block_dim, smem_size>>>(tma_q,
+//                                              tma_k,
+//                                              tma_v,
+//                                              tma_paged_k_cache,
+//                                              tma_paged_v_cache,
+//                                              tma_output,
+//                                              paged_k_cache_ptr,
+//                                              paged_v_cache_ptr,
+//                                              qo_indptr_buffer_ptr,
+//                                              paged_kv_indptr_buffer_ptr,
+//                                              paged_kv_indices_buffer_ptr,
+//                                              paged_kv_last_page_len_buffer_ptr,
+//                                              request_id,
+//                                              qk_norm,
+//                                              rope,
+//                                              q_norm_weight_ptr,
+//                                              k_norm_weight_ptr,
+//                                              cos_ptr,
+//                                              sin_ptr,
+//                                              q_eps,
+//                                              k_eps);
+//   }
+//   cudaDeviceSynchronize();
+
+//   printf("Running %d benchmark iterations...\n", BENCHMARK_RUNS);
+
+//   float *iteration_times = new float[BENCHMARK_RUNS];
+//   float total_time_ms = 0.0f;
+
+//   for (int i = 0; i < BENCHMARK_RUNS; i++) {
+//     cudaEventRecord(start);
+//     multitoken_paged_attention_wrapper_hopper<T,
+//                                               NUM_QO_HEADS,
+//                                               NUM_KV_HEADS,
+//                                               KV_CACHE_STRIDE,
+//                                               QKV_STRIDE,
+//                                               O_STRIDE,
+//                                               HEAD_DIM,
+//                                               MAX_SEQ_LEN,
+//                                               PAGE_SIZE,
+//                                               TMA_Q,
+//                                               TMA_KV,
+//                                               TMA_PAGED_KV_CACHE,
+//                                               TMA_OUTPUT,
+//                                               num_tokens>
+//         <<<grid_dim, block_dim, smem_size>>>(tma_q,
+//                                              tma_k,
+//                                              tma_v,
+//                                              tma_paged_k_cache,
+//                                              tma_paged_v_cache,
+//                                              tma_output,
+//                                              paged_k_cache_ptr,
+//                                              paged_v_cache_ptr,
+//                                              qo_indptr_buffer_ptr,
+//                                              paged_kv_indptr_buffer_ptr,
+//                                              paged_kv_indices_buffer_ptr,
+//                                              paged_kv_last_page_len_buffer_ptr,
+//                                              request_id,
+//                                              qk_norm,
+//                                              rope,
+//                                              q_norm_weight_ptr,
+//                                              k_norm_weight_ptr,
+//                                              cos_ptr,
+//                                              sin_ptr,
+//                                              q_eps,
+//                                              k_eps);
+//     cudaEventRecord(stop);
+//     cudaEventSynchronize(stop);
+
+//     float iteration_time_ms;
+//     cudaEventElapsedTime(&iteration_time_ms, start, stop);
+
+//     iteration_times[i] = iteration_time_ms;
+//     total_time_ms += iteration_time_ms;
+//   }
+
+//   float avg_time_ms = total_time_ms / BENCHMARK_RUNS;
+
+//   printf("\n=== Multitoken Paged Attention Performance Results ===\n");
+//   printf("Configuration:\n");
+//   printf("  NUM_QO_HEADS=%d, NUM_KV_HEADS=%d, HEAD_DIM=%d\n",
+//          NUM_QO_HEADS,
+//          NUM_KV_HEADS,
+//          HEAD_DIM);
+//   printf("  MAX_SEQ_LEN=%d, PAGE_SIZE=%d, MAX_TOKENS=%d\n",
+//          MAX_SEQ_LEN,
+//          PAGE_SIZE,
+//          MAX_TOKENS);
+//   printf("  Average: %.3f ms\n", avg_time_ms);
+
+//   printf("===============================\n");
+
+//   delete[] iteration_times;
+//   cudaEventDestroy(start);
+//   cudaEventDestroy(stop);
+// #endif
+// }
+
+// void multitoken_paged_attention_hopper(
+//     torch::Tensor qkv,
+//     torch::Tensor paged_k_cache,
+//     torch::Tensor paged_v_cache,
+//     torch::Tensor output,
+//     torch::Tensor qo_indptr_buffer,
+//     torch::Tensor paged_kv_indptr_buffer,
+//     torch::Tensor paged_kv_indices_buffer,
+//     torch::Tensor paged_kv_last_page_len_buffer,
+//     int request_id,
+//     bool qk_norm,
+//     bool rope,
+//     torch::optional<torch::Tensor> q_norm_weight = torch::nullopt,
+//     torch::optional<torch::Tensor> k_norm_weight = torch::nullopt,
+//     torch::optional<torch::Tensor> cos = torch::nullopt,
+//     torch::optional<torch::Tensor> sin = torch::nullopt,
+//     float q_eps = 0.0f,
+//     float k_eps = 0.0f) {
+//   void *qkv_ptr = qkv.data_ptr();
+//   void *paged_k_cache_ptr = paged_k_cache.data_ptr();
+//   void *paged_v_cache_ptr = paged_v_cache.data_ptr();
+//   void *output_ptr = output.data_ptr();
+//   int const *qo_indptr_buffer_ptr = qo_indptr_buffer.data_ptr<int>();
+//   int const *paged_kv_indptr_buffer_ptr =
+//       paged_kv_indptr_buffer.data_ptr<int>();
+//   int const *paged_kv_indices_buffer_ptr =
+//       paged_kv_indices_buffer.data_ptr<int>();
+//   int const *paged_kv_last_page_len_buffer_ptr =
+//       paged_kv_last_page_len_buffer.data_ptr<int>();
+
+//   void const *q_norm_weight_ptr = qk_norm ? q_norm_weight->data_ptr() :
+//   nullptr; void const *k_norm_weight_ptr = qk_norm ?
+//   k_norm_weight->data_ptr() : nullptr; void const *cos_ptr = rope ?
+//   cos->data_ptr() : nullptr; void const *sin_ptr = rope ? sin->data_ptr() :
+//   nullptr; int const qo_heads = 4; int const kv_heads = 1; int const head_dim
+//   = 128; int const qkv_stride = (qo_heads + 2 * kv_heads) * head_dim;
+//   assert(qkv_stride == qkv.stride(0));
+//   int const kv_stride = head_dim * kv_heads;
+//   assert(kv_stride == paged_k_cache.stride(1));
+//   int const o_stride = head_dim * qo_heads;
+//   int const page_size = 4096;
+//   int const max_seq_len = 512;
+
+//   launch_multitoken_paged_attention_hopper<bfloat16,
+//                                            qo_heads,
+//                                            kv_heads,
+//                                            kv_stride,
+//                                            qkv_stride,
+//                                            o_stride,
+//                                            head_dim,
+//                                            max_seq_len,
+//                                            page_size>(
+//       qkv_ptr,
+//       paged_k_cache_ptr,
+//       paged_v_cache_ptr,
+//       output_ptr,
+//       qo_indptr_buffer_ptr,
+//       paged_kv_indptr_buffer_ptr,
+//       paged_kv_indices_buffer_ptr,
+//       paged_kv_last_page_len_buffer_ptr,
+//       request_id,
+//       qk_norm,
+//       rope,
+//       q_norm_weight_ptr,
+//       k_norm_weight_ptr,
+//       cos_ptr,
+//       sin_ptr,
+//       q_eps,
+//       k_eps);
+
+//   cudaError_t err = cudaDeviceSynchronize();
+//   if (err != cudaSuccess) {
+//     printf("CUDA kernel launch error: %s\n", cudaGetErrorString(err));
+//   }
+// }
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("linear", &linear_kernel, "Linear kernel");
+  m.def("linear_swapAB", &linear_swapAB_kernel, "Linear swapAB kernel");
+  // m.def("norm_linear", &norm_linear_kernel, "NormLinear kernel");
+  // m.def("multitoken_paged_attention",
+  //       &multitoken_paged_attention_hopper,
+  //       "Multitoken paged attention for Grace Hopper GPU");
+}

--- a/tests/runtime_python/hopper/runtime_kernel_wrapper_hopper.cu
+++ b/tests/runtime_python/hopper/runtime_kernel_wrapper_hopper.cu
@@ -12,664 +12,1388 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "bfloat16.h"
-#include "hopper/linear_hopper.cuh"
-#include "hopper/linear_swapAB_hopper.cuh"
-#include "hopper/multitoken_paged_attention_hopper.cuh"
-#include "hopper/norm_linear_hopper.cuh"
-#include <cuda_runtime.h>
-#include <torch/extension.h>
-
-using kernel::linear_kernel_hopper;
-using kernel::linear_swapAB_kernel_hopper;
-using kernel::multitoken_paged_attention_hopper_impl;
-using kernel::norm_linear_kernel_hopper;
-using bfloat16 = type::bfloat16_t;
-
-template <typename T,
-          int BATCH_SIZE,
-          int OUTPUT_SIZE,
-          int REDUCTION_SIZE,
-          typename TMA_A,
-          typename TMA_B,
-          typename TMA_RESIDUAL,
-          typename TMA_OUT,
-          int Kstages = 4>
-__global__ __launch_bounds__(256, 1) void linear_kernel_swapAB_hopper_wrapper(
-    const __grid_constant__ TMA_A tma_a,
-    const __grid_constant__ TMA_B tma_b,
-    const __grid_constant__ TMA_RESIDUAL tma_residual,
-    const __grid_constant__ TMA_OUT tma_out) {
-
-  linear_swapAB_kernel_hopper<T,
-                              BATCH_SIZE,
-                              OUTPUT_SIZE,
-                              REDUCTION_SIZE,
-                              Kstages,
-                              TMA_A,
-                              TMA_B,
-                              TMA_OUT>(tma_a, tma_b, tma_out, &tma_residual);
-}
-
-template <typename T,
-          int BATCH_SIZE,
-          int OUTPUT_SIZE,
-          int REDUCTION_SIZE,
-          typename TMA_A,
-          typename TMA_B,
-          typename TMA_OUT,
-          int Kstages = 2>
-__global__
-    __launch_bounds__(256, 1) void linear_kernel_swapAB_no_residual_hopper_wrapper(
-        const __grid_constant__ TMA_A tma_a,
-        const __grid_constant__ TMA_B tma_b,
-        const __grid_constant__ TMA_OUT tma_out) {
-
-  linear_swapAB_kernel_hopper<T,
-                              BATCH_SIZE,
-                              OUTPUT_SIZE,
-                              REDUCTION_SIZE,
-                              Kstages,
-                              TMA_A,
-                              TMA_B,
-                              TMA_OUT,
-                              void>(tma_a, tma_b, tma_out, nullptr);
-}
-
-template <typename T, int BATCH_SIZE, int OUTPUT_SIZE, int REDUCTION_SIZE>
-void launch_linear_swapAB(void *input_ptr,
-                          void *weight_ptr,
-                          void *residual_ptr,
-                          void *output_ptr = nullptr) {
-
-  constexpr int B = 3;
-  constexpr int M = 3;
-  constexpr int S = 3;
-
-  constexpr int TMA_CP_ASYNC_SIZE =
-      64; // note that if swizzle 128 is used, 64 is maximal cp size
-  constexpr int TILE_SIZE =
-      128; // we should modify this param if we want larger tile size
-  constexpr int TMA_CP_ASYNC_REPEAT_COL =
-      (TILE_SIZE + TMA_CP_ASYNC_SIZE - 1) / TMA_CP_ASYNC_SIZE;
-
-  constexpr int OUTPUT_ATOM_SIZE = 64; // this is padded
-  constexpr int OUTPUT_TMA_CP_SIZE = OUTPUT_SIZE < 64 ? OUTPUT_SIZE : 64;
-  constexpr int OUTPUT_ATOM_REPEAT_COL = 1;
-
-  constexpr int SMEM_M_SIZE = 16;
-  using TMA_B =
-      kernel::tma::tma_2d<bfloat16,
-                          B,
-                          M,
-                          S,
-                          BATCH_SIZE,                      /*GMEM_ROW_*/
-                          REDUCTION_SIZE,                  /*GMEM_COL_*/
-                          BATCH_SIZE,                      /*SMEM_ROW_*/
-                          TMA_CP_ASYNC_SIZE,               /*SMEM_COL_*/
-                          REDUCTION_SIZE,                  /*GMEM_STRIDE_ROW_*/
-                          1,                               /*GMEM_STRIDE_COL_*/
-                          1,                               /*SMEM_REPEAT_ROW_*/
-                          TMA_CP_ASYNC_REPEAT_COL,         /*SMEM_REPEAT_COL_*/
-                          SMEM_M_SIZE * TMA_CP_ASYNC_SIZE, /*SMEM_STRIDE_*/
-                          true>;
-  using TMA_A =
-      kernel::tma::tma_2d<bfloat16,
-                          B,
-                          M,
-                          S,
-                          OUTPUT_SIZE,             /*GMEM_ROW_*/
-                          REDUCTION_SIZE,          /*GMEM_COL_*/
-                          OUTPUT_ATOM_SIZE,        /*SMEM_ROW_*/
-                          TMA_CP_ASYNC_SIZE,       /*SMEM_COL_*/
-                          REDUCTION_SIZE,          /*GMEM_STRIDE_ROW_*/
-                          1,                       /*GMEM_STRIDE_COL_*/
-                          1,                       /*SMEM_REPEAT_ROW_*/
-                          TMA_CP_ASYNC_REPEAT_COL, /*SMEM_REPEAT_COL_*/
-                          OUTPUT_ATOM_SIZE * TMA_CP_ASYNC_SIZE, /*SMEM_STRIDE_*/
-                          true>;
-  using TMA_RESIDUAL = kernel::tma::tma_2d<bfloat16,
-                                           0,
-                                           0,
-                                           0,
+ #include "bfloat16.h"
+ #include "hopper/linear_hopper.cuh"
+ #include "hopper/linear_swapAB_hopper.cuh"
+ #include "hopper/multitoken_paged_attention_hopper.cuh"
+ #include "hopper/norm_linear_hopper.cuh"
+ #include <cuda_runtime.h>
+ #include <torch/extension.h>
+ 
+ using kernel::linear_kernel_hopper;
+ using kernel::linear_swapAB_kernel_hopper;
+ using kernel::multitoken_paged_attention_hopper_impl;
+ using kernel::norm_linear_kernel_hopper;
+ using bfloat16 = type::bfloat16_t;
+ 
+ template <typename T,
+           int BATCH_SIZE,
+           int OUTPUT_SIZE,
+           int REDUCTION_SIZE,
+           typename TMA_A,
+           typename TMA_B,
+           typename TMA_RESIDUAL,
+           typename TMA_OUT,
+           int Kstages = 4>
+ __global__ __launch_bounds__(256, 1) void linear_kernel_swapAB_hopper_wrapper(
+     const __grid_constant__ TMA_A tma_a,
+     const __grid_constant__ TMA_B tma_b,
+     const __grid_constant__ TMA_RESIDUAL tma_residual,
+     const __grid_constant__ TMA_OUT tma_out) {
+ 
+   linear_swapAB_kernel_hopper<T,
+                               BATCH_SIZE,
+                               OUTPUT_SIZE,
+                               REDUCTION_SIZE,
+                               Kstages,
+                               TMA_A,
+                               TMA_B,
+                               TMA_OUT>(tma_a, tma_b, tma_out, &tma_residual);
+ }
+ 
+ template <typename T,
+           int BATCH_SIZE,
+           int OUTPUT_SIZE,
+           int REDUCTION_SIZE,
+           typename TMA_A,
+           typename TMA_B,
+           typename TMA_OUT,
+           int Kstages = 2>
+ __global__
+     __launch_bounds__(256, 1) void linear_kernel_swapAB_no_residual_hopper_wrapper(
+         const __grid_constant__ TMA_A tma_a,
+         const __grid_constant__ TMA_B tma_b,
+         const __grid_constant__ TMA_OUT tma_out) {
+ 
+   linear_swapAB_kernel_hopper<T,
+                               BATCH_SIZE,
+                               OUTPUT_SIZE,
+                               REDUCTION_SIZE,
+                               Kstages,
+                               TMA_A,
+                               TMA_B,
+                               TMA_OUT,
+                               void>(tma_a, tma_b, tma_out, nullptr);
+ }
+ 
+ template <typename T, int BATCH_SIZE, int OUTPUT_SIZE, int REDUCTION_SIZE>
+ void launch_linear_swapAB(void *input_ptr,
+                           void *weight_ptr,
+                           void *residual_ptr,
+                           void *output_ptr = nullptr) {
+ 
+   constexpr int B = 3;
+   constexpr int M = 3;
+   constexpr int S = 3;
+ 
+   constexpr int TMA_CP_ASYNC_SIZE =
+       64; // note that if swizzle 128 is used, 64 is maximal cp size
+   constexpr int TILE_SIZE =
+       128; // we should modify this param if we want larger tile size
+   constexpr int TMA_CP_ASYNC_REPEAT_COL =
+       (TILE_SIZE + TMA_CP_ASYNC_SIZE - 1) / TMA_CP_ASYNC_SIZE;
+ 
+   constexpr int OUTPUT_ATOM_SIZE = 64; // this is padded
+   constexpr int OUTPUT_TMA_CP_SIZE = OUTPUT_SIZE < 64 ? OUTPUT_SIZE : 64;
+   constexpr int OUTPUT_ATOM_REPEAT_COL = 1;
+ 
+   constexpr int SMEM_M_SIZE = 16;
+   using TMA_B =
+       kernel::tma::tma_2d<bfloat16,
+                           B,
+                           M,
+                           S,
+                           BATCH_SIZE,                      /*GMEM_ROW_*/
+                           REDUCTION_SIZE,                  /*GMEM_COL_*/
+                           BATCH_SIZE,                      /*SMEM_ROW_*/
+                           TMA_CP_ASYNC_SIZE,               /*SMEM_COL_*/
+                           REDUCTION_SIZE,                  /*GMEM_STRIDE_ROW_*/
+                           1,                               /*GMEM_STRIDE_COL_*/
+                           1,                               /*SMEM_REPEAT_ROW_*/
+                           TMA_CP_ASYNC_REPEAT_COL,         /*SMEM_REPEAT_COL_*/
+                           SMEM_M_SIZE * TMA_CP_ASYNC_SIZE, /*SMEM_STRIDE_*/
+                           true>;
+   using TMA_A =
+       kernel::tma::tma_2d<bfloat16,
+                           B,
+                           M,
+                           S,
+                           OUTPUT_SIZE,             /*GMEM_ROW_*/
+                           REDUCTION_SIZE,          /*GMEM_COL_*/
+                           OUTPUT_ATOM_SIZE,        /*SMEM_ROW_*/
+                           TMA_CP_ASYNC_SIZE,       /*SMEM_COL_*/
+                           REDUCTION_SIZE,          /*GMEM_STRIDE_ROW_*/
+                           1,                       /*GMEM_STRIDE_COL_*/
+                           1,                       /*SMEM_REPEAT_ROW_*/
+                           TMA_CP_ASYNC_REPEAT_COL, /*SMEM_REPEAT_COL_*/
+                           OUTPUT_ATOM_SIZE * TMA_CP_ASYNC_SIZE, /*SMEM_STRIDE_*/
+                           true>;
+   using TMA_RESIDUAL = kernel::tma::tma_2d<bfloat16,
+                                            0,
+                                            0,
+                                            0,
+                                            BATCH_SIZE,
+                                            OUTPUT_SIZE,
+                                            BATCH_SIZE,
+                                            OUTPUT_TMA_CP_SIZE,
+                                            OUTPUT_SIZE,
+                                            1,
+                                            1,
+                                            OUTPUT_ATOM_REPEAT_COL,
+                                            SMEM_M_SIZE * OUTPUT_TMA_CP_SIZE,
+                                            true>;
+ 
+   using TMA_OUT = kernel::tma::tma_2d<bfloat16,
+                                       B,
+                                       M,
+                                       S,
+                                       BATCH_SIZE,
+                                       OUTPUT_SIZE,
+                                       BATCH_SIZE,
+                                       OUTPUT_TMA_CP_SIZE,
+                                       OUTPUT_SIZE,
+                                       1,
+                                       1,
+                                       OUTPUT_ATOM_REPEAT_COL,
+                                       SMEM_M_SIZE * TMA_CP_ASYNC_SIZE,
+                                       true>;
+   TMA_A tma_a(weight_ptr);
+   TMA_B tma_b(input_ptr);
+   TMA_RESIDUAL tma_residual(residual_ptr);
+   TMA_OUT tma_out(output_ptr);
+ 
+   dim3 grid_dim(1, 1, 1);
+   dim3 block_dim(256, 1, 1);
+   size_t smem_size = 224 * 1024;
+ 
+   if (residual_ptr != nullptr) {
+     cudaFuncSetAttribute(linear_kernel_swapAB_hopper_wrapper<T,
+                                                              BATCH_SIZE,
+                                                              OUTPUT_SIZE,
+                                                              REDUCTION_SIZE,
+                                                              TMA_A,
+                                                              TMA_B,
+                                                              TMA_RESIDUAL,
+                                                              TMA_OUT>,
+                          cudaFuncAttributeMaxDynamicSharedMemorySize,
+                          smem_size);
+ 
+   } else {
+ 
+     cudaFuncSetAttribute(
+         linear_kernel_swapAB_no_residual_hopper_wrapper<T,
+                                                         BATCH_SIZE,
+                                                         OUTPUT_SIZE,
+                                                         REDUCTION_SIZE,
+                                                         TMA_A,
+                                                         TMA_B,
+                                                         TMA_OUT>,
+         cudaFuncAttributeMaxDynamicSharedMemorySize,
+         smem_size);
+   }
+ 
+ #ifndef MIRAGE_PROFILE_HOPPER
+   if (residual_ptr != nullptr) {
+ 
+     linear_kernel_swapAB_hopper_wrapper<T,
+                                         BATCH_SIZE,
+                                         OUTPUT_SIZE,
+                                         REDUCTION_SIZE,
+                                         TMA_A,
+                                         TMA_B,
+                                         TMA_RESIDUAL,
+                                         TMA_OUT>
+         <<<grid_dim, block_dim, smem_size>>>(
+             tma_a, tma_b, tma_residual, tma_out);
+   } else {
+ 
+     linear_kernel_swapAB_no_residual_hopper_wrapper<T,
+                                                     BATCH_SIZE,
+                                                     OUTPUT_SIZE,
+                                                     REDUCTION_SIZE,
+                                                     TMA_A,
+                                                     TMA_B,
+                                                     TMA_OUT>
+         <<<grid_dim, block_dim, smem_size>>>(tma_a, tma_b, tma_out);
+   }
+ #else
+ 
+   cudaEvent_t start, stop;
+   cudaEventCreate(&start);
+   cudaEventCreate(&stop);
+ 
+   constexpr int WARMUP_RUNS = 16;
+   constexpr int BENCHMARK_RUNS = 1000;
+ 
+   printf("=== Kernel Performance Profiling ===\n");
+ 
+   for (int i = 0; i < WARMUP_RUNS; i++) {
+     if (residual_ptr != nullptr) {
+       linear_kernel_swapAB_hopper_wrapper<T,
                                            BATCH_SIZE,
                                            OUTPUT_SIZE,
+                                           REDUCTION_SIZE,
+                                           TMA_A,
+                                           TMA_B,
+                                           TMA_RESIDUAL,
+                                           TMA_OUT>
+           <<<grid_dim, block_dim, smem_size>>>(
+               tma_a, tma_b, tma_residual, tma_out);
+     } else {
+       linear_kernel_swapAB_no_residual_hopper_wrapper<T,
+                                                       BATCH_SIZE,
+                                                       OUTPUT_SIZE,
+                                                       REDUCTION_SIZE,
+                                                       TMA_A,
+                                                       TMA_B,
+                                                       TMA_OUT>
+           <<<grid_dim, block_dim, smem_size>>>(tma_a, tma_b, tma_out);
+     }
+   }
+   cudaDeviceSynchronize(); // Wait for all warmup runs to complete
+ 
+   printf("Running %d benchmark iterations...\n", BENCHMARK_RUNS);
+ 
+   float *iteration_times = new float[BENCHMARK_RUNS];
+   float total_time_ms = 0.0f;
+ 
+   for (int i = 0; i < BENCHMARK_RUNS; i++) {
+     cudaEventRecord(start);
+     if (residual_ptr != nullptr) {
+       linear_kernel_swapAB_hopper_wrapper<T,
                                            BATCH_SIZE,
-                                           OUTPUT_TMA_CP_SIZE,
                                            OUTPUT_SIZE,
-                                           1,
-                                           1,
-                                           OUTPUT_ATOM_REPEAT_COL,
-                                           SMEM_M_SIZE * OUTPUT_TMA_CP_SIZE,
-                                           true>;
-
-  using TMA_OUT = kernel::tma::tma_2d<bfloat16,
-                                      B,
-                                      M,
-                                      S,
-                                      BATCH_SIZE,
-                                      OUTPUT_SIZE,
-                                      BATCH_SIZE,
-                                      OUTPUT_TMA_CP_SIZE,
-                                      OUTPUT_SIZE,
-                                      1,
-                                      1,
-                                      OUTPUT_ATOM_REPEAT_COL,
-                                      SMEM_M_SIZE * TMA_CP_ASYNC_SIZE,
-                                      true>;
-  TMA_A tma_a(weight_ptr);
-  TMA_B tma_b(input_ptr);
-  TMA_RESIDUAL tma_residual(residual_ptr);
-  TMA_OUT tma_out(output_ptr);
-
-  dim3 grid_dim(1, 1, 1);
-  dim3 block_dim(256, 1, 1);
-  size_t smem_size = 224 * 1024;
-
-  if (residual_ptr != nullptr) {
-    cudaFuncSetAttribute(linear_kernel_swapAB_hopper_wrapper<T,
-                                                             BATCH_SIZE,
-                                                             OUTPUT_SIZE,
-                                                             REDUCTION_SIZE,
-                                                             TMA_A,
-                                                             TMA_B,
-                                                             TMA_RESIDUAL,
-                                                             TMA_OUT>,
-                         cudaFuncAttributeMaxDynamicSharedMemorySize,
-                         smem_size);
-
-  } else {
-
-    cudaFuncSetAttribute(
-        linear_kernel_swapAB_no_residual_hopper_wrapper<T,
-                                                        BATCH_SIZE,
-                                                        OUTPUT_SIZE,
-                                                        REDUCTION_SIZE,
-                                                        TMA_A,
-                                                        TMA_B,
-                                                        TMA_OUT>,
-        cudaFuncAttributeMaxDynamicSharedMemorySize,
-        smem_size);
-  }
-
-#ifndef MIRAGE_PROFILE_HOPPER
-  if (residual_ptr != nullptr) {
-
-    linear_kernel_swapAB_hopper_wrapper<T,
-                                        BATCH_SIZE,
-                                        OUTPUT_SIZE,
-                                        REDUCTION_SIZE,
-                                        TMA_A,
-                                        TMA_B,
-                                        TMA_RESIDUAL,
-                                        TMA_OUT>
-        <<<grid_dim, block_dim, smem_size>>>(
-            tma_a, tma_b, tma_residual, tma_out);
-  } else {
-
-    linear_kernel_swapAB_no_residual_hopper_wrapper<T,
-                                                    BATCH_SIZE,
-                                                    OUTPUT_SIZE,
-                                                    REDUCTION_SIZE,
-                                                    TMA_A,
-                                                    TMA_B,
-                                                    TMA_OUT>
-        <<<grid_dim, block_dim, smem_size>>>(tma_a, tma_b, tma_out);
-  }
-#else
-
-  cudaEvent_t start, stop;
-  cudaEventCreate(&start);
-  cudaEventCreate(&stop);
-
-  constexpr int WARMUP_RUNS = 16;
-  constexpr int BENCHMARK_RUNS = 1000;
-
-  printf("=== Kernel Performance Profiling ===\n");
-
-  for (int i = 0; i < WARMUP_RUNS; i++) {
-    if (residual_ptr != nullptr) {
-      linear_kernel_swapAB_hopper_wrapper<T,
-                                          BATCH_SIZE,
-                                          OUTPUT_SIZE,
-                                          REDUCTION_SIZE,
-                                          TMA_A,
-                                          TMA_B,
-                                          TMA_RESIDUAL,
-                                          TMA_OUT>
-          <<<grid_dim, block_dim, smem_size>>>(
-              tma_a, tma_b, tma_residual, tma_out);
-    } else {
-      linear_kernel_swapAB_no_residual_hopper_wrapper<T,
-                                                      BATCH_SIZE,
-                                                      OUTPUT_SIZE,
-                                                      REDUCTION_SIZE,
-                                                      TMA_A,
-                                                      TMA_B,
-                                                      TMA_OUT>
-          <<<grid_dim, block_dim, smem_size>>>(tma_a, tma_b, tma_out);
-    }
-  }
-  cudaDeviceSynchronize(); // Wait for all warmup runs to complete
-
-  printf("Running %d benchmark iterations...\n", BENCHMARK_RUNS);
-
-  float *iteration_times = new float[BENCHMARK_RUNS];
-  float total_time_ms = 0.0f;
-
-  for (int i = 0; i < BENCHMARK_RUNS; i++) {
-    cudaEventRecord(start);
-    if (residual_ptr != nullptr) {
-      linear_kernel_swapAB_hopper_wrapper<T,
-                                          BATCH_SIZE,
-                                          OUTPUT_SIZE,
-                                          REDUCTION_SIZE,
-                                          TMA_A,
-                                          TMA_B,
-                                          TMA_RESIDUAL,
-                                          TMA_OUT>
-          <<<grid_dim, block_dim, smem_size>>>(
-              tma_a, tma_b, tma_residual, tma_out);
-    } else {
-      linear_kernel_swapAB_no_residual_hopper_wrapper<T,
-                                                      BATCH_SIZE,
-                                                      OUTPUT_SIZE,
-                                                      REDUCTION_SIZE,
-                                                      TMA_A,
-                                                      TMA_B,
-                                                      TMA_OUT>
-          <<<grid_dim, block_dim, smem_size>>>(tma_a, tma_b, tma_out);
-    }
-    cudaEventRecord(stop);
-    cudaEventSynchronize(stop);
-
-    float iteration_time_ms;
-    cudaEventElapsedTime(&iteration_time_ms, start, stop);
-
-    total_time_ms += iteration_time_ms;
-  }
-
-  float avg_time_ms = total_time_ms / BENCHMARK_RUNS;
-
-  printf("\n=== Performance Results ===\n");
-  printf("Configuration:\n");
-  printf("  BATCH_SIZE=%d, OUTPUT_SIZE=%d, REDUCTION_SIZE=%d\n",
-         BATCH_SIZE,
-         OUTPUT_SIZE,
-         REDUCTION_SIZE);
-  printf(" TILE SIZE: %d\n", TILE_SIZE);
-  printf("  Average: %.3f ms\n", avg_time_ms);
-
-  printf("===============================\n");
-
-  delete[] iteration_times;
-  cudaEventDestroy(start);
-  cudaEventDestroy(stop);
-#endif
-}
-
-#define DISPATCH_LINEAR_SWAPAB_REDUCTION_SIZE_CASE(                            \
-    BATCH_SIZE, OUTPUT_SIZE, REDUCTION_SIZE)                                   \
-  case REDUCTION_SIZE:                                                         \
-    launch_linear_swapAB<bfloat16, BATCH_SIZE, OUTPUT_SIZE, REDUCTION_SIZE>(   \
-        input_ptr, weight_ptr, residual_ptr, output_ptr);                      \
-    break;
-
-#define DISPATCH_LINEAR_SWAPAB_REDUCTION_SIZE(BATCH_SIZE, OUTPUT_SIZE)         \
-  switch (input.size(1)) {                                                     \
-    /*                                                                         \
-    DISPATCH_LINEAR_SWAPAB_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, 64)    \
-    DISPATCH_LINEAR_SWAPAB_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, 128)   \
-    DISPATCH_LINEAR_SWAPAB_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, 256)   \
-    DISPATCH_LINEAR_SWAPAB_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, 512)   \
-    DISPATCH_LINEAR_SWAPAB_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, 3072)  \
-    */                                                                         \
-    DISPATCH_LINEAR_SWAPAB_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, 12288) \
-    DISPATCH_LINEAR_SWAPAB_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, 4096)  \
-    default:                                                                   \
-      printf("Unsupported reduction size in test: %zu\n", input.size(1));      \
-      break;                                                                   \
-  }
-
-#define DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE)       \
-  case OUTPUT_SIZE:                                                            \
-    DISPATCH_LINEAR_SWAPAB_REDUCTION_SIZE(BATCH_SIZE, OUTPUT_SIZE)             \
-    break;
-
-#define DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE(BATCH_SIZE)                         \
-  switch (output.size(1)) {                                                    \
-    DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE_CASE(BATCH_SIZE, 48)                    \
-    DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE_CASE(BATCH_SIZE, 64)                    \
-    DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE_CASE(BATCH_SIZE, 128)                   \
-    DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE_CASE(BATCH_SIZE, 256)                   \
-    DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE_CASE(BATCH_SIZE, 2048)                  \
-    /*                                                                         \
-    DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE_CASE(BATCH_SIZE, 192)                   \
-    DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE_CASE(BATCH_SIZE, 16)                    \
-    DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE_CASE(BATCH_SIZE, 1600)                  \
-    DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE_CASE(BATCH_SIZE, 32)                    \
-    DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE_CASE(BATCH_SIZE, 512)                   \
-    DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE_CASE(BATCH_SIZE, 1024)                  \
-    */                                                                         \
-    default:                                                                   \
-      printf("Unsupported output size in test: %zu\n", output.size(1));        \
-      break;                                                                   \
-  }
-
-#define DISPATCH_LINEAR_SWAPAB_BATCH_SIZE_CASE(BATCH_SIZE)                     \
-  case BATCH_SIZE:                                                             \
-    DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE(BATCH_SIZE)                             \
-    break;
-
-void linear_swapAB_kernel(torch::Tensor input,
-                          torch::Tensor weight,
-                          c10::optional<at::Tensor> residual,
-                          torch::Tensor output) {
-
-  void *input_ptr = input.data_ptr();
-  void *weight_ptr = weight.data_ptr();
-  bool has_residual = residual.has_value();
-  void *residual_ptr = has_residual ? residual->data_ptr() : nullptr;
-  void *output_ptr = output.data_ptr();
-
-  switch (input.size(0)) {
-    DISPATCH_LINEAR_SWAPAB_BATCH_SIZE_CASE(8)
-    DISPATCH_LINEAR_SWAPAB_BATCH_SIZE_CASE(16)
-    default:
-      printf("Unsupported batch size in test: %zu\n", output.size(0));
-      break;
-  }
-
-  cudaError_t err = cudaDeviceSynchronize();
-  if (err != cudaSuccess) {
-    printf("CUDA kernel launch error: %s\n", cudaGetErrorString(err));
-  }
-}
-
-// template <typename T,
-//           int BATCH_SIZE,
-//           int OUTPUT_SIZE,
-//           int REDUCTION_SIZE,
-//           typename TMA_A,
-//           typename TMA_B,
-//           typename TMA_RESIDUAL,
-//           typename TMA_OUT,
-//           int Kstages = 2>
-// __global__ __launch_bounds__(256, 1) void linear_kernel_hopper_wrapper(
-//     const __grid_constant__ TMA_A tma_a,
-//     const __grid_constant__ TMA_B tma_b,
-//     const __grid_constant__ TMA_RESIDUAL tma_residual,
-//     const __grid_constant__ TMA_OUT tma_out) {
-
-//   linear_kernel_hopper<T,
-//                        BATCH_SIZE,
-//                        OUTPUT_SIZE,
-//                        REDUCTION_SIZE,
-//                        Kstages,
-//                        TMA_A,
-//                        TMA_B,
-//                        TMA_OUT>(tma_a, tma_b, tma_out, &tma_residual);
-// }
-
-// template <typename T,
-//           int BATCH_SIZE,
-//           int OUTPUT_SIZE,
-//           int REDUCTION_SIZE,
-//           typename TMA_A,
-//           typename TMA_B,
-//           typename TMA_OUT,
-//           int Kstages = 2>
-// __global__
-//     __launch_bounds__(256, 1) void linear_kernel_hopper_no_residual_wrapper(
-//         const __grid_constant__ TMA_A tma_a,
-//         const __grid_constant__ TMA_B tma_b,
-//         const __grid_constant__ TMA_OUT tma_out) {
-
-//   linear_kernel_hopper<T,
-//                        BATCH_SIZE,
-//                        OUTPUT_SIZE,
-//                        REDUCTION_SIZE,
-//                        Kstages,
-//                        TMA_A,
-//                        TMA_B,
-//                        TMA_OUT,
-//                        void>(tma_a, tma_b, tma_out, nullptr);
-// }
-
-// template <typename T, int BATCH_SIZE, int OUTPUT_SIZE, int REDUCTION_SIZE>
-// void launch_linear_hopper(void *input_ptr,
-//                           void *weight_ptr,
-//                           void *residual_ptr,
-//                           void *output_ptr) {
-
-//   constexpr int B = 3;
-//   constexpr int M = 3;
-//   constexpr int S = 3;
-
-//   constexpr int TMA_CP_ASYNC_SIZE =
-//       64; // note that if swizzle 128 is used, 64 is maximal cp size
-//   constexpr int TILE_SIZE =
-//       128; // we should modify this param if we want larger tile size
-//   constexpr int TMA_CP_ASYNC_REPEAT_COL =
-//       (TILE_SIZE + TMA_CP_ASYNC_SIZE - 1) / TMA_CP_ASYNC_SIZE;
-
-//   constexpr int OUTPUT_ATOM_SIZE = (OUTPUT_SIZE >= 256)   ? 256
-//                                    : (OUTPUT_SIZE >= 128) ? 128
-//                                    : (OUTPUT_SIZE >= 64)  ? 64
-//                                    : (OUTPUT_SIZE >= 32)  ? 32
-//                                                           : 16;
-//   constexpr int OUTPUT_ATOM_REPEAT_COL =
-//       (OUTPUT_ATOM_SIZE + TMA_CP_ASYNC_SIZE - 1) / TMA_CP_ASYNC_SIZE;
-
-//   constexpr int OUTPUT_TMA_CP_SIZE = OUTPUT_SIZE < 64 ? OUTPUT_SIZE : 64;
-//   constexpr int SMEM_M_SIZE = BATCH_SIZE;
-//   using TMA_A =
-//       kernel::tma::tma_2d<bfloat16,
-//                           B,
-//                           M,
-//                           S,
-//                           BATCH_SIZE,                      /*GMEM_ROW_*/
-//                           REDUCTION_SIZE,                  /*GMEM_COL_*/
-//                           BATCH_SIZE,                      /*SMEM_ROW_*/
-//                           TMA_CP_ASYNC_SIZE,               /*SMEM_COL_*/
-//                           REDUCTION_SIZE, /*GMEM_STRIDE_ROW_*/ 1,
-//                           /*GMEM_STRIDE_COL_*/ 1, /*SMEM_REPEAT_ROW_*/
-//                           TMA_CP_ASYNC_REPEAT_COL, /*SMEM_REPEAT_COL_*/
-//                           SMEM_M_SIZE * TMA_CP_ASYNC_SIZE, /*SMEM_STRIDE_*/
-//                           true>;
-//   using TMA_B =
-//       kernel::tma::tma_2d<bfloat16,
-//                           B,
-//                           M,
-//                           S,
-//                           OUTPUT_SIZE,             /*GMEM_ROW_*/
-//                           REDUCTION_SIZE,          /*GMEM_COL_*/
-//                           OUTPUT_ATOM_SIZE,        /*SMEM_ROW_*/
-//                           TMA_CP_ASYNC_SIZE,       /*SMEM_COL_*/
-//                           REDUCTION_SIZE,          /*GMEM_STRIDE_ROW_*/
-//                           1,                       /*GMEM_STRIDE_COL_*/
-//                           1,                       /*SMEM_REPEAT_ROW_*/
-//                           TMA_CP_ASYNC_REPEAT_COL, /*SMEM_REPEAT_COL_*/
-//                           OUTPUT_ATOM_SIZE * TMA_CP_ASYNC_SIZE,
-//                           /*SMEM_STRIDE_*/ true>;
-//   using TMA_RESIDUAL = kernel::tma::tma_2d<bfloat16,
-//                                            B,
-//                                            M,
-//                                            S,
-//                                            BATCH_SIZE,
-//                                            OUTPUT_SIZE,
-//                                            BATCH_SIZE,
-//                                            OUTPUT_TMA_CP_SIZE,
-//                                            OUTPUT_SIZE,
-//                                            1,
-//                                            1,
-//                                            OUTPUT_ATOM_REPEAT_COL,
-//                                            SMEM_M_SIZE * TMA_CP_ASYNC_SIZE,
-//                                            true>;
-
-//   using TMA_OUT = kernel::tma::tma_2d<bfloat16,
-//                                       B,
-//                                       M,
-//                                       S,
-//                                       BATCH_SIZE,
-//                                       OUTPUT_SIZE,
-//                                       BATCH_SIZE,
-//                                       OUTPUT_TMA_CP_SIZE,
-//                                       OUTPUT_SIZE,
-//                                       1,
-//                                       1,
-//                                       OUTPUT_ATOM_REPEAT_COL,
-//                                       SMEM_M_SIZE * TMA_CP_ASYNC_SIZE,
-//                                       true>;
-//   TMA_A tma_a(input_ptr);
-//   TMA_B tma_b(weight_ptr);
-//   TMA_RESIDUAL tma_residual(residual_ptr);
-//   TMA_OUT tma_out(output_ptr);
-
-//   dim3 grid_dim(1, 1, 1);
-//   dim3 block_dim(256, 1, 1);
-//   size_t smem_size = 224 * 1024;
-
-//   if (residual_ptr != nullptr) {
-//     cudaFuncSetAttribute(linear_kernel_hopper_wrapper<T,
-//                                                       BATCH_SIZE,
-//                                                       OUTPUT_SIZE,
-//                                                       REDUCTION_SIZE,
-//                                                       TMA_A,
-//                                                       TMA_B,
-//                                                       TMA_RESIDUAL,
-//                                                       TMA_OUT>,
-//                          cudaFuncAttributeMaxDynamicSharedMemorySize,
-//                          smem_size);
-
-//   } else {
-
-//     cudaFuncSetAttribute(
-//         linear_kernel_hopper_no_residual_wrapper<T,
-//                                                  BATCH_SIZE,
-//                                                  OUTPUT_SIZE,
-//                                                  REDUCTION_SIZE,
-//                                                  TMA_A,
-//                                                  TMA_B,
-//                                                  TMA_OUT>,
-//         cudaFuncAttributeMaxDynamicSharedMemorySize,
-//         smem_size);
-//   }
-
-// #ifndef MIRAGE_PROFILE_HOPPER
-//   if (residual_ptr != nullptr) {
-
-//     linear_kernel_hopper_wrapper<T,
-//                                  BATCH_SIZE,
-//                                  OUTPUT_SIZE,
-//                                  REDUCTION_SIZE,
-//                                  TMA_A,
-//                                  TMA_B,
-//                                  TMA_RESIDUAL,
-//                                  TMA_OUT><<<grid_dim, block_dim,
-//                                  smem_size>>>(
-//         tma_a, tma_b, tma_residual, tma_out);
-//   } else {
-
-//     linear_kernel_hopper_no_residual_wrapper<T,
-//                                              BATCH_SIZE,
-//                                              OUTPUT_SIZE,
-//                                              REDUCTION_SIZE,
-//                                              TMA_A,
-//                                              TMA_B,
-//                                              TMA_OUT>
-//         <<<grid_dim, block_dim, smem_size>>>(tma_a, tma_b, tma_out);
-//   }
-// #else
-
-//   cudaEvent_t start, stop;
-//   cudaEventCreate(&start);
-//   cudaEventCreate(&stop);
-
-//   constexpr int WARMUP_RUNS = 16;
-//   constexpr int BENCHMARK_RUNS = 1000;
-
-//   printf("=== Kernel Performance Profiling ===\n");
-
-//   for (int i = 0; i < WARMUP_RUNS; i++) {
-//     if (residual_ptr != nullptr) {
-//       linear_kernel_hopper_wrapper<T,
-//                                    BATCH_SIZE,
-//                                    OUTPUT_SIZE,
-//                                    REDUCTION_SIZE,
-//                                    TMA_A,
-//                                    TMA_B,
-//                                    TMA_RESIDUAL,
-//                                    TMA_OUT><<<grid_dim, block_dim,
-//                                    smem_size>>>(
-//           tma_a, tma_b, tma_residual, tma_out);
-//     } else {
-//       linear_kernel_hopper_no_residual_wrapper<T,
-//                                                BATCH_SIZE,
-//                                                OUTPUT_SIZE,
-//                                                REDUCTION_SIZE,
-//                                                TMA_A,
-//                                                TMA_B,
-//                                                TMA_OUT>
-//           <<<grid_dim, block_dim, smem_size>>>(tma_a, tma_b, tma_out);
-//     }
-//   }
-//   cudaDeviceSynchronize(); // Wait for all warmup runs to complete
-
-//   printf("Running %d benchmark iterations...\n", BENCHMARK_RUNS);
-
-//   float *iteration_times = new float[BENCHMARK_RUNS];
-//   float total_time_ms = 0.0f;
-
-//   for (int i = 0; i < BENCHMARK_RUNS; i++) {
-//     cudaEventRecord(start);
-//     if (residual_ptr != nullptr) {
-//       linear_kernel_hopper_wrapper<T,
-//                                    BATCH_SIZE,
-//                                    OUTPUT_SIZE,
-//                                    REDUCTION_SIZE,
-//                                    TMA_A,
-//                                    TMA_B,
-//                                    TMA_RESIDUAL,
-//                                    TMA_OUT><<<grid_dim, block_dim,
-//                                    smem_size>>>(
-//           tma_a, tma_b, tma_residual, tma_out);
-//     } else {
-//       linear_kernel_hopper_no_residual_wrapper<T,
-//                                                BATCH_SIZE,
-//                                                OUTPUT_SIZE,
-//                                                REDUCTION_SIZE,
-//                                                TMA_A,
-//                                                TMA_B,
-//                                                TMA_OUT>
-//           <<<grid_dim, block_dim, smem_size>>>(tma_a, tma_b, tma_out);
-//     }
-//     cudaEventRecord(stop);
-//     cudaEventSynchronize(stop);
-
-//     float iteration_time_ms;
-//     cudaEventElapsedTime(&iteration_time_ms, start, stop);
-
-//     total_time_ms += iteration_time_ms;
-//   }
-
-//   float avg_time_ms = total_time_ms / BENCHMARK_RUNS;
-
-//   printf("\n=== Performance Results ===\n");
-//   printf("Configuration:\n");
-//   printf("  BATCH_SIZE=%d, OUTPUT_SIZE=%d, REDUCTION_SIZE=%d\n",
-//          BATCH_SIZE,
-//          OUTPUT_SIZE,
-//          REDUCTION_SIZE);
-//   printf(" TILE SIZE: %d\n", TILE_SIZE);
-//   printf("  Average: %.3f ms\n", avg_time_ms);
-
-//   printf("===============================\n");
-
-  PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+                                           REDUCTION_SIZE,
+                                           TMA_A,
+                                           TMA_B,
+                                           TMA_RESIDUAL,
+                                           TMA_OUT>
+           <<<grid_dim, block_dim, smem_size>>>(
+               tma_a, tma_b, tma_residual, tma_out);
+     } else {
+       linear_kernel_swapAB_no_residual_hopper_wrapper<T,
+                                                       BATCH_SIZE,
+                                                       OUTPUT_SIZE,
+                                                       REDUCTION_SIZE,
+                                                       TMA_A,
+                                                       TMA_B,
+                                                       TMA_OUT>
+           <<<grid_dim, block_dim, smem_size>>>(tma_a, tma_b, tma_out);
+     }
+     cudaEventRecord(stop);
+     cudaEventSynchronize(stop);
+ 
+     float iteration_time_ms;
+     cudaEventElapsedTime(&iteration_time_ms, start, stop);
+ 
+     total_time_ms += iteration_time_ms;
+   }
+ 
+   float avg_time_ms = total_time_ms / BENCHMARK_RUNS;
+ 
+   printf("\n=== Performance Results ===\n");
+   printf("Configuration:\n");
+   printf("  BATCH_SIZE=%d, OUTPUT_SIZE=%d, REDUCTION_SIZE=%d\n",
+          BATCH_SIZE,
+          OUTPUT_SIZE,
+          REDUCTION_SIZE);
+   printf(" TILE SIZE: %d\n", TILE_SIZE);
+   printf("  Average: %.3f ms\n", avg_time_ms);
+ 
+   printf("===============================\n");
+ 
+   delete[] iteration_times;
+   cudaEventDestroy(start);
+   cudaEventDestroy(stop);
+ #endif
+ }
+ 
+ #define DISPATCH_LINEAR_SWAPAB_REDUCTION_SIZE_CASE(                            \
+     BATCH_SIZE, OUTPUT_SIZE, REDUCTION_SIZE)                                   \
+   case REDUCTION_SIZE:                                                         \
+     launch_linear_swapAB<bfloat16, BATCH_SIZE, OUTPUT_SIZE, REDUCTION_SIZE>(   \
+         input_ptr, weight_ptr, residual_ptr, output_ptr);                      \
+     break;
+ 
+ #define DISPATCH_LINEAR_SWAPAB_REDUCTION_SIZE(BATCH_SIZE, OUTPUT_SIZE)         \
+   switch (input.size(1)) {                                                     \
+     /*                                                                         \
+     DISPATCH_LINEAR_SWAPAB_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, 64)    \
+     DISPATCH_LINEAR_SWAPAB_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, 128)   \
+     DISPATCH_LINEAR_SWAPAB_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, 256)   \
+     DISPATCH_LINEAR_SWAPAB_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, 512)   \
+     DISPATCH_LINEAR_SWAPAB_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, 3072)  \
+     */                                                                         \
+     DISPATCH_LINEAR_SWAPAB_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, 12288) \
+     DISPATCH_LINEAR_SWAPAB_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, 4096)  \
+     default:                                                                   \
+       printf("Unsupported reduction size in test: %zu\n", input.size(1));      \
+       break;                                                                   \
+   }
+ 
+ #define DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE)       \
+   case OUTPUT_SIZE:                                                            \
+     DISPATCH_LINEAR_SWAPAB_REDUCTION_SIZE(BATCH_SIZE, OUTPUT_SIZE)             \
+     break;
+ 
+ #define DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE(BATCH_SIZE)                         \
+   switch (output.size(1)) {                                                    \
+     DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE_CASE(BATCH_SIZE, 48)                    \
+     DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE_CASE(BATCH_SIZE, 64)                    \
+     DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE_CASE(BATCH_SIZE, 128)                   \
+     DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE_CASE(BATCH_SIZE, 256)                   \
+     DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE_CASE(BATCH_SIZE, 2048)                  \
+     /*                                                                         \
+     DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE_CASE(BATCH_SIZE, 192)                   \
+     DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE_CASE(BATCH_SIZE, 16)                    \
+     DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE_CASE(BATCH_SIZE, 1600)                  \
+     DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE_CASE(BATCH_SIZE, 32)                    \
+     DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE_CASE(BATCH_SIZE, 512)                   \
+     DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE_CASE(BATCH_SIZE, 1024)                  \
+     */                                                                         \
+     default:                                                                   \
+       printf("Unsupported output size in test: %zu\n", output.size(1));        \
+       break;                                                                   \
+   }
+ 
+ #define DISPATCH_LINEAR_SWAPAB_BATCH_SIZE_CASE(BATCH_SIZE)                     \
+   case BATCH_SIZE:                                                             \
+     DISPATCH_LINEAR_SWAPAB_OUTPUT_SIZE(BATCH_SIZE)                             \
+     break;
+ 
+ void linear_swapAB_kernel(torch::Tensor input,
+                           torch::Tensor weight,
+                           c10::optional<at::Tensor> residual,
+                           torch::Tensor output) {
+ 
+   void *input_ptr = input.data_ptr();
+   void *weight_ptr = weight.data_ptr();
+   bool has_residual = residual.has_value();
+   void *residual_ptr = has_residual ? residual->data_ptr() : nullptr;
+   void *output_ptr = output.data_ptr();
+ 
+   switch (input.size(0)) {
+     DISPATCH_LINEAR_SWAPAB_BATCH_SIZE_CASE(8)
+     DISPATCH_LINEAR_SWAPAB_BATCH_SIZE_CASE(16)
+     default:
+       printf("Unsupported batch size in test: %zu\n", output.size(0));
+       break;
+   }
+ 
+   cudaError_t err = cudaDeviceSynchronize();
+   if (err != cudaSuccess) {
+     printf("CUDA kernel launch error: %s\n", cudaGetErrorString(err));
+   }
+ }
+ 
+ template <typename T,
+           int BATCH_SIZE,
+           int OUTPUT_SIZE,
+           int REDUCTION_SIZE,
+           typename TMA_A,
+           typename TMA_B,
+           typename TMA_RESIDUAL,
+           typename TMA_OUT,
+           int Kstages = 3>
+ __global__ __launch_bounds__(256, 1) void linear_kernel_hopper_wrapper(
+     const __grid_constant__ TMA_A tma_a,
+     const __grid_constant__ TMA_B tma_b,
+     const __grid_constant__ TMA_RESIDUAL tma_residual,
+     const __grid_constant__ TMA_OUT tma_out) {
+ 
+   linear_kernel_hopper<T,
+                        BATCH_SIZE,
+                        OUTPUT_SIZE,
+                        REDUCTION_SIZE,
+                        Kstages,
+                        TMA_A,
+                        TMA_B,
+                        TMA_OUT>(tma_a, tma_b, tma_out, &tma_residual);
+ }
+ 
+ template <typename T,
+           int BATCH_SIZE,
+           int OUTPUT_SIZE,
+           int REDUCTION_SIZE,
+           typename TMA_A,
+           typename TMA_B,
+           typename TMA_OUT,
+           int Kstages = 3>
+ __global__
+     __launch_bounds__(256, 1) void linear_kernel_hopper_no_residual_wrapper(
+         const __grid_constant__ TMA_A tma_a,
+         const __grid_constant__ TMA_B tma_b,
+         const __grid_constant__ TMA_OUT tma_out) {
+ 
+   linear_kernel_hopper<T,
+                        BATCH_SIZE,
+                        OUTPUT_SIZE,
+                        REDUCTION_SIZE,
+                        Kstages,
+                        TMA_A,
+                        TMA_B,
+                        TMA_OUT,
+                        void>(tma_a, tma_b, tma_out, nullptr);
+ }
+ 
+ template <typename T, int BATCH_SIZE, int OUTPUT_SIZE, int REDUCTION_SIZE>
+ void launch_linear_hopper(void *input_ptr,
+                           void *weight_ptr,
+                           void *residual_ptr,
+                           void *output_ptr) {
+ 
+   constexpr int B = 3;
+   constexpr int M = 3;
+   constexpr int S = 3;
+ 
+   constexpr int TMA_CP_ASYNC_SIZE =
+       64; // note that if swizzle 128 is used, 64 is maximal cp size
+   constexpr int TILE_SIZE =
+       128; // we should modify this param if we want larger tile size
+   constexpr int TMA_CP_ASYNC_REPEAT_COL =
+       (TILE_SIZE + TMA_CP_ASYNC_SIZE - 1) / TMA_CP_ASYNC_SIZE;
+ 
+   constexpr int OUTPUT_ATOM_SIZE = (OUTPUT_SIZE >= 256)   ? 256
+                                    : (OUTPUT_SIZE >= 128) ? 128
+                                    : (OUTPUT_SIZE >= 64)  ? 64
+                                    : (OUTPUT_SIZE >= 32)  ? 32
+                                                           : 16;
+   constexpr int OUTPUT_ATOM_REPEAT_COL =
+       (OUTPUT_ATOM_SIZE + TMA_CP_ASYNC_SIZE - 1) / TMA_CP_ASYNC_SIZE;
+ 
+   constexpr int OUTPUT_TMA_CP_SIZE = OUTPUT_SIZE < 64 ? OUTPUT_SIZE : 64;
+   constexpr int SMEM_M_SIZE = BATCH_SIZE;
+   using TMA_A =
+       kernel::tma::tma_2d<bfloat16,
+                           B,
+                           M,
+                           S,
+                           BATCH_SIZE,                      /*GMEM_ROW_*/
+                           REDUCTION_SIZE,                  /*GMEM_COL_*/
+                           BATCH_SIZE,                      /*SMEM_ROW_*/
+                           TMA_CP_ASYNC_SIZE,               /*SMEM_COL_*/
+                           REDUCTION_SIZE, /*GMEM_STRIDE_ROW_*/ 1,
+                           /*GMEM_STRIDE_COL_*/ 1, /*SMEM_REPEAT_ROW_*/
+                           TMA_CP_ASYNC_REPEAT_COL, /*SMEM_REPEAT_COL_*/
+                           SMEM_M_SIZE * TMA_CP_ASYNC_SIZE, /*SMEM_STRIDE_*/
+                           true>;
+   using TMA_B =
+       kernel::tma::tma_2d<bfloat16,
+                           B,
+                           M,
+                           S,
+                           OUTPUT_SIZE,             /*GMEM_ROW_*/
+                           REDUCTION_SIZE,          /*GMEM_COL_*/
+                           OUTPUT_ATOM_SIZE,        /*SMEM_ROW_*/
+                           TMA_CP_ASYNC_SIZE,       /*SMEM_COL_*/
+                           REDUCTION_SIZE,          /*GMEM_STRIDE_ROW_*/
+                           1,                       /*GMEM_STRIDE_COL_*/
+                           1,                       /*SMEM_REPEAT_ROW_*/
+                           TMA_CP_ASYNC_REPEAT_COL, /*SMEM_REPEAT_COL_*/
+                           OUTPUT_ATOM_SIZE * TMA_CP_ASYNC_SIZE,
+                           /*SMEM_STRIDE_*/ true>;
+   using TMA_RESIDUAL = kernel::tma::tma_2d<bfloat16,
+                                            B,
+                                            M,
+                                            S,
+                                            BATCH_SIZE,
+                                            OUTPUT_SIZE,
+                                            BATCH_SIZE,
+                                            OUTPUT_TMA_CP_SIZE,
+                                            OUTPUT_SIZE,
+                                            1,
+                                            1,
+                                            OUTPUT_ATOM_REPEAT_COL,
+                                            SMEM_M_SIZE * TMA_CP_ASYNC_SIZE,
+                                            true>;
+ 
+   using TMA_OUT = kernel::tma::tma_2d<bfloat16,
+                                       B,
+                                       M,
+                                       S,
+                                       BATCH_SIZE,
+                                       OUTPUT_SIZE,
+                                       BATCH_SIZE,
+                                       OUTPUT_TMA_CP_SIZE,
+                                       OUTPUT_SIZE,
+                                       1,
+                                       1,
+                                       OUTPUT_ATOM_REPEAT_COL,
+                                       SMEM_M_SIZE * TMA_CP_ASYNC_SIZE,
+                                       true>;
+   TMA_A tma_a(input_ptr);
+   TMA_B tma_b(weight_ptr);
+   TMA_RESIDUAL tma_residual(residual_ptr);
+   TMA_OUT tma_out(output_ptr);
+ 
+   dim3 grid_dim(1, 1, 1);
+   dim3 block_dim(256, 1, 1);
+   size_t smem_size = 224 * 1024;
+ 
+   if (residual_ptr != nullptr) {
+     cudaFuncSetAttribute(linear_kernel_hopper_wrapper<T,
+                                                       BATCH_SIZE,
+                                                       OUTPUT_SIZE,
+                                                       REDUCTION_SIZE,
+                                                       TMA_A,
+                                                       TMA_B,
+                                                       TMA_RESIDUAL,
+                                                       TMA_OUT>,
+                          cudaFuncAttributeMaxDynamicSharedMemorySize,
+                          smem_size);
+ 
+   } else {
+ 
+     cudaFuncSetAttribute(
+         linear_kernel_hopper_no_residual_wrapper<T,
+                                                  BATCH_SIZE,
+                                                  OUTPUT_SIZE,
+                                                  REDUCTION_SIZE,
+                                                  TMA_A,
+                                                  TMA_B,
+                                                  TMA_OUT>,
+         cudaFuncAttributeMaxDynamicSharedMemorySize,
+         smem_size);
+   }
+ 
+ #ifndef MIRAGE_PROFILE_HOPPER
+   if (residual_ptr != nullptr) {
+ 
+     linear_kernel_hopper_wrapper<T,
+                                  BATCH_SIZE,
+                                  OUTPUT_SIZE,
+                                  REDUCTION_SIZE,
+                                  TMA_A,
+                                  TMA_B,
+                                  TMA_RESIDUAL,
+                                  TMA_OUT><<<grid_dim, block_dim,
+                                  smem_size>>>(
+         tma_a, tma_b, tma_residual, tma_out);
+   } else {
+ 
+     linear_kernel_hopper_no_residual_wrapper<T,
+                                              BATCH_SIZE,
+                                              OUTPUT_SIZE,
+                                              REDUCTION_SIZE,
+                                              TMA_A,
+                                              TMA_B,
+                                              TMA_OUT>
+         <<<grid_dim, block_dim, smem_size>>>(tma_a, tma_b, tma_out);
+   }
+ #else
+ 
+   cudaEvent_t start, stop;
+   cudaEventCreate(&start);
+   cudaEventCreate(&stop);
+ 
+   constexpr int WARMUP_RUNS = 16;
+   constexpr int BENCHMARK_RUNS = 1000;
+ 
+   printf("=== Kernel Performance Profiling ===\n");
+ 
+   for (int i = 0; i < WARMUP_RUNS; i++) {
+     if (residual_ptr != nullptr) {
+       linear_kernel_hopper_wrapper<T,
+                                    BATCH_SIZE,
+                                    OUTPUT_SIZE,
+                                    REDUCTION_SIZE,
+                                    TMA_A,
+                                    TMA_B,
+                                    TMA_RESIDUAL,
+                                    TMA_OUT><<<grid_dim, block_dim,
+                                    smem_size>>>(
+           tma_a, tma_b, tma_residual, tma_out);
+     } else {
+       linear_kernel_hopper_no_residual_wrapper<T,
+                                                BATCH_SIZE,
+                                                OUTPUT_SIZE,
+                                                REDUCTION_SIZE,
+                                                TMA_A,
+                                                TMA_B,
+                                                TMA_OUT>
+           <<<grid_dim, block_dim, smem_size>>>(tma_a, tma_b, tma_out);
+     }
+   }
+   cudaDeviceSynchronize(); // Wait for all warmup runs to complete
+ 
+   printf("Running %d benchmark iterations...\n", BENCHMARK_RUNS);
+ 
+   float *iteration_times = new float[BENCHMARK_RUNS];
+   float total_time_ms = 0.0f;
+ 
+   for (int i = 0; i < BENCHMARK_RUNS; i++) {
+     cudaEventRecord(start);
+     if (residual_ptr != nullptr) {
+       linear_kernel_hopper_wrapper<T,
+                                    BATCH_SIZE,
+                                    OUTPUT_SIZE,
+                                    REDUCTION_SIZE,
+                                    TMA_A,
+                                    TMA_B,
+                                    TMA_RESIDUAL,
+                                    TMA_OUT><<<grid_dim, block_dim,
+                                    smem_size>>>(
+           tma_a, tma_b, tma_residual, tma_out);
+     } else {
+       linear_kernel_hopper_no_residual_wrapper<T,
+                                                BATCH_SIZE,
+                                                OUTPUT_SIZE,
+                                                REDUCTION_SIZE,
+                                                TMA_A,
+                                                TMA_B,
+                                                TMA_OUT>
+           <<<grid_dim, block_dim, smem_size>>>(tma_a, tma_b, tma_out);
+     }
+     cudaEventRecord(stop);
+     cudaEventSynchronize(stop);
+ 
+     float iteration_time_ms;
+     cudaEventElapsedTime(&iteration_time_ms, start, stop);
+ 
+     total_time_ms += iteration_time_ms;
+   }
+ 
+   float avg_time_ms = total_time_ms / BENCHMARK_RUNS;
+ 
+   printf("\n=== Performance Results ===\n");
+   printf("Configuration:\n");
+   printf("  BATCH_SIZE=%d, OUTPUT_SIZE=%d, REDUCTION_SIZE=%d\n",
+          BATCH_SIZE,
+          OUTPUT_SIZE,
+          REDUCTION_SIZE);
+   printf(" TILE SIZE: %d\n", TILE_SIZE);
+   printf("  Average: %.3f ms\n", avg_time_ms);
+ 
+   printf("===============================\n");
+ 
+   delete[] iteration_times;
+   cudaEventDestroy(start);
+   cudaEventDestroy(stop);
+ #endif
+ }
+ 
+ #define DISPATCH_LINEAR_HOPPER_REDUCTION_SIZE_CASE(                            \
+     BATCH_SIZE, OUTPUT_SIZE, REDUCTION_SIZE)                                   \
+   case REDUCTION_SIZE:                                                         \
+     launch_linear_hopper<bfloat16, BATCH_SIZE, OUTPUT_SIZE, REDUCTION_SIZE>(   \
+         input_ptr, weight_ptr, residual_ptr, output_ptr);                      \
+     break;
+ 
+ #define DISPATCH_LINEAR_HOPPER_REDUCTION_SIZE(BATCH_SIZE, OUTPUT_SIZE)         \
+   switch (input.size(1)) {                                                     \
+     /*                                                                         \
+     DISPATCH_LINEAR_HOPPER_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, 64)    \
+     DISPATCH_LINEAR_HOPPER_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, 128)   \
+     DISPATCH_LINEAR_HOPPER_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, 256)   \
+     DISPATCH_LINEAR_HOPPER_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, 512)   \
+     DISPATCH_LINEAR_HOPPER_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, 3072)  \
+     */                                                                             \
+     DISPATCH_LINEAR_HOPPER_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, 4096)  \
+     DISPATCH_LINEAR_HOPPER_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, 12288) \
+     default:                                                                   \
+       printf("Unsupported reduction size in test: %zu\n", input.size(1));      \
+       break;                                                                   \
+   }
+ 
+ #define DISPATCH_LINEAR_HOPPER_OUTPUT_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE)       \
+   case OUTPUT_SIZE:                                                            \
+     DISPATCH_LINEAR_HOPPER_REDUCTION_SIZE(BATCH_SIZE, OUTPUT_SIZE)             \
+     break;
+ 
+ #define DISPATCH_LINEAR_HOPPER_OUTPUT_SIZE(BATCH_SIZE)                         \
+   switch (output.size(1)) {                                                    \
+     DISPATCH_LINEAR_HOPPER_OUTPUT_SIZE_CASE(BATCH_SIZE, 64)                    \
+     DISPATCH_LINEAR_HOPPER_OUTPUT_SIZE_CASE(BATCH_SIZE, 128)                   \
+     DISPATCH_LINEAR_HOPPER_OUTPUT_SIZE_CASE(BATCH_SIZE, 256)                   \
+     /*                                                                         \
+     DISPATCH_LINEAR_HOPPER_OUTPUT_SIZE_CASE(BATCH_SIZE, 1600)                  \
+     DISPATCH_LINEAR_HOPPER_OUTPUT_SIZE_CASE(BATCH_SIZE, 32)                    \
+     DISPATCH_LINEAR_HOPPER_OUTPUT_SIZE_CASE(BATCH_SIZE, 512)                   \
+     DISPATCH_LINEAR_HOPPER_OUTPUT_SIZE_CASE(BATCH_SIZE, 1024)                  \
+     DISPATCH_LINEAR_HOPPER_OUTPUT_SIZE_CASE(BATCH_SIZE, 2048)                  \
+     */                                                                         \
+     default:                                                                   \
+       printf("Unsupported output size in test: %zu\n", output.size(1));        \
+       break;                                                                   \
+   }
+ 
+ #define DISPATCH_LINEAR_HOPPER_BATCH_SIZE_CASE(BATCH_SIZE)                     \
+   case BATCH_SIZE:                                                             \
+     DISPATCH_LINEAR_HOPPER_OUTPUT_SIZE(BATCH_SIZE)                             \
+     break;
+ 
+ void linear_kernel(torch::Tensor input,
+                    torch::Tensor weight,
+                    c10::optional<at::Tensor> residual,
+                    torch::Tensor output) {
+ 
+   void *input_ptr = input.data_ptr();
+   void *weight_ptr = weight.data_ptr();
+   bool has_residual = residual.has_value();
+   void *residual_ptr = has_residual ? residual->data_ptr() : nullptr;
+   void *output_ptr = output.data_ptr();
+ 
+   switch (input.size(0)) {
+     DISPATCH_LINEAR_HOPPER_BATCH_SIZE_CASE(8)
+     /* \
+     DISPATCH_LINEAR_HOPPER_BATCH_SIZE_CASE(1)
+     DISPATCH_LINEAR_HOPPER_BATCH_SIZE_CASE(64)
+     */
+     default:
+       printf("Unsupported batch size in test: %zu\n", output.size(0));
+       break;
+   }
+ 
+   cudaError_t err = cudaDeviceSynchronize();
+   if (err != cudaSuccess) {
+     printf("CUDA kernel launch error: %s\n", cudaGetErrorString(err));
+   }
+ }
+ 
+ // norm linear
+ // template <typename T,
+ //           int BATCH_SIZE,
+ //           int OUTPUT_SIZE,
+ //           int REDUCTION_SIZE,
+ //           typename TMA_INPUT,
+ //           typename TMA_NORM_WEIGHT,
+ //           typename TMA_LINEAR_WEIGHT,
+ //           typename TMA_OUT,
+ //           int Kstages = 2>
+ // __global__ __launch_bounds__(256, 1) void norm_linear_kernel_hopper_wrapper(
+ //     const __grid_constant__ TMA_INPUT tma_input,
+ //     const __grid_constant__ TMA_NORM_WEIGHT tma_norm_weight,
+ //     const __grid_constant__ TMA_LINEAR_WEIGHT tma_linear_weight,
+ //     const __grid_constant__ TMA_OUT tma_out,
+ //     float eps) {
+ //   norm_linear_kernel_hopper<T,
+ //                             BATCH_SIZE,
+ //                             OUTPUT_SIZE,
+ //                             REDUCTION_SIZE,
+ //                             Kstages,
+ //                             TMA_INPUT,
+ //                             TMA_NORM_WEIGHT,
+ //                             TMA_LINEAR_WEIGHT,
+ //                             TMA_OUT>(
+ //       tma_input, tma_norm_weight, tma_linear_weight, tma_out, eps);
+ // }
+ 
+ // template <typename T, int BATCH_SIZE, int OUTPUT_SIZE, int REDUCTION_SIZE>
+ // void launch_norm_linear_hopper(void *input_ptr,
+ //                                void *norm_weight_ptr,
+ //                                void *weight_ptr,
+ //                                void *output_ptr,
+ //                                float eps) {
+ 
+ //   constexpr int B = 3;
+ //   constexpr int M = 3;
+ //   constexpr int S = 3;
+ 
+ //   constexpr int TILE_SIZE = 64;
+ 
+ //   using TMA_INPUT = kernel::tma::tma_2d<bfloat16,
+ //                                         B,
+ //                                         M,
+ //                                         S,
+ //                                         BATCH_SIZE,
+ //                                         REDUCTION_SIZE,
+ //                                         BATCH_SIZE,
+ //                                         TILE_SIZE>;
+ //   using TMA_NORM_WEIGHT = kernel::tma::tma_2d<bfloat16,
+ //                                               B,
+ //                                               M,
+ //                                               S,
+ //                                               BATCH_SIZE,
+ //                                               REDUCTION_SIZE,
+ //                                               BATCH_SIZE,
+ //                                               TILE_SIZE>;
+ //   using TMA_LINEAR_WEIGHT = kernel::tma::tma_2d<bfloat16,
+ //                                                 B,
+ //                                                 M,
+ //                                                 S,
+ //                                                 OUTPUT_SIZE,
+ //                                                 REDUCTION_SIZE,
+ //                                                 OUTPUT_SIZE,
+ //                                                 TILE_SIZE>;
+ 
+ //   using TMA_OUT = kernel::tma::tma_2d<bfloat16,
+ //                                       0,
+ //                                       0,
+ //                                       0,
+ //                                       BATCH_SIZE,
+ //                                       OUTPUT_SIZE,
+ //                                       BATCH_SIZE,
+ //                                       OUTPUT_SIZE>;
+ 
+ //   TMA_INPUT tma_input(input_ptr);
+ //   TMA_NORM_WEIGHT tma_norm_weight(norm_weight_ptr);
+ //   TMA_LINEAR_WEIGHT tma_linear_weight(weight_ptr);
+ //   TMA_OUT tma_out(output_ptr);
+ 
+ //   dim3 grid_dim(1, 1, 1);
+ //   dim3 block_dim(256, 1, 1);
+ //   size_t smem_size = 88888;
+ //   cudaFuncSetAttribute(norm_linear_kernel_hopper_wrapper<T,
+ //                                                          BATCH_SIZE,
+ //                                                          OUTPUT_SIZE,
+ //                                                          REDUCTION_SIZE,
+ //                                                          TMA_INPUT,
+ //                                                          TMA_NORM_WEIGHT,
+ //                                                          TMA_LINEAR_WEIGHT,
+ //                                                          TMA_OUT>,
+ //                        cudaFuncAttributeMaxDynamicSharedMemorySize,
+ //                        smem_size);
+ 
+ //   norm_linear_kernel_hopper_wrapper<T,
+ //                                     BATCH_SIZE,
+ //                                     OUTPUT_SIZE,
+ //                                     REDUCTION_SIZE,
+ //                                     TMA_INPUT,
+ //                                     TMA_NORM_WEIGHT,
+ //                                     TMA_LINEAR_WEIGHT,
+ //                                     TMA_OUT>
+ //       <<<grid_dim, block_dim, smem_size>>>(
+ //           tma_input, tma_norm_weight, tma_linear_weight, tma_out, eps);
+ // }
+ 
+ // #define DISPATCH_NORM_LINEAR_HOPPER_REDUCTION_SIZE_CASE(                       \
+  //     BATCH_SIZE, OUTPUT_SIZE, REDUCTION_SIZE)                                   \
+  //   case REDUCTION_SIZE:                                                         \
+  //     launch_norm_linear_hopper<bfloat16,                                        \
+  //                               BATCH_SIZE,                                      \
+  //                               OUTPUT_SIZE,                                     \
+  //                               REDUCTION_SIZE>(                                 \
+  //         input_ptr, norm_weight_ptr, weight_ptr, output_ptr, eps);              \
+  //     break;
+ 
+ // #define DISPATCH_NORM_LINEAR_HOPPER_REDUCTION_SIZE(BATCH_SIZE, OUTPUT_SIZE)    \
+  //   switch (input.size(1)) {                                                     \
+  //     /*DISPATCH_NORM_LINEAR_HOPPER_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE, \
+  //     128) DISPATCH_NORM_LINEAR_HOPPER_REDUCTION_SIZE_CASE(BATCH_SIZE,           \
+  //     OUTPUT_SIZE, 256)                                                          \
+  //     DISPATCH_NORM_LINEAR_HOPPER_REDUCTION_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE,   \
+  //     512) DISPATCH_NORM_LINEAR_HOPPER_REDUCTION_SIZE_CASE(BATCH_SIZE,           \
+  //     OUTPUT_SIZE, 3072)  */                                                     \
+  //     DISPATCH_NORM_LINEAR_HOPPER_REDUCTION_SIZE_CASE(                           \
+  //         BATCH_SIZE, OUTPUT_SIZE, 4096)                                         \
+  //     default:                                                                   \
+  //       printf("Unsupported reduction size in test: %zu\n", input.size(1));      \
+  //       break;                                                                   \
+  //   }
+ 
+ // #define DISPATCH_NORM_LINEAR_HOPPER_OUTPUT_SIZE_CASE(BATCH_SIZE, OUTPUT_SIZE)  \
+  //   case OUTPUT_SIZE:                                                            \
+  //     DISPATCH_NORM_LINEAR_HOPPER_REDUCTION_SIZE(BATCH_SIZE, OUTPUT_SIZE)        \
+  //     break;
+ 
+ // #define DISPATCH_NORM_LINEAR_HOPPER_OUTPUT_SIZE(BATCH_SIZE)                    \
+  //   switch (output.size(1)) {                                                    \
+  //     DISPATCH_NORM_LINEAR_HOPPER_OUTPUT_SIZE_CASE(BATCH_SIZE, 16)               \
+  //     DISPATCH_NORM_LINEAR_HOPPER_OUTPUT_SIZE_CASE(BATCH_SIZE, 32)               \
+  //     DISPATCH_NORM_LINEAR_HOPPER_OUTPUT_SIZE_CASE(BATCH_SIZE, 64)               \
+  //     default:                                                                   \
+  //       printf("Unsupported output size in test: %zu\n", output.size(1));        \
+  //       break;                                                                   \
+  //   }
+ 
+ // #define DISPATCH_NORM_LINEAR_HOPPER_BATCH_SIZE_CASE(BATCH_SIZE)                \
+  //   case BATCH_SIZE:                                                             \
+  //     DISPATCH_NORM_LINEAR_HOPPER_OUTPUT_SIZE(BATCH_SIZE)                        \
+  //     break;
+ 
+ // void norm_linear_kernel(torch::Tensor input,
+ //                         torch::Tensor norm_weight,
+ //                         torch::Tensor weight,
+ //                         torch::Tensor output,
+ //                         float eps) {
+ 
+ //   void *input_ptr = input.data_ptr();
+ //   void *norm_weight_ptr = norm_weight.data_ptr();
+ //   void *weight_ptr = weight.data_ptr();
+ //   void *output_ptr = output.data_ptr();
+ 
+ //   switch (input.size(0)) {
+ //     // DISPATCH_NORM_LINEAR_HOPPER_BATCH_SIZE_CASE(64)
+ //     default:
+ //       printf("Unsupported output size in test: %zu\n", output.size(0));
+ //       break;
+ //   }
+ 
+ //   cudaError_t err = cudaDeviceSynchronize();
+ //   if (err != cudaSuccess) {
+ //     printf("CUDA kernel launch error: %s\n", cudaGetErrorString(err));
+ //   }
+ // }
+ 
+ // Multitoken Paged Attention
+ // template <typename T,
+ //           int NUM_QO_HEADS,
+ //           int NUM_KV_HEADS,
+ //           int KV_CACHE_STRIDE,
+ //           int QKV_STRIDE,
+ //           int O_STRIDE,
+ //           int HEAD_DIM,
+ //           int MAX_SEQ_LEN,
+ //           int PAGE_SIZE,
+ //           typename TMA_Q,
+ //           typename TMA_KV,
+ //           typename TMA_PAGED_KV,
+ //           typename TMA_OUTPUT,
+ //           int MAX_TOKENS = 8>
+ // __global__ void multitoken_paged_attention_wrapper_hopper(
+ //     const __grid_constant__ TMA_Q tma_q,
+ //     const __grid_constant__ TMA_KV tma_k,
+ //     const __grid_constant__ TMA_KV tma_v,
+ //     const __grid_constant__ TMA_PAGED_KV tma_paged_k_cache,
+ //     const __grid_constant__ TMA_PAGED_KV tma_paged_v_cache,
+ //     const __grid_constant__ TMA_OUTPUT tma_output,
+ //     void *paged_k_cache_ptr,
+ //     void *paged_v_cache_ptr,
+ //     int const *qo_indptr_buffer_ptr,
+ //     int const *paged_kv_indptr_buffer_ptr,
+ //     int const *paged_kv_indices_buffer_ptr,
+ //     int const *paged_kv_last_page_len_buffer_ptr,
+ //     int request_id,
+ //     bool qk_norm,
+ //     bool rope,
+ //     void const *q_norm_weight_ptr,
+ //     void const *k_norm_weight_ptr,
+ //     void const *cos_ptr,
+ //     void const *sin_ptr,
+ //     float q_eps,
+ //     float k_eps,
+ //     void *output_ptr,
+ //     void *qkv_ptr) {
+ 
+ //   multitoken_paged_attention_hopper_impl<T,
+ //                                          NUM_QO_HEADS,
+ //                                          NUM_KV_HEADS,
+ //                                          KV_CACHE_STRIDE,
+ //                                          QKV_STRIDE,
+ //                                          O_STRIDE,
+ //                                          HEAD_DIM,
+ //                                          MAX_SEQ_LEN,
+ //                                          PAGE_SIZE,
+ //                                          TMA_Q,
+ //                                          TMA_KV,
+ //                                          TMA_PAGED_KV,
+ //                                          TMA_OUTPUT,
+ //                                          MAX_TOKENS>(
+ //       tma_q,
+ //       tma_k,
+ //       tma_v,
+ //       tma_paged_k_cache,
+ //       tma_paged_v_cache,
+ //       tma_output,
+ //       paged_k_cache_ptr,
+ //       paged_v_cache_ptr,
+ //       qo_indptr_buffer_ptr,
+ //       paged_kv_indptr_buffer_ptr,
+ //       paged_kv_indices_buffer_ptr,
+ //       paged_kv_last_page_len_buffer_ptr,
+ //       request_id,
+ //       qk_norm,
+ //       rope,
+ //       q_norm_weight_ptr,
+ //       k_norm_weight_ptr,
+ //       cos_ptr,
+ //       sin_ptr,
+ //       q_eps,
+ //       k_eps,
+ //       output_ptr,
+ //       qkv_ptr);
+ // }
+ 
+ // template <typename T,
+ //           int NUM_QO_HEADS,
+ //           int NUM_KV_HEADS,
+ //           int KV_CACHE_STRIDE,
+ //           int QKV_STRIDE,
+ //           int O_STRIDE,
+ //           int HEAD_DIM,
+ //           int MAX_SEQ_LEN,
+ //           int PAGE_SIZE,
+ //           int MAX_TOKENS = 8>
+ // void launch_multitoken_paged_attention_hopper(
+ //     void *qkv_ptr,
+ //     void *paged_k_cache_ptr,
+ //     void *paged_v_cache_ptr,
+ //     void *output_ptr,
+ //     int const *qo_indptr_buffer_ptr,
+ //     int const *paged_kv_indptr_buffer_ptr,
+ //     int const *paged_kv_indices_buffer_ptr,
+ //     int const *paged_kv_last_page_len_buffer_ptr,
+ //     int request_id,
+ //     bool qk_norm,
+ //     bool rope,
+ //     void const *q_norm_weight_ptr,
+ //     void const *k_norm_weight_ptr,
+ //     void const *cos_ptr,
+ //     void const *sin_ptr,
+ //     float q_eps,
+ //     float k_eps) {
+ //   dim3 grid_dim(1, 1, 1);
+ //   dim3 block_dim(256, 1, 1);
+ //   size_t smem_size = 224 * 1024;
+ 
+ //   constexpr int B = 3;
+ //   constexpr int M = 3;
+ //   constexpr int S = 3;
+ //   constexpr int TMA_CP_SIZE = 64;
+ //   constexpr int KV_TILE_SIZE = 64;
+ //   constexpr int prompt_len = 8;
+ //   constexpr int num_tokens = 8;
+ 
+ //   constexpr int NUM_PAGES = 100;
+ //   constexpr int TAIL_PAGE_SIZE = prompt_len % PAGE_SIZE;
+ 
+ //   using TMA_Q =
+ //       kernel::tma::tma_3d<bfloat16,
+ //                           B,
+ //                           M,
+ //                           S,
+ //                           num_tokens,
+ //                           (NUM_QO_HEADS + 2 * NUM_KV_HEADS),
+ //                           HEAD_DIM,
+ //                           num_tokens,
+ //                           NUM_QO_HEADS,
+ //                           TMA_CP_SIZE,
+ //                           (NUM_QO_HEADS + 2 * NUM_KV_HEADS) * HEAD_DIM,
+ //                           HEAD_DIM,
+ //                           1,
+ //                           1,
+ //                           (HEAD_DIM + TMA_CP_SIZE - 1) / TMA_CP_SIZE,
+ //                           num_tokens * NUM_QO_HEADS * TMA_CP_SIZE,
+ //                           true>;
+ 
+ //   using TMA_KV =
+ //       kernel::tma::tma_3d<bfloat16,
+ //                           B,
+ //                           M,
+ //                           S,
+ //                           num_tokens,
+ //                           (NUM_QO_HEADS + 2 * NUM_KV_HEADS),
+ //                           HEAD_DIM,
+ //                           num_tokens,
+ //                           NUM_KV_HEADS,
+ //                           TMA_CP_SIZE,
+ //                           (NUM_QO_HEADS + 2 * NUM_KV_HEADS) * HEAD_DIM,
+ //                           HEAD_DIM,
+ //                           1,
+ //                           1,
+ //                           (HEAD_DIM + TMA_CP_SIZE - 1) / TMA_CP_SIZE,
+ //                           num_tokens * NUM_KV_HEADS *
+ //                               TMA_CP_SIZE, // skip number of rows between
+ //                                            // current 64 cols and next 64
+ //                                            cols
+ //                           true>;
+ 
+ //   using TMA_PAGED_KV_CACHE =
+ //       kernel::tma::tma_3d<bfloat16,
+ //                           B,
+ //                           M,
+ //                           S,
+ //                           NUM_PAGES,
+ //                           PAGE_SIZE,
+ //                           HEAD_DIM,
+ //                           1,
+ //                           KV_TILE_SIZE,
+ //                           TMA_CP_SIZE,
+ //                           PAGE_SIZE * HEAD_DIM,
+ //                           HEAD_DIM,
+ //                           1,
+ //                           1,
+ //                           (HEAD_DIM + TMA_CP_SIZE - 1) / TMA_CP_SIZE,
+ //                           KV_TILE_SIZE * TMA_CP_SIZE,
+ //                           true>;
+ 
+ //   using TMA_OUTPUT =
+ //       kernel::tma::tma_2d<bfloat16,
+ //                           3,
+ //                           3,
+ //                           3,
+ //                           num_tokens * NUM_QO_HEADS,
+ //                           HEAD_DIM,
+ //                           num_tokens * NUM_QO_HEADS,
+ //                           TMA_CP_SIZE,
+ //                           HEAD_DIM,
+ //                           1,
+ //                           1,
+ //                           (HEAD_DIM + TMA_CP_SIZE - 1) / TMA_CP_SIZE,
+ //                           num_tokens * NUM_QO_HEADS * TMA_CP_SIZE,
+ //                           true>;
+ 
+ //   // bfloat16 *__restrict__ qkv_ptr_bf16 = static_cast<bfloat16 *>(qkv_ptr);
+ 
+ //   TMA_Q tma_q(qkv_ptr);
+ //   TMA_KV tma_k(qkv_ptr);
+ //   TMA_KV tma_v(qkv_ptr);
+ //   TMA_PAGED_KV_CACHE tma_paged_k_cache(paged_k_cache_ptr);
+ //   TMA_PAGED_KV_CACHE tma_paged_v_cache(paged_v_cache_ptr);
+ //   TMA_OUTPUT tma_output(output_ptr);
+ 
+ //   cudaFuncSetAttribute(
+ //       multitoken_paged_attention_wrapper_hopper<T,
+ //                                                 NUM_QO_HEADS,
+ //                                                 NUM_KV_HEADS,
+ //                                                 KV_CACHE_STRIDE,
+ //                                                 QKV_STRIDE,
+ //                                                 O_STRIDE,
+ //                                                 HEAD_DIM,
+ //                                                 MAX_SEQ_LEN,
+ //                                                 PAGE_SIZE,
+ //                                                 TMA_Q,
+ //                                                 TMA_KV,
+ //                                                 TMA_PAGED_KV_CACHE,
+ //                                                 TMA_OUTPUT,
+ //                                                 num_tokens>,
+ //       cudaFuncAttributeMaxDynamicSharedMemorySize,
+ //       smem_size);
+ 
+ // #ifndef MIRAGE_PROFILE_HOPPER
+ //   multitoken_paged_attention_wrapper_hopper<T,
+ //                                             NUM_QO_HEADS,
+ //                                             NUM_KV_HEADS,
+ //                                             KV_CACHE_STRIDE,
+ //                                             QKV_STRIDE,
+ //                                             O_STRIDE,
+ //                                             HEAD_DIM,
+ //                                             MAX_SEQ_LEN,
+ //                                             PAGE_SIZE,
+ //                                             TMA_Q,
+ //                                             TMA_KV,
+ //                                             TMA_PAGED_KV_CACHE,
+ //                                             TMA_OUTPUT,
+ //                                             num_tokens>
+ //       <<<grid_dim, block_dim, smem_size>>>(tma_q,
+ //                                            tma_k,
+ //                                            tma_v,
+ //                                            tma_paged_k_cache,
+ //                                            tma_paged_v_cache,
+ //                                            tma_output,
+ //                                            paged_k_cache_ptr,
+ //                                            paged_v_cache_ptr,
+ //                                            qo_indptr_buffer_ptr,
+ //                                            paged_kv_indptr_buffer_ptr,
+ //                                            paged_kv_indices_buffer_ptr,
+ //                                            paged_kv_last_page_len_buffer_ptr,
+ //                                            request_id,
+ //                                            qk_norm,
+ //                                            rope,
+ //                                            q_norm_weight_ptr,
+ //                                            k_norm_weight_ptr,
+ //                                            cos_ptr,
+ //                                            sin_ptr,
+ //                                            q_eps,
+ //                                            k_eps,
+ //                                            output_ptr,
+ //                                            qkv_ptr);
+ // #else
+ 
+ //   cudaEvent_t start, stop;
+ //   cudaEventCreate(&start);
+ //   cudaEventCreate(&stop);
+ 
+ //   constexpr int WARMUP_RUNS = 16;
+ //   constexpr int BENCHMARK_RUNS = 1000;
+ 
+ //   printf("=== Multitoken Paged Attention Kernel Performance Profiling
+ //   ===\n");
+ 
+ //   for (int i = 0; i < WARMUP_RUNS; i++) {
+ //     multitoken_paged_attention_wrapper_hopper<T,
+ //                                               NUM_QO_HEADS,
+ //                                               NUM_KV_HEADS,
+ //                                               KV_CACHE_STRIDE,
+ //                                               QKV_STRIDE,
+ //                                               O_STRIDE,
+ //                                               HEAD_DIM,
+ //                                               MAX_SEQ_LEN,
+ //                                               PAGE_SIZE,
+ //                                               TMA_Q,
+ //                                               TMA_KV,
+ //                                               TMA_PAGED_KV_CACHE,
+ //                                               TMA_OUTPUT,
+ //                                               num_tokens>
+ //         <<<grid_dim, block_dim, smem_size>>>(tma_q,
+ //                                              tma_k,
+ //                                              tma_v,
+ //                                              tma_paged_k_cache,
+ //                                              tma_paged_v_cache,
+ //                                              tma_output,
+ //                                              paged_k_cache_ptr,
+ //                                              paged_v_cache_ptr,
+ //                                              qo_indptr_buffer_ptr,
+ //                                              paged_kv_indptr_buffer_ptr,
+ //                                              paged_kv_indices_buffer_ptr,
+ //                                              paged_kv_last_page_len_buffer_ptr,
+ //                                              request_id,
+ //                                              qk_norm,
+ //                                              rope,
+ //                                              q_norm_weight_ptr,
+ //                                              k_norm_weight_ptr,
+ //                                              cos_ptr,
+ //                                              sin_ptr,
+ //                                              q_eps,
+ //                                              k_eps);
+ //   }
+ //   cudaDeviceSynchronize();
+ 
+ //   printf("Running %d benchmark iterations...\n", BENCHMARK_RUNS);
+ 
+ //   float *iteration_times = new float[BENCHMARK_RUNS];
+ //   float total_time_ms = 0.0f;
+ 
+ //   for (int i = 0; i < BENCHMARK_RUNS; i++) {
+ //     cudaEventRecord(start);
+ //     multitoken_paged_attention_wrapper_hopper<T,
+ //                                               NUM_QO_HEADS,
+ //                                               NUM_KV_HEADS,
+ //                                               KV_CACHE_STRIDE,
+ //                                               QKV_STRIDE,
+ //                                               O_STRIDE,
+ //                                               HEAD_DIM,
+ //                                               MAX_SEQ_LEN,
+ //                                               PAGE_SIZE,
+ //                                               TMA_Q,
+ //                                               TMA_KV,
+ //                                               TMA_PAGED_KV_CACHE,
+ //                                               TMA_OUTPUT,
+ //                                               num_tokens>
+ //         <<<grid_dim, block_dim, smem_size>>>(tma_q,
+ //                                              tma_k,
+ //                                              tma_v,
+ //                                              tma_paged_k_cache,
+ //                                              tma_paged_v_cache,
+ //                                              tma_output,
+ //                                              paged_k_cache_ptr,
+ //                                              paged_v_cache_ptr,
+ //                                              qo_indptr_buffer_ptr,
+ //                                              paged_kv_indptr_buffer_ptr,
+ //                                              paged_kv_indices_buffer_ptr,
+ //                                              paged_kv_last_page_len_buffer_ptr,
+ //                                              request_id,
+ //                                              qk_norm,
+ //                                              rope,
+ //                                              q_norm_weight_ptr,
+ //                                              k_norm_weight_ptr,
+ //                                              cos_ptr,
+ //                                              sin_ptr,
+ //                                              q_eps,
+ //                                              k_eps);
+ //     cudaEventRecord(stop);
+ //     cudaEventSynchronize(stop);
+ 
+ //     float iteration_time_ms;
+ //     cudaEventElapsedTime(&iteration_time_ms, start, stop);
+ 
+ //     iteration_times[i] = iteration_time_ms;
+ //     total_time_ms += iteration_time_ms;
+ //   }
+ 
+ //   float avg_time_ms = total_time_ms / BENCHMARK_RUNS;
+ 
+ //   printf("\n=== Multitoken Paged Attention Performance Results ===\n");
+ //   printf("Configuration:\n");
+ //   printf("  NUM_QO_HEADS=%d, NUM_KV_HEADS=%d, HEAD_DIM=%d\n",
+ //          NUM_QO_HEADS,
+ //          NUM_KV_HEADS,
+ //          HEAD_DIM);
+ //   printf("  MAX_SEQ_LEN=%d, PAGE_SIZE=%d, MAX_TOKENS=%d\n",
+ //          MAX_SEQ_LEN,
+ //          PAGE_SIZE,
+ //          MAX_TOKENS);
+ //   printf("  Average: %.3f ms\n", avg_time_ms);
+ 
+ //   printf("===============================\n");
+ 
+ //   delete[] iteration_times;
+ //   cudaEventDestroy(start);
+ //   cudaEventDestroy(stop);
+ // #endif
+ // }
+ 
+ // void multitoken_paged_attention_hopper(
+ //     torch::Tensor qkv,
+ //     torch::Tensor paged_k_cache,
+ //     torch::Tensor paged_v_cache,
+ //     torch::Tensor output,
+ //     torch::Tensor qo_indptr_buffer,
+ //     torch::Tensor paged_kv_indptr_buffer,
+ //     torch::Tensor paged_kv_indices_buffer,
+ //     torch::Tensor paged_kv_last_page_len_buffer,
+ //     int request_id,
+ //     bool qk_norm,
+ //     bool rope,
+ //     torch::optional<torch::Tensor> q_norm_weight = torch::nullopt,
+ //     torch::optional<torch::Tensor> k_norm_weight = torch::nullopt,
+ //     torch::optional<torch::Tensor> cos = torch::nullopt,
+ //     torch::optional<torch::Tensor> sin = torch::nullopt,
+ //     float q_eps = 0.0f,
+ //     float k_eps = 0.0f) {
+ //   void *qkv_ptr = qkv.data_ptr();
+ //   void *paged_k_cache_ptr = paged_k_cache.data_ptr();
+ //   void *paged_v_cache_ptr = paged_v_cache.data_ptr();
+ //   void *output_ptr = output.data_ptr();
+ //   int const *qo_indptr_buffer_ptr = qo_indptr_buffer.data_ptr<int>();
+ //   int const *paged_kv_indptr_buffer_ptr =
+ //       paged_kv_indptr_buffer.data_ptr<int>();
+ //   int const *paged_kv_indices_buffer_ptr =
+ //       paged_kv_indices_buffer.data_ptr<int>();
+ //   int const *paged_kv_last_page_len_buffer_ptr =
+ //       paged_kv_last_page_len_buffer.data_ptr<int>();
+ 
+ //   void const *q_norm_weight_ptr = qk_norm ? q_norm_weight->data_ptr() :
+ //   nullptr; void const *k_norm_weight_ptr = qk_norm ?
+ //   k_norm_weight->data_ptr() : nullptr; void const *cos_ptr = rope ?
+ //   cos->data_ptr() : nullptr; void const *sin_ptr = rope ? sin->data_ptr() :
+ //   nullptr; int const qo_heads = 4; int const kv_heads = 1; int const head_dim
+ //   = 128; int const qkv_stride = (qo_heads + 2 * kv_heads) * head_dim;
+ //   assert(qkv_stride == qkv.stride(0));
+ //   int const kv_stride = head_dim * kv_heads;
+ //   assert(kv_stride == paged_k_cache.stride(1));
+ //   int const o_stride = head_dim * qo_heads;
+ //   int const page_size = 4096;
+ //   int const max_seq_len = 512;
+ 
+ //   launch_multitoken_paged_attention_hopper<bfloat16,
+ //                                            qo_heads,
+ //                                            kv_heads,
+ //                                            kv_stride,
+ //                                            qkv_stride,
+ //                                            o_stride,
+ //                                            head_dim,
+ //                                            max_seq_len,
+ //                                            page_size>(
+ //       qkv_ptr,
+ //       paged_k_cache_ptr,
+ //       paged_v_cache_ptr,
+ //       output_ptr,
+ //       qo_indptr_buffer_ptr,
+ //       paged_kv_indptr_buffer_ptr,
+ //       paged_kv_indices_buffer_ptr,
+ //       paged_kv_last_page_len_buffer_ptr,
+ //       request_id,
+ //       qk_norm,
+ //       rope,
+ //       q_norm_weight_ptr,
+ //       k_norm_weight_ptr,
+ //       cos_ptr,
+ //       sin_ptr,
+ //       q_eps,
+ //       k_eps);
+ 
+ //   cudaError_t err = cudaDeviceSynchronize();
+ //   if (err != cudaSuccess) {
+ //     printf("CUDA kernel launch error: %s\n", cudaGetErrorString(err));
+ //   }
+ // }
+ 
+ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     m.def("linear", &linear_kernel, "Linear kernel");
-    m.def("norm_linear", &norm_linear_kernel, "NormLinear kernel");
-    m.def("multitoken_paged_attention",
-          &multitoken_paged_attention_hopper,
-          "Multitoken paged attention for Grace Hopper GPU");
-  }
+   m.def("linear_swapAB", &linear_swapAB_kernel, "Linear swapAB kernel");
+   // m.def("norm_linear", &norm_linear_kernel, "NormLinear kernel");
+   // m.def("multitoken_paged_attention",
+   //       &multitoken_paged_attention_hopper,
+   //       "Multitoken paged attention for Grace Hopper GPU");
+ }

--- a/tests/runtime_python/hopper/setup.py
+++ b/tests/runtime_python/hopper/setup.py
@@ -34,11 +34,12 @@ setup(
             libraries=["cuda"],
             library_dirs=cuda_library_dirs,
             extra_compile_args={
-                'cxx': ['-DMIRAGE_GRACE_HOPPER'],
+                'cxx': ['-DMIRAGE_GRACE_HOPPER', '-DMIRAGE_BACKEND_USE_CUDA'],
                 'nvcc': [
                     '-O3',
                     '-gencode=arch=compute_90a,code=sm_90a',
                     '-DMIRAGE_GRACE_HOPPER',
+                    '-DMIRAGE_BACKEND_USE_CUDA',
                     # '-DMIRAGE_PROFILE_HOPPER',
                 ]
             }


### PR DESCRIPTION
**Description of changes:**
This pr changes the `linear_layer` and `linear_layer_with_residual` partitioning strategy to always partitioning `N=64`, which means **no forloop** is required in both M/N dimension and instead we have more tasks for worker SMs to handle.

This surprisingly reduced the per token latency from ~8.25 to ~7.25ms, without changing anything in the kernels. This might indicate that we **SHOULD NOT** do too much forloop in Hopper/Blackwell kernels if we can partition the task to make several worker SMs to handle them, even if more tasks may introduce more task fetching overhead. I believe this task partitioning strategy can be more effective after we enable task descriptor prefetching in the future.


**Related Issues:**

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #


