### PR TITLE
feat: support ignore eos for qwen3 demo

### DIFF
--- a/demo/qwen3/demo.py
+++ b/demo/qwen3/demo.py
@@ -73,6 +73,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--model", type=str, default='Qwen/Qwen3-8B', help="Model path on hugging face"
     )
+    parser.add_argument("--ignore-eos", action="store_true", help="Ignore eos token during generation")
     args = parser.parse_args()
     try:
         from mpi4py import MPI
@@ -225,7 +226,7 @@ if __name__ == "__main__":
             max_num_batched_tokens=args.max_num_batched_tokens,
             max_num_pages=args.max_num_pages,
             page_size=args.page_size,
-            eos_token_id=model.config.eos_token_id,
+            eos_token_id=model.config.eos_token_id if not args.ignore_eos else -1,
             meta_tensors={
                 "step": step,
                 "tokens": tokens,

--- a/demo/qwen3/demo_hopper.py
+++ b/demo/qwen3/demo_hopper.py
@@ -73,6 +73,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--model", type=str, default='Qwen/Qwen3-8B', help="Model path on hugging face"
     )
+    parser.add_argument("--ignore-eos", action="store_true", help="Ignore eos token during generation")
     args = parser.parse_args()
     try:
         from mpi4py import MPI
@@ -225,7 +226,7 @@ if __name__ == "__main__":
             max_num_batched_tokens=args.max_num_batched_tokens,
             max_num_pages=args.max_num_pages,
             page_size=args.page_size,
-            eos_token_id=model.config.eos_token_id,
+            eos_token_id=model.config.eos_token_id if not args.ignore_eos else -1,
             meta_tensors={
                 "step": step,
                 "tokens": tokens,


### PR DESCRIPTION
**Description of changes:**

As titled, this PR support ignore eos for qwen3 demo. 

By the way, I'm not sure if it's appropriate to introduce a new ignore_eos argument for PersistentKernel and modify the internal prepare_next_batch, as it seems somewhat redundant with eos_token_id. Therefore, I opted for a minimal change: when EOS should be ignored, we simply set eos_token_id = -1 to achieve the same effect.

**Related Issues:**

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #


