### PR TITLE
swizzling attn tasks to improve prefill performance

### DIFF
--- a/include/mirage/persistent_kernel/persistent_kernel.cuh
+++ b/include/mirage/persistent_kernel/persistent_kernel.cuh
@@ -174,6 +174,7 @@ __global__ void prepare_kernel(RuntimeConfig config,
 // TODO: parallelize this processing
 __device__ __forceinline__ bool
     prepare_next_batch(RuntimeConfig const &config) {
+  // printf("offline prepare: bid: %d, tid: %d\n", blockIdx.x, threadIdx.x);
   __shared__ int smem_kv_indices[MPK_MAX_NUM_PAGES];
   int page_queue_head = *config.page_queue_head;
   int page_queue_tail = *config.page_queue_tail;
@@ -194,6 +195,7 @@ __device__ __forceinline__ bool
         }
       }
       config.step[request_id] = step + num_tokens;
+      // printf("for %d of request %d, before its step: %d, qo_indptr: %d, it get num_tokens: %d\n", i, request_id, step, qo_indptr, num_tokens);
 #ifdef MPK_ENABLE_PROFILING
       if (true)
 #else
@@ -238,10 +240,12 @@ __device__ __forceinline__ bool
       int num_new_tokens = config.prompt_length[request_id] - step;
       if (num_new_tokens > 0) {
         // Prefill requests
+        // printf("Prefill, num_reqs: %d is for request_id: %d, num_tokens: %d\n", num_reqs, request_id, num_tokens);
         num_new_tokens =
             min(num_new_tokens, MPK_MAX_NUM_BATCHED_TOKENS - num_tokens);
       } else {
         // Decode requests
+        // printf("Decode, num_reqs: %d is for request_id: %d, num_tokens: %d\n", num_reqs, request_id, num_tokens);
         num_new_tokens = min(1, MPK_MAX_NUM_BATCHED_TOKENS - num_tokens);
       }
       // Move tokens to input_tokens
@@ -280,6 +284,7 @@ __device__ __forceinline__ bool
     config.qo_indptr_buffer[num_reqs] = num_tokens;
     config.paged_kv_indptr_buffer[num_reqs] = num_pages;
     // Prefill request
+    // printf("Addtional Prefill, num_reqs: %d is for request_id: %d, num_tokens: %d\n", num_reqs, next_request_id, num_tokens);
     int num_new_tokens = min(config.prompt_length[next_request_id],
                              MPK_MAX_NUM_BATCHED_TOKENS - num_tokens);
     // Move tokens to input tokens
@@ -556,6 +561,25 @@ __device__ __forceinline__ void execute_worker(RuntimeConfig config) {
                                       config.per_worker_queue_len]);
       }
       __syncthreads();
