### PR TITLE
fix: add lib/stubs to CUDA library search paths in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ else:
 cuda_include_dir = os.path.join(cuda_home, "include")
 cuda_library_dirs = [
     os.path.join(cuda_home, "lib"),
+    os.path.join(cuda_home, "lib", "stubs"),
     os.path.join(cuda_home, "lib64"),
     os.path.join(cuda_home, "lib64", "stubs"),
 ]


### PR DESCRIPTION
**Description of changes:**
  - Fix missing `lib/stubs` in CUDA library search paths in `setup.py`, which caused `-lcuda` linker failure on systems where `libcuda.so` is under `lib/stubs/` rather than `lib64/stubs/` (e.g. my NixOS)


