### PR TITLE
feat: support more hidden_dim in rms_norm to enable all Qwen3 models for demo_hopper

### DIFF
--- a/include/mirage/persistent_kernel/tasks/ampere/rmsnorm.cuh
+++ b/include/mirage/persistent_kernel/tasks/ampere/rmsnorm.cuh
@@ -23,7 +23,20 @@ __device__ __forceinline__ void rms_norm_impl(void const *input_ptr,
                                               float eps) {
   static_assert(BATCH_SIZE == 1);
   extern __shared__ char smem[];
-  constexpr int CHUNK_SIZE = 16 / sizeof(T); // 128b copy-async
+  static_assert(HIDDEN_DIM % NUM_THREADS == 0);
+  constexpr int ELTS_PER_THREAD = HIDDEN_DIM / NUM_THREADS;
+  constexpr int BYTES_PER_THREAD = ELTS_PER_THREAD * sizeof(T);
+  constexpr int BYTES_PER_CP = []() {
+    if constexpr (BYTES_PER_THREAD % 16 == 0) {
+      return 16; // 128bit copy-async
+    } else if constexpr (BYTES_PER_THREAD % 8 == 0) {
+      return 8;  // 64bit copy-async
+    } else {
+      static_assert(BYTES_PER_THREAD % 4 == 0);
+      return 4;  // 32bit copy-async
+    }
+  }();
+  constexpr int CHUNK_SIZE = BYTES_PER_CP / sizeof(T);
   constexpr int TILE_SIZE = NUM_THREADS * CHUNK_SIZE;
   static_assert(HIDDEN_DIM % TILE_SIZE == 0);
   constexpr int NUM_TILES = HIDDEN_DIM / TILE_SIZE;
@@ -53,9 +66,9 @@ __device__ __forceinline__ void rms_norm_impl(void const *input_ptr,
 
   // Warm up input tiles for the first atoms
   {
-    load_smem(shared_input_buffer + threadIdx.x * CHUNK_SIZE,
+    load_smem<T, BYTES_PER_CP>(shared_input_buffer + threadIdx.x * CHUNK_SIZE,
               d_input + threadIdx.x * CHUNK_SIZE);
-    load_smem(shared_weight_buffer + threadIdx.x * CHUNK_SIZE,
+    load_smem<T, BYTES_PER_CP>(shared_weight_buffer + threadIdx.x * CHUNK_SIZE,
               d_weight + threadIdx.x * CHUNK_SIZE);
     cp_async_fence();
   }
@@ -65,10 +78,10 @@ __device__ __forceinline__ void rms_norm_impl(void const *input_ptr,
   for (int for_idx = 0; for_idx < NUM_TILES; for_idx++) {
     // copy
     if (for_idx + 1 < NUM_TILES) {
-      load_smem(shared_input_buffer + threadIdx.x * CHUNK_SIZE +
+      load_smem<T, BYTES_PER_CP>(shared_input_buffer + threadIdx.x * CHUNK_SIZE +
                     (for_idx + 1) * TILE_SIZE,
                 d_input + threadIdx.x * CHUNK_SIZE + (for_idx + 1) * TILE_SIZE);
-      load_smem(shared_weight_buffer + threadIdx.x * CHUNK_SIZE +
+      load_smem<T, BYTES_PER_CP>(shared_weight_buffer + threadIdx.x * CHUNK_SIZE +
                     (for_idx + 1) * TILE_SIZE,
                 d_weight + threadIdx.x * CHUNK_SIZE +
                     (for_idx + 1) * TILE_SIZE);
@@ -115,8 +128,16 @@ __device__ __forceinline__ void rms_norm_impl(void const *input_ptr,
   __syncthreads();
 #pragma unroll
   for (int i = threadIdx.x; i < NUM_CHUNKS_OUTPUT; i += NUM_THREADS) {
-    *((__uint128_t *)((void *)&d_output[i * CHUNK_SIZE])) =
-        *((__uint128_t *)((void *)&shared_output_buffer[i * CHUNK_SIZE]));
+    if constexpr (BYTES_PER_CP == 16) {
+        *((__uint128_t *)((void *)&d_output[i * CHUNK_SIZE])) =
+            *((__uint128_t *)((void *)&shared_output_buffer[i * CHUNK_SIZE]));
+    } else if constexpr (BYTES_PER_CP == 8) {
+        *((uint64_t *)((void *)&d_output[i * CHUNK_SIZE])) =
+            *((uint64_t *)((void *)&shared_output_buffer[i * CHUNK_SIZE]));
+    } else { // BYTES_PER_CP == 4
+        *((uint32_t *)((void *)&d_output[i * CHUNK_SIZE])) =
+            *((uint32_t *)((void *)&shared_output_buffer[i * CHUNK_SIZE]));
+    }
   }
 }
 


### PR DESCRIPTION
**Description of changes:**

The current code can only run successfully with Qwen3-8B and Qwen3-1.7B for demo_hopper.py. However, for Qwen3-0.6B, Qwen3-4B, and Qwen3-32B, it fails due to the `static_assert(HIDDEN_DIM % TILE_SIZE == 0)` check in rms_norm. This PR references the cute implementation:

https://github.com/NVIDIA/cutlass/blob/main/include/cute/arch/copy_sm80.hpp#L55-L65

It modifies the `load_smem` implementation by using `cp.async.ca.shared.global.L2::128B`,  which supporting more cp-sizes, thereby enabling Qwen3-0.6B, Qwen3-4B, and Qwen3-32B. Additionally, other common models' hidden_dim should also be supported as a result of this change.

**Related Issues:**

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #538 