+      // if (threadIdx.x == 0 && blockIdx.x == 25) {
+      //   for (int i = 0; i < num_loaded_tasks; i++) {
+      //     printf(
+      //         "[%d][FTCH] worker_id(%d) queue_idx(%d) next_task_pos(%llu, "
+      //         "%llu) last_task_pos(%llu, %llu) "
+      //         "task_id(%llu) task_type(%d) event_id(%llx) \n",
+      //         config.my_gpu_id,
+      //         worker_id,
+      //         queue_idx,
+      //         next_task_pos[0],
+      //         next_task_pos[1],
+      //         last_task_pos[0],
+      //         last_task_pos[1],
+      //         get_task_position_index(task_ids[i]),
+      //         config.all_tasks[get_task_position_index(task_ids[i])].task_type,
+      //         config.all_tasks[get_task_position_index(task_ids[i])]
+      //             .trigger_event);
+      //   }
+      // }
       if (threadIdx.x == 0) {
 #ifdef MPK_ENABLE_VERBOSE
         for (int i = 0; i < num_loaded_tasks; i++) {
@@ -642,6 +666,10 @@ __device__ __forceinline__ void execute_worker(RuntimeConfig config) {
     } else if (task_desc->task_type == TASK_BEGIN_TASK_GRAPH) {
       // Do nothing
     } else {
+      // if (threadIdx.x == 0 && blockIdx.x == 25) {
+      //   printf("[worker] _execute_task EXECUTE_TASK %d\n",
+      //          task_desc->task_type);
+      // }
 #ifdef MPK_ENABLE_VERBOSE
       if (threadIdx.x == 0) {
         printf("[worker] _execute_task EXECUTE_TASK %d\n",
@@ -844,6 +872,7 @@ __device__ __forceinline__ void execute_scheduler(RuntimeConfig config,
       EventId event_id = ld_relaxed_gpu_u64(
           &sched_queues[queue_idx]
                        [cur_event_pos[queue_idx] % config.per_sched_queue_len]);
+      // printf("event_id: %d, bid: %d, tid: %d\n", event_id, blockIdx.x, threadIdx.x);
       EventDesc e = config.all_events[event_id];
       if (is_termination_event(event_id, e)) {
         // terminate all workers
@@ -926,6 +955,19 @@ __device__ __forceinline__ void execute_scheduler(RuntimeConfig config,
               atom_add_release_gpu_u64(
                   &config.worker_queue_last_ready_task_id[next_worker], 1);
 
+              // if (next_worker == 25) {
+              //   printf("[%d][SCHD] EVENT_LAUNCH_DEPENDENT_TASKS schd_id(%d) iter_num(%llu) "
+              //         "task_idx(%llu) "
+              //         "worker_id(%d) "
+              //         "worker_last_ready_pos(%llu)\n",
+              //         config.my_gpu_id,
+              //         sched_id,
+              //         iteration_num,
+              //         position_index,
+              //         next_worker,
+              //         last_task_id + 1);
+              // }
+
 #ifdef MPK_ENABLE_VERBOSE
               if (sched_id == 0) {
                 printf("[%d][SCHD] EVENT_LAUNCH_DEPENDENT_TASKS schd_id(%d) "
@@ -952,6 +994,9 @@ __device__ __forceinline__ void execute_scheduler(RuntimeConfig config,
           }
         }
       } else {
+        // if (e.event_type == EVENT_EMPTY) {
+        //   printf("EVENT_EMPTY 222: bid: %d, tid: %d\n", blockIdx.x, threadIdx.x);
+        // }
         TaskId my_first_task = e.first_task_id, my_last_task = e.last_task_id;
         if (e.event_type == EVENT_LAUNCH_MASSIVE_TASKS) {
           // Split event across local schedulers
@@ -979,6 +1024,18 @@ __device__ __forceinline__ void execute_scheduler(RuntimeConfig config,
           // worker CTAs before we increase its last_ready_task_id
           atom_add_release_gpu_u64(
               &config.worker_queue_last_ready_task_id[next_worker], 1);
+          // if (next_worker == 25) {
+          //   printf("[%d][SCHD] EXECUTE_TASK schd_id(%d) iter_num(%llu) "
+          //        "task_idx(%llu) "
+          //        "worker_id(%d) "
+          //        "worker_last_ready_pos(%llu)\n",
+          //        config.my_gpu_id,
+          //        sched_id,
+          //        iteration_num,
+          //        i,
+          //        next_worker,
+          //        last_task_id + 1);
+          // }
 
 #ifdef MPK_ENABLE_VERBOSE
           printf("[%d][SCHD] EXECUTE_TASK schd_id(%d) iter_num(%llu) "

--- a/include/mirage/persistent_kernel/tasks/ampere/multitoken_paged_attention_32_64.cuh
+++ b/include/mirage/persistent_kernel/tasks/ampere/multitoken_paged_attention_32_64.cuh
@@ -87,6 +87,12 @@ __device__ __forceinline__ void multitoken_paged_attention_task_impl_32_64(
   int const first_token_pos = qo_indptr_buffer_ptr[request_id];
   int const last_token_pos = qo_indptr_buffer_ptr[request_id + 1];
   // Exit the current task is number of query tokens is zero
+  // if (threadIdx.x == 0 && (blockIdx.x == 25 || blockIdx.x == 24)) {
+  //   printf("blockIdx.x: %d, first_token_pos: %d, last_token_pos: %d\n", blockIdx.x, first_token_pos, last_token_pos);
+  // }
+  // if (threadIdx.x == 0 && (blockIdx.x == 18 || blockIdx.x == 17)) {
+  //   printf("blockIdx.x: %d, first_token_pos: %d, last_token_pos: %d\n", blockIdx.x, first_token_pos, last_token_pos);
+  // }
   if (first_token_pos == last_token_pos) {
     return;
   }

--- a/include/mirage/persistent_kernel/tasks/ampere/multitoken_paged_attention_4_16.cuh
+++ b/include/mirage/persistent_kernel/tasks/ampere/multitoken_paged_attention_4_16.cuh
@@ -81,6 +81,9 @@ __device__ __forceinline__ void multitoken_paged_attention_task_impl_4_16(
   int const first_token_pos = qo_indptr_buffer_ptr[request_id];
   int const last_token_pos = qo_indptr_buffer_ptr[request_id + 1];
   // Exit the current task is number of query tokens is zero
+  // if (threadIdx.x == 0 && (blockIdx.x == 18 || blockIdx.x == 17)) {
+  //   printf("4_16 paged attn kernel, blockIdx.x: %d, first_token_pos: %d, last_token_pos: %d\n", blockIdx.x, first_token_pos, last_token_pos);
+  // }
   if (first_token_pos == last_token_pos) {
     return;
   }

--- a/src/kernel/runtime.cc
+++ b/src/kernel/runtime.cc
@@ -67,12 +67,18 @@ void dfs_create_events_add_tasks(
     std::vector<FullTaskDesc> const &cur_op_tasks,
     std::map<dim3, TaskId, Dim3Comparator> const &pre_task_map,
     std::map<dim3, TaskId, Dim3Comparator> &cur_task_map) {
+  if (all_tasks.size() < 400 && cur_op_tasks.size() == 128) {
+    printf("cccccc consumer_hi_bid.x: %d, consumer_hi_bid.y: %d, consumer_hi_bid.z: %d\n", consumer_hi_bid.x, consumer_hi_bid.y, consumer_hi_bid.z);
+  }
   if (depth >= mirage::config::MAX_TENSOR_DIMS) {
     EventDesc event_desc;
     event_desc.num_triggers = 0;
     event_desc.first_task_id = all_tasks.size();
     // Add consumer tasks
     dim3 bid;
+    if (all_tasks.size() < 400 && cur_op_tasks.size() == 128) {
+      printf("consumer_hi_bid.x: %d, consumer_hi_bid.y: %d, consumer_hi_bid.z: %d\n", consumer_hi_bid.x, consumer_hi_bid.y, consumer_hi_bid.z);
+    }
     for (bid.x = consumer_lo_bid.x; bid.x < consumer_hi_bid.x; bid.x++) {
       for (bid.y = consumer_lo_bid.y; bid.y < consumer_hi_bid.y; bid.y++) {
         for (bid.z = consumer_lo_bid.z; bid.z < consumer_hi_bid.z; bid.z++) {
@@ -80,6 +86,9 @@ void dfs_create_events_add_tasks(
           int offset = bid.x * consumer_grid_dim.y * consumer_grid_dim.z +
                        bid.y * consumer_grid_dim.z + bid.z;
           all_tasks.push_back(cur_op_tasks[offset]);
+          if (all_tasks.size() < 400 && cur_op_tasks.size() == 128) {
+            printf("push_back for offset: %d, its bid: (%d, %d), its request_id: %d\n", offset, bid.x, bid.y, cur_op_tasks[offset].task_metadata.request_id);
+          }
         }
       }
     }
@@ -363,6 +372,9 @@ void register_mugraph(
     }
     // Step 1: add all tasks based on their blockIdx
     // (bid.x, bid.y, bid.z) ordering
+    if (task_type == TASK_PAGED_ATTENTION_1) {
+      printf("x.dim: %d, y.dim: %d\n", bgraph.grid_dim.x, bgraph.grid_dim.y);
+    }
     for (bid.x = 0; bid.x < bgraph.grid_dim.x; bid.x++) {
       for (bid.y = 0; bid.y < bgraph.grid_dim.y; bid.y++) {
         for (bid.z = 0; bid.z < bgraph.grid_dim.z; bid.z++) {
@@ -433,6 +445,44 @@ void register_mugraph(
         }
       }
     }
+    if (task_type == TASK_PAGED_ATTENTION_1 && all_tasks.size() < 400) {
+      const int last_task_idx = tasks.size() - 1;
+      const int first_attn_tasks_idx = last_task_idx - (bgraph.grid_dim.x * bgraph.grid_dim.y * bgraph.grid_dim.z) + 1;
+      for (int i = first_attn_tasks_idx; i <= last_task_idx; i ++) {
+        int x = (i - first_attn_tasks_idx) / bgraph.grid_dim.y;
+        int y = (i - first_attn_tasks_idx) % bgraph.grid_dim.y;
+        printf("for task %d, its bid: (%d, %d), its request_id: %d\n", i, x, y, tasks[i].task_metadata.request_id);
+      }
+      printf("aaaaa bgraph.grid_dim.x: %d, bgraph.grid_dim.y: %d, bgraph.grid_dim.z: %d\n", bgraph.grid_dim.x, bgraph.grid_dim.y, bgraph.grid_dim.z);
+    }
+
+
+
+    if (task_type == TASK_PAGED_ATTENTION_1) {
+      // swizzle for attn task
+      const int task_cnt = tasks.size();
+      std::vector<FullTaskDesc> tmp_tasks(task_cnt);
+      for (int x = 0; x < bgraph.grid_dim.x; x ++) {
+        for (int y = 0; y < bgraph.grid_dim.y; y ++) {
+          // do swizzling here
+          int pre_offset = x * bgraph.grid_dim.y + y;
+          int new_x = x ^ y;
+          int cur_offset = new_x * bgraph.grid_dim.y + y;
+          tmp_tasks[cur_offset] = tasks[pre_offset];
+        }
+      }
+      tasks = std::move(tmp_tasks);
+
+      if (task_type == TASK_PAGED_ATTENTION_1 && all_tasks.size() < 400) {
+        const int last_task_idx = tasks.size() - 1;
+        const int first_attn_tasks_idx = last_task_idx - (bgraph.grid_dim.x * bgraph.grid_dim.y * bgraph.grid_dim.z) + 1;
+        for (int i = first_attn_tasks_idx; i <= last_task_idx; i ++) {
+          int x = (i - first_attn_tasks_idx) / bgraph.grid_dim.y;
+          int y = (i - first_attn_tasks_idx) % bgraph.grid_dim.y;
+          printf("for swizzled task %d, its bid: (%d, %d), its request_id: %d\n", i, x, y, tasks[i].task_metadata.request_id);
+        }
+      }
+    }
     // Step 2: create events between operators
     if (pre_op == nullptr) {
       dim3 bid;
@@ -491,6 +541,9 @@ void register_mugraph(
       std::vector<int> event_dims(mirage::config::MAX_TENSOR_DIMS, 1);
       for (int d = 0; d < mirage::config::MAX_TENSOR_DIMS; d++) {
         event_dims[d] = std::gcd(producer_partition[d], consumer_partition[d]);
+      }
+      if (task_type == TASK_PAGED_ATTENTION_1 && all_tasks.size() < 400) {
+        printf("bbbbb bgraph.grid_dim.x: %d, bgraph.grid_dim.y: %d, bgraph.grid_dim.z: %d\n", bgraph.grid_dim.x, bgraph.grid_dim.y, bgraph.grid_dim.z);
       }
       dfs_create_events_add_tasks(0,                       /*depth*/
                                   my_gpu_id,               /*my_gpu_id*/


### PR DESCRIPTION
**Description of changes:**

This PR try to swizzling the attn tasks, which could dispatch consecutive attention tasks in a same worker to different workers, which improve **15%** prefill performance for `Qwen3-8B` on A100.

## Background
When it run MPK with batch size as **16**, like `python demo/qwen3/demo.py --use-mirage --max-num-batched-requests=16`, we may see some attn task are consecutive even though there are many idle workers, which looks like:
<img width="1262" height="446" alt="image" src="https://github.com/user-attachments/assets/2adb5d56-0a4a-44c0-bdb2-18bd0c693fa4" />

That's because there are **128** tasks for attention (but only **8** will do the computation, and the stride between them is **16**), and there are only **96** workers on A100.

Given that MPK only have `96 = 6 * 16` workers, but there're `128 = 8 * 16` tasks, so there will be **2** workers have to execute **2** attn tasks, which make then attention time cost double.

## Solution
This issue is very similar to **bank conflict** in GPU, there're several tasks will go to same worker (just like some wavefronts go to the same bank in GPU), so we could borrow the  idea of **"swizzling"** to solve this issue, after the swizzling, we could see:

<img width="906" height="420" alt="Screenshot from 2026-01-17 22-05-40" src="https://github.com/user-attachments/assets/b0757a6f-415d-49d7-9a91-062f46d57716" />

It improves prefill performance by **~15%** (from 35ms to 30ms) on A100 (with command `python demo/qwen3/demo.py --use-mirage --max-num-batched-requests=16 --max-seq-length=40`).

## Alternative
The solution is a little trick and fragile, if mpk want to solve this issue more elegant I guess we could do more optimization at somewhere else, like:
https://github.com/mirage-project/mirage/blob/3c7a12005d82261b12d5179d4e60332679c9d9f5/src/kernel/runtime.cc#L76-L85


**Related Issues:**

Linked Issues:
- Issue #603

Issues closed by this PR:
- Closes #


