### PR TITLE
Add -DMIRAGE_BACKEND_USE_CUDA flag to kernel compilation

### DIFF
--- a/python/mirage/kernel.py
+++ b/python/mirage/kernel.py
@@ -143,6 +143,7 @@ def get_cc_cmd(
         f"-I{py_include_dir}",
         f"-I{os.path.join(INCLUDE_PATH, 'mirage/transpiler/runtime')}",
         f"-I{os.path.join(DEPS_PATH, 'cutlass/include')}",
+        "-DMIRAGE_BACKEND_USE_CUDA",
         "-shared",
         "-std=c++17",
         "-use_fast_math",


### PR DESCRIPTION
**Description of Changes**

`nvcc` compilation command in `get_cc_cmd()` was missing the `-DMIRAGE_BACKEND_USE_CUDA` flag, which causes compilation to fail with the following error:

```c
#error "Please define either MIRAGE_BACKEND_USE_CUDA or MIRAGE_BACKEND_USE_NKI."
```

Flag is already present in `persistent_kernel.py` (line 161) and is required by `include/mirage/config.h` to:

* Select the correct backend
* Set memory size constants

Fixes kernel compilation on CUDA systems.
