### PR TITLE
Revert attention kernel page_indices loading logics

### DIFF
--- a/include/mirage/persistent_kernel/tasks/hopper/multitoken_paged_attention_hopper.cuh
+++ b/include/mirage/persistent_kernel/tasks/hopper/multitoken_paged_attention_hopper.cuh
@@ -111,7 +111,15 @@ __device__ __forceinline__ void multitoken_paged_attention_hopper_impl(
 
   // Load the paged KV indices into shared memory
   __shared__ int page_indices[MAX_PAGES_PER_REQUEST];
-
+#pragma unroll
+  for (int i = threadIdx.x; i < num_pages * sizeof(int) / 16;
+       i += NUM_THREADS) {
+    __uint128_t const *src_ptr =
+        reinterpret_cast<__uint128_t const *>(paged_kv_indices_buffer_ptr +
+                                              first_page_pos) + i;
+    __uint128_t *dst_ptr = reinterpret_cast<__uint128_t *>(page_indices) + i;
+    *dst_ptr = *src_ptr;
+  }
   if (num_pages % (16 / sizeof(int)) != 0) {
     int tail_pages = num_pages % (16 / sizeof(int));
     int tail_offset = num_pages - tail_pages;


### PR DESCRIPTION
**Description of changes:**
Bring back the mis-deleted logic loading page_indices from paged_kv_indices_buffer_ptr in attention kernels.
It is required when num_pages (kv cache) is larger than 4 per request, i.e. seq_len > 4 * PAGE_SIZE.


**Related Issues:**

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #


