### PR TITLE
Removed -use_fast_math flag from compile command

### DIFF
--- a/python/mirage/kernel.py
+++ b/python/mirage/kernel.py
@@ -146,7 +146,7 @@ def get_cc_cmd(
         "-DMIRAGE_BACKEND_USE_CUDA",
         "-shared",
         "-std=c++17",
-        "-use_fast_math",
+        # "-use_fast_math", # # converts powf to exp(y * log(x)), which returns NaN on negative values
         "-lcublas",
         "-Xcompiler=-fPIC",
         "--expt-relaxed-constexpr",


### PR DESCRIPTION
**Description of changes:**
The use_fast_math flag converts powf to exp(y * log(x)), which produces NaN results when the input contains negative numbers.


