### PR TITLE
page_indices alignment fix for long context generation

### DIFF
--- a/include/mirage/persistent_kernel/tasks/ampere/multitoken_paged_attention_32_64.cuh
+++ b/include/mirage/persistent_kernel/tasks/ampere/multitoken_paged_attention_32_64.cuh
@@ -105,7 +105,7 @@ __device__ __forceinline__ void multitoken_paged_attention_task_impl_32_64(
   // seq_len = 7 * 64 + 64 = 512
   // num tokens = 8
   // Load the paged KV indices into shared memory
-  __shared__ int page_indices[MAX_PAGES_PER_REQUEST];
+  __shared__ __align__(16) int page_indices[MAX_PAGES_PER_REQUEST];
 #pragma unroll
   for (int i = threadIdx.x; i < num_pages * sizeof(int) / 16;
        i += NUM_THREADS) {

--- a/include/mirage/persistent_kernel/tasks/ampere/multitoken_paged_attention_4_16.cuh
+++ b/include/mirage/persistent_kernel/tasks/ampere/multitoken_paged_attention_4_16.cuh
@@ -98,7 +98,7 @@ __device__ __forceinline__ void multitoken_paged_attention_task_impl_4_16(
   // valid_lens = [seq_len - num_tokens + 1 + i for i in range(num_tokens)]
 
   // Load the paged KV indices into shared memory
-  __shared__ int page_indices[MAX_PAGES_PER_REQUEST];
+  __shared__ __align__(16) int page_indices[MAX_PAGES_PER_REQUEST];
 #pragma unroll
   for (int i = threadIdx.x; i < num_pages * sizeof(int) / 16;
        i += NUM_THREADS) {

--- a/include/mirage/persistent_kernel/tasks/blackwell/attention_sm100.cuh
+++ b/include/mirage/persistent_kernel/tasks/blackwell/attention_sm100.cuh
@@ -103,7 +103,7 @@ __device__ __forceinline__ void multitoken_paged_attention_sm100_task_impl(
     // valid_lens = [seq_len - num_tokens + 1 + i for i in range(num_tokens)]
 
     // Load the paged KV indices into shared memory
-    __shared__ int page_indices[MAX_PAGES_PER_REQUEST];
+    __shared__ __align__(16) int page_indices[MAX_PAGES_PER_REQUEST];
 #pragma unroll
     for (int i = threadIdx.x; i < num_pages * sizeof(int) / 16;
          i += NUM_THREADS) {

--- a/include/mirage/persistent_kernel/tasks/hopper/multitoken_paged_attention_hopper.cuh
+++ b/include/mirage/persistent_kernel/tasks/hopper/multitoken_paged_attention_hopper.cuh
@@ -110,7 +110,7 @@ __device__ __forceinline__ void multitoken_paged_attention_hopper_impl(
   int const prompt_len = seq_len - num_tokens;
 
   // Load the paged KV indices into shared memory
-  __shared__ int page_indices[MAX_PAGES_PER_REQUEST];
+  __shared__ __align__(16) int page_indices[MAX_PAGES_PER_REQUEST];
 #pragma unroll
   for (int i = threadIdx.x; i < num_pages * sizeof(int) / 16;
        i += NUM_THREADS) {


### PR DESCRIPTION
**Description of changes:**
align smem allocated page_indices array to 16 byte for 128b copy, the demo should then be able to do long context/decode generation


**Related Issues:**

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #


