### PR TITLE
[Not to land] support clang as compiler for mpk

### DIFF
--- a/demo/qwen3/demo.py
+++ b/demo/qwen3/demo.py
@@ -12,6 +12,9 @@ import os
 def grid_for_rmsnorm_linear_layer(size: int):
     # 96 and 64 are enough to cover all Qwen3 model? Please update the method
     # if you meet any incompatibility.
+    # if we use 64 as output_size for all linear kernel, we will see perf gain with clang++ as compiler.
+    if size % 64 == 0:
+        return size // 64
     if size / 96 > 400:
         # TODO: An add-hoc workaround for linear kernel, both MPK ptx and
         # cutlass version will output unexpect result (not same out put for

--- a/include/mirage/config.h
+++ b/include/mirage/config.h
@@ -28,7 +28,7 @@ uint16_t const FP_PQ = 13861;
 uint16_t const FP_P_MUL_Q_MOD_1 = 167;
 // FP_Q_MUL_P_MOD_1 is a multiplier of Q and is 1 module P
 uint16_t const FP_Q_MUL_P_MOD_1 = 13695;
-size_t const MAX_NUM_THREADBLOCKS_PER_KERNEL = 1024;
+size_t const MAX_NUM_THREADBLOCKS_PER_KERNEL = 4096;
 int const MAX_NUM_DEVICES = 16;
 constexpr int MAX_TENSOR_DIMS = 4;
 int const DEFAULT_TB_REDUCTION_DIMX = 64;

--- a/include/mirage/persistent_kernel/profiler.h
+++ b/include/mirage/persistent_kernel/profiler.h
@@ -42,9 +42,9 @@ constexpr uint32_t EVENT_INSTANT = 0x2;
 
 __device__ __forceinline__ void sleep_cycles(uint32_t cycles) {
   uint32_t start = 0, now = 0;
-  asm volatile("mov.u32 %0, %globaltimer_lo;" : "=r"(start));
+  asm volatile("mov.u32 %0, %%globaltimer_lo;" : "=r"(start));
   do {
-    asm volatile("mov.u32 %0, %globaltimer_lo;" : "=r"(now));
+    asm volatile("mov.u32 %0, %%globaltimer_lo;" : "=r"(now));
   } while ((now - start) < cycles);
 }
 
@@ -78,7 +78,7 @@ __device__ __forceinline__ uint32_t make_event_tag_instant(uint32_t base_tag,
 
 __device__ __forceinline__ uint32_t get_timestamp() {
   uint32_t volatile ret;
-  asm volatile("mov.u32 %0, %globaltimer_lo;" : "=r"(ret));
+  asm volatile("mov.u32 %0, %%globaltimer_lo;" : "=r"(ret));
   return ret;
 }
 

--- a/include/mirage/persistent_kernel/runtime_header.h
+++ b/include/mirage/persistent_kernel/runtime_header.h
@@ -180,7 +180,9 @@ struct alignas(16) TaskDesc {
     }
 #endif
   }
-  TaskDesc() {}
+  // remove "__host__ __device__" when build and instal mirage
+  // add them when running mirage to compile MPK with clang.
+  __host__ __device__ TaskDesc() {}
   TaskType task_type;
   unsigned variant_id;
   EventId trigger_event;

--- a/python/mirage/persistent_kernel.py
+++ b/python/mirage/persistent_kernel.py
@@ -147,14 +147,34 @@ def get_compile_command(
         f"-DMIRAGE_USE_CUTLASS_KERNEL={'1' if use_cutlass_kernel else '0'}",
     ]
 
+    # flags = [
+    #     "-shared",
+    #     "-std=c++17",
+    #     "-rdc=false" if not use_nvshmem else "-rdc=true",
+    #     "-use_fast_math",
+    #     "-lcuda",
+    #     "-Xcompiler=-fPIC",
+    #     "--expt-relaxed-constexpr",
+    #     "-o",
+    #     py_so_path,
+    # ]
+    # below for clang
     flags = [
         "-shared",
         "-std=c++17",
-        "-rdc=false" if not use_nvshmem else "-rdc=true",
+        # "-rdc=false" if not use_nvshmem else "-rdc=true",
         "-use_fast_math",
         "-lcuda",
-        "-Xcompiler=-fPIC",
-        "--expt-relaxed-constexpr",
+        "-L/usr/local/cuda/lib64",
+        "-lcudart",
+        "-isystem",
+        "/usr/include/c++/11",
+        "-isystem",
+        "/usr/include/x86_64-linux-gnu/c++/11",
+        "-L/usr/lib/x86_64-linux-gnu/libstdc++.so",
+        "-fPIC",
+        # "-Xcompiler=-fPIC",
+        # "--expt-relaxed-constexpr",
         "-o",
         py_so_path,
     ]
@@ -206,7 +226,9 @@ def get_compile_command(
         ]
     else:
         specific_cmd = [
-            "-arch=native",
+            # "-arch=native",
+            # below for clang
+            "--cuda-gpu-arch=sm_80",
         ]
     
     if profiling:
@@ -950,6 +972,8 @@ class PersistentKernel:
             shutil.copy(json_file_path, os.path.join(output_dir, "task_graph.json"))
 
         cc = shutil.which("nvcc")
+        # below for clang
+        cc = shutil.which("clang++-20")
         if cc is None:
             raise RuntimeError(
                 "nvcc not found. Please make sure you have installed CUDA."


### PR DESCRIPTION
**Description of changes:**

Given there are lots of **bit-wise op and index/offset calculation** in the linear kernel for shared memory load/write, it seems `nvcc` don't do very well for these hand-written code, I tried to use clang to build mpk, it show **5%** ITL perf gain on A100 with `--no-use-cutlass-kernel`.

**NCU instruction:**
We could see the clang reduce **~20%** inst for the linear layer.
<img width="1581" height="768" alt="Screenshot from 2025-10-21 20-44-18" src="https://github.com/user-attachments/assets/07961b6c-d4df-48a2-9db0-8f34e2a28a23" />

**CUTLASS linear kernel**

I observed some regression if I try the `clang` for cutlass linear kernel in mpk, it shows some regression for the ITL, I guess that's because the `nvcc` is highly optimized for cutlass, but `clang` is suboptimal for these patterns in cutlass. 


**Related Issues:**

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #


