### PR TITLE
Parallel-path DAG compilation support in register_mugraph

### DIFF
--- a/include/mirage/kernel/annotated_graph.h
+++ b/include/mirage/kernel/annotated_graph.h
@@ -1,0 +1,120 @@
+/* Copyright 2025 CMU
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#pragma once
+
+#include "mirage/config.h"
+#include "mirage/kernel/customized.h"
+#include "mirage/kernel/graph.h"
+#include "mirage/persistent_kernel/runtime_header.h"
+
+#include <array>
+#include <cstddef>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <vector>
+
+namespace mirage {
+namespace kernel {
+
+// A per-side view of a layer's task grid with respect to a single producer or
+// consumer edge (or the unified LCM result at a fork/join).
+//
+// Layout:
+//   event_dim[0..MAX_TENSOR_DIMS): number of events along each TENSOR
+//     dimension. Product across these dims = total events at this boundary.
+//   last3[0..2]: block of tasks per event along each GRID axis (x, y, z).
+//     Derived as grid_dim[g] / event_dim[axis_map[g]] when axis_map[g] >= 0,
+//     else grid_dim[g] (unmapped / replicated axis).
+//   grid_dim: the owning layer's bgraph grid dimensions.
+//   axis_map: input_map (consumer-side) or output_map (producer-side) from
+//     the bridging tensor; grid-axis -> tensor-dim (or -1 if replicated).
+struct TaskView {
+  std::array<int, mirage::config::MAX_TENSOR_DIMS> event_dim;
+  std::array<int, 3> last3;
+  dim3 grid_dim;
+  int3 axis_map;
+};
+
+// One data-flow edge producer_layer -> consumer_layer on a specific bridging
+// DTensor (identified by the producer's out_slot).
+struct EdgeInfo {
+  int prod_layer;
+  int cons_layer;
+  int out_slot;
+  int in_slot;
+  size_t tensor_guid;
+  int3 output_map;
+  int3 input_map;
+  std::array<int, mirage::config::MAX_TENSOR_DIMS> event_dim;
+  TaskView producer_side_view;
+  TaskView consumer_side_view;
+  int fork_group_id = -1;
+  int join_group_id = -1;
+  bool is_residual_stripped = false;
+};
+
+// Group of edges sharing a single fork-producer layer; the LCM-adjusted
+// last3 is unified across all branches (in producer grid-axis space).
+struct ForkGroupInfo {
+  int producer_layer;
+  std::vector<int> outgoing_edges;
+  std::array<int, 3> lcm_last3;
+};
+
+// Group of edges sharing a single join-consumer layer; LCM-adjusted last3
+// unified across incoming branches (in consumer grid-axis space).
+struct JoinGroupInfo {
+  int consumer_layer;
+  std::vector<int> incoming_edges;
+  std::array<int, 3> lcm_last3;
+};
+
+struct LayerInfo {
+  mirage::kernel::KNCustomizedOp const *op = nullptr;
+  std::vector<int> in_edges;
+  std::vector<int> out_edges;
+  bool is_fork_producer = false;
+  bool is_join_consumer = false;
+  int fork_parent_group = -1;
+  int fork_branch_index = -1;
+  mirage::runtime::TaskType task_type;
+  int variant_id = 0;
+  int num_inputs = 0;
+  int num_outputs = 0;
+};
+
+struct AnnotatedGraph {
+  std::vector<LayerInfo> layers;
+  std::vector<int> ordered_layers;
+  std::vector<EdgeInfo> edges;
+  std::vector<ForkGroupInfo> fork_groups;
+  std::vector<JoinGroupInfo> join_groups;
+  std::vector<EdgeInfo> stripped_residual_edges;
+};
+
+using TaskConfigMap = std::unordered_map<
+    mirage::kernel::KNOperator const *,
+    std::tuple<int, int, mirage::runtime::TaskType, int>>;
+
+// Build the AnnotatedGraph from a KNGraph. Throws std::runtime_error on:
+//   - cycles in the DAG (should be impossible under most-recent-writer)
+//   - disallowed role combinations (case 2: join-consumer + fork-consumer;
+//     case 3: join-producer + fork-producer)
+//   - fork/join LCM that exceeds the producer's / consumer's grid_dim.
+AnnotatedGraph build_annotated_graph(mirage::kernel::Graph const &kn_graph,
+                                     TaskConfigMap const &task_configs);
+
+// Optional: dumps the AnnotatedGraph to JSON for debugging when
+// MIRAGE_DUMP_ANNOTATED_GRAPH is set. Returns empty string when disabled.
+std::string maybe_dump_annotated_graph(AnnotatedGraph const &ag);
+
+} // namespace kernel
+} // namespace mirage

--- a/include/mirage/kernel/annotated_graph.h
+++ b/include/mirage/kernel/annotated_graph.h
@@ -150,9 +150,9 @@ struct AnnotatedGraph {
   std::vector<EdgeInfo> stripped_residual_edges;
 };
 
-using TaskConfigMap = std::unordered_map<
-    mirage::kernel::KNOperator const *,
-    std::tuple<int, int, mirage::runtime::TaskType, int>>;
+using TaskConfigMap =
+    std::unordered_map<mirage::kernel::KNOperator const *,
+                       std::tuple<int, int, mirage::runtime::TaskType, int>>;
 
 // Build the AnnotatedGraph from a KNGraph.
 //

--- a/include/mirage/kernel/annotated_graph.h
+++ b/include/mirage/kernel/annotated_graph.h
@@ -27,12 +27,25 @@ namespace kernel {
 // A per-side view of a layer's task grid with respect to a single producer or
 // consumer edge (or the unified LCM result at a fork/join).
 //
-// Layout:
-//   event_dim[0..MAX_TENSOR_DIMS): number of events along each TENSOR
-//     dimension. Product across these dims = total events at this boundary.
+// Why per-side (not per-layer): a layer's consumer-side view (which drives
+// its tasks' `trigger_event` assignment, i.e. the event that LAUNCHES each
+// task post-prelaunch) is independent from its producer-side view (which
+// drives `dependent_event`, i.e. the event that each task FIRES on
+// completion). For layers playing both case-1 (join-consumer + fork-producer)
+// or case-4 (join-producer + fork-consumer) roles, the two views are
+// analyzed by separate LCM passes and never conflict because they write to
+// different slots on the FullTaskDesc.
+//
+// Why event_dim indexes tensor dims but last3 indexes grid axes: the event
+// grid lives in the bridging tensor's dim space (so it's invariant to how
+// each side's grid maps to it); the task block per event is a sub-cuboid
+// of the OWNING layer's bid grid (so grid-axis coords are natural).
+//   event_dim[0..MAX_TENSOR_DIMS): count of events along each TENSOR dim.
+//     Product = total events at this boundary.
 //   last3[0..2]: block of tasks per event along each GRID axis (x, y, z).
 //     Derived as grid_dim[g] / event_dim[axis_map[g]] when axis_map[g] >= 0,
-//     else grid_dim[g] (unmapped / replicated axis).
+//     else grid_dim[g] (axis is replicated and every task on it observes
+//     the full tensor).
 //   grid_dim: the owning layer's bgraph grid dimensions.
 //   axis_map: input_map (consumer-side) or output_map (producer-side) from
 //     the bridging tensor; grid-axis -> tensor-dim (or -1 if replicated).
@@ -44,7 +57,21 @@ struct TaskView {
 };
 
 // One data-flow edge producer_layer -> consumer_layer on a specific bridging
-// DTensor (identified by the producer's out_slot).
+// DTensor.
+//
+// Edge identity is (prod_layer, out_slot, cons_layer, in_slot), NOT the
+// tensor guid. qwen3 reuses physical tensor buffers aggressively (e.g.
+// x = attn_out; x = mlp_out), so a single guid can have multiple distinct
+// producers across a program; using (prod, out_slot) pins each read to the
+// writer that was current at read-registration time, which is the behavior
+// we want and trivially avoids false cycles.
+//
+// After fork/join LCM, `event_dim` may be reduced on the tensor dims that
+// corresponded to grid axes where the LCM absorbed a factor, and the two
+// task_views are recomputed accordingly. Residual edges are kept in the
+// edge list (is_residual_stripped = true) but excluded from per-layer
+// in_edges/out_edges so they don't influence role classification or event
+// emission.
 struct EdgeInfo {
   int prod_layer;
   int cons_layer;
@@ -61,16 +88,28 @@ struct EdgeInfo {
   bool is_residual_stripped = false;
 };
 
-// Group of edges sharing a single fork-producer layer; the LCM-adjusted
-// last3 is unified across all branches (in producer grid-axis space).
+// Group of edges sharing a single fork-producer layer.
+//
+// The LCM is taken on grid-axis space (not tensor-dim space) because the
+// producer's grid is shared across all branches (only one producer layer),
+// while the bridging tensor and the consumer grids/input_maps can differ
+// per branch. Grid-axis LCM is therefore the only frame that makes all
+// branches commensurable. After LCM, every branch's producer-side last3
+// equals `lcm_last3`, which lets us lay out each fork event as a single
+// contiguous producer sub-cuboid feeding an interleaved slab of consumer
+// tasks drawn from all branches.
 struct ForkGroupInfo {
   int producer_layer;
   std::vector<int> outgoing_edges;
   std::array<int, 3> lcm_last3;
 };
 
-// Group of edges sharing a single join-consumer layer; LCM-adjusted last3
-// unified across incoming branches (in consumer grid-axis space).
+// Group of edges sharing a single join-consumer layer.
+//
+// Symmetric to ForkGroupInfo: the consumer's grid is shared across incoming
+// branches, so we LCM on consumer grid axes. Each join event corresponds to
+// one sub-cuboid of the consumer's grid and collects completion signals
+// from N producer sub-cuboids (one per incoming edge).
 struct JoinGroupInfo {
   int consumer_layer;
   std::vector<int> incoming_edges;
@@ -79,10 +118,21 @@ struct JoinGroupInfo {
 
 struct LayerInfo {
   mirage::kernel::KNCustomizedOp const *op = nullptr;
+  // Non-stripped edges only. in/out_edges.size() reflects the DAG topology
+  // used by classification, not the raw incoming/outgoing tensor count.
   std::vector<int> in_edges;
   std::vector<int> out_edges;
+  // is_fork_producer: >=2 DISTINCT downstream consumer layers. Multiple
+  // out-edges to the same consumer (e.g. a producer with 2 output tensors
+  // both feeding the same next op, as in qwen3) are NOT a fork: they stay
+  // on one normal chain edge-group from the dependency perspective.
   bool is_fork_producer = false;
+  // is_join_consumer: >=2 DISTINCT upstream producer layers. Same "distinct"
+  // rule for the symmetric reason.
   bool is_join_consumer = false;
+  // Set on the immediate fork-consumer layers (those directly triggered by
+  // a fork event). branch_index 0 is the "bundle head" that actually runs
+  // the interleaved emission; other branches are skipped by the outer loop.
   int fork_parent_group = -1;
   int fork_branch_index = -1;
   mirage::runtime::TaskType task_type;
@@ -104,11 +154,34 @@ using TaskConfigMap = std::unordered_map<
     mirage::kernel::KNOperator const *,
     std::tuple<int, int, mirage::runtime::TaskType, int>>;
 
-// Build the AnnotatedGraph from a KNGraph. Throws std::runtime_error on:
-//   - cycles in the DAG (should be impossible under most-recent-writer)
-//   - disallowed role combinations (case 2: join-consumer + fork-consumer;
-//     case 3: join-producer + fork-producer)
-//   - fork/join LCM that exceeds the producer's / consumer's grid_dim.
+// Build the AnnotatedGraph from a KNGraph.
+//
+// Pipeline (see annotated_graph.cc for step-by-step):
+//   (a) DAG construction with most-recent-writer: walk ops in insertion
+//       order, bind each input to the latest prior writer of its guid.
+//   (b) Cycle check via Kahn's algorithm.
+//   (c) Residual stripping: drop any edge u->v that coexists with a path
+//       u->...->v of length >=2 (transitive dependency makes the direct
+//       edge redundant; this converts e.g. transformer residuals into
+//       plain chains).
+//   (d) Role classification (distinct consumers/producers counted).
+//   (e) Case 2/3 rejection (see docs/mpk/parallel_path_design.md).
+//   (f) Topological ordering (determines task emission order).
+//   (g) Per-edge GCD event_dim + per-side TaskViews.
+//   (h) Fork LCM unifies producer-side last3 across all fork branches.
+//   (i) Join LCM unifies consumer-side last3 across all join incoming edges.
+//   (j) Tag immediate fork-consumer layers with their parent group and
+//       branch index for interleaved emission.
+//
+// Throws std::runtime_error on:
+//   - cycles (should be impossible under most-recent-writer for well-formed
+//     programs; acts as a defensive guard)
+//   - disallowed role combinations (case 2: join-consumer + fork-consumer
+//     would need two trigger_events on one task; case 3: join-producer +
+//     fork-producer would need two dependent_events on one task)
+//   - a fork/join LCM that doesn't divide the shared grid_dim (shouldn't
+//     happen if per-edge event_dims were correct GCDs of valid partitions,
+//     since the LCM of divisors of N always divides N).
 AnnotatedGraph build_annotated_graph(mirage::kernel::Graph const &kn_graph,
                                      TaskConfigMap const &task_configs);
 

--- a/src/kernel/annotated_graph.cc
+++ b/src/kernel/annotated_graph.cc
@@ -409,16 +409,66 @@ AnnotatedGraph build_annotated_graph(mirage::kernel::Graph const &kn_graph,
   }
 
   // ---------------------------------------------------------------------
-  // Step (f): topological ordering (Kahn's). Tiebreaker: prefer the smallest
-  // layer index, which preserves original insertion order when unconstrained.
+  // Step (f): topological ordering (Kahn's) with a (depth, index) tie-break.
+  //
+  // Why depth, not just layer index: for a symmetric fork like
+  // A -> B -> C -> D and A -> E -> F -> G, an index-only tie-break yields
+  // [A, B, C, D, E, F, G] (chain alpha emitted fully before chain beta).
+  // That means C and F's chain events end up on opposite ends of the
+  // prelaunch queue, even though they are ready to run at the same depth.
+  // Using depth-first-ascending, index-second gives [A, B, E, C, F, D, G]:
+  // within each depth stratum we still respect original insertion order,
+  // but across strata we advance both chains in lockstep. B and E are
+  // (required) interleaved within a single fork event by the bundle-head
+  // emission (runtime.cc); the downstream layers C/F/D/G are interleaved
+  // here via the topo order. For pure chain graphs (e.g. qwen3 after
+  // residual stripping) depth == layer index, so the output matches the
+  // previous insertion-order behaviour.
+  //
+  // Depth is defined as 0 for layers with no incoming edge, and
+  // depth[v] = max_{(u, v) in E} (depth[u] + 1) otherwise. We compute it
+  // by a first Kahn pass (any valid order suffices) and then run a second
+  // Kahn pass using the depth array as the primary tie-break key.
   // ---------------------------------------------------------------------
+  std::vector<int> depth(V, 0);
   {
+    // First pass: any valid topo order to compute depth.
+    std::vector<int> in_deg_tmp(V, 0);
+    for (int i = 0; i < V; i++) {
+      in_deg_tmp[i] = (int)ag.layers[i].in_edges.size();
+    }
+    std::queue<int> q;
+    for (int i = 0; i < V; i++) {
+      if (in_deg_tmp[i] == 0) {
+        q.push(i);
+      }
+    }
+    while (!q.empty()) {
+      int u = q.front();
+      q.pop();
+      for (int eidx : ag.layers[u].out_edges) {
+        int v = ag.edges[eidx].cons_layer;
+        depth[v] = std::max(depth[v], depth[u] + 1);
+        if (--in_deg_tmp[v] == 0) {
+          q.push(v);
+        }
+      }
+    }
+  }
+  {
+    // Second pass: min-heap keyed by (depth, index). Smaller depth first;
+    // within the same depth, smaller original-insertion index first.
     std::vector<int> in_deg(V, 0);
     for (int i = 0; i < V; i++) {
       in_deg[i] = (int)ag.layers[i].in_edges.size();
     }
-    // min-heap priority queue by layer index
-    std::priority_queue<int, std::vector<int>, std::greater<int>> pq;
+    auto cmp = [&depth](int a, int b) {
+      if (depth[a] != depth[b]) {
+        return depth[a] > depth[b];
+      }
+      return a > b;
+    };
+    std::priority_queue<int, std::vector<int>, decltype(cmp)> pq(cmp);
     for (int i = 0; i < V; i++) {
       if (in_deg[i] == 0) {
         pq.push(i);
@@ -664,6 +714,14 @@ std::string maybe_dump_annotated_graph(AnnotatedGraph const &ag) {
        << (L.is_join_consumer ? " [JOIN]" : "")
        << (L.fork_parent_group >= 0 ? " [fork-consumer]" : "") << "\n";
   }
+  os << "  ordered_layers: [";
+  for (size_t i = 0; i < ag.ordered_layers.size(); i++) {
+    if (i > 0) {
+      os << ", ";
+    }
+    os << ag.ordered_layers[i];
+  }
+  os << "]\n";
   return os.str();
 }
 

--- a/src/kernel/annotated_graph.cc
+++ b/src/kernel/annotated_graph.cc
@@ -1,0 +1,611 @@
+/* Copyright 2025 CMU
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#include "mirage/kernel/annotated_graph.h"
+#include "mirage/threadblock/operator.h"
+
+#include <algorithm>
+#include <cstdlib>
+#include <numeric>
+#include <queue>
+#include <sstream>
+#include <stdexcept>
+#include <unordered_map>
+#include <unordered_set>
+
+namespace mirage {
+namespace kernel {
+
+namespace {
+
+namespace tb = mirage::threadblock;
+
+int axis_lookup(int3 const &m, int g) {
+  return (g == 0) ? m.x : (g == 1) ? m.y : m.z;
+}
+
+int grid_lookup(dim3 const &d, int g) {
+  return (g == 0) ? (int)d.x : (g == 1) ? (int)d.y : (int)d.z;
+}
+
+// Compute last3 for a task_view: last3[g] = grid[g] / event_dim[axis_map[g]]
+// when axis_map[g] >= 0 (axis participates in event partition); else
+// last3[g] = grid[g] (replicated / unmapped axis).
+std::array<int, 3> derive_last3(
+    std::array<int, mirage::config::MAX_TENSOR_DIMS> const &event_dim,
+    dim3 const &grid,
+    int3 const &axis_map) {
+  std::array<int, 3> last3{};
+  for (int g = 0; g < 3; g++) {
+    int d = axis_lookup(axis_map, g);
+    int gsize = grid_lookup(grid, g);
+    if (d >= 0 && d < mirage::config::MAX_TENSOR_DIMS) {
+      int ev = event_dim[d];
+      last3[g] = (ev > 0) ? (gsize / ev) : gsize;
+    } else {
+      last3[g] = gsize;
+    }
+  }
+  return last3;
+}
+
+// Build per-tensor-dim partition vector from a layer's grid_dim and a map.
+std::array<int, mirage::config::MAX_TENSOR_DIMS> build_partition(
+    dim3 const &grid, int3 const &m) {
+  std::array<int, mirage::config::MAX_TENSOR_DIMS> part{};
+  for (int d = 0; d < (int)mirage::config::MAX_TENSOR_DIMS; d++) {
+    part[d] = 1;
+  }
+  if (m.x >= 0 && m.x < (int)mirage::config::MAX_TENSOR_DIMS) {
+    part[m.x] = (int)grid.x;
+  }
+  if (m.y >= 0 && m.y < (int)mirage::config::MAX_TENSOR_DIMS) {
+    part[m.y] = (int)grid.y;
+  }
+  if (m.z >= 0 && m.z < (int)mirage::config::MAX_TENSOR_DIMS) {
+    part[m.z] = (int)grid.z;
+  }
+  return part;
+}
+
+// Parse bgraph.operators into (inputs, outputs) by position. Outputs are also
+// TB_INPUT_OPs (see runtime.cc:266-274); their input_map field is the
+// output_map.
+void split_bgraph_ops(tb::Graph const &bgraph,
+                      int num_inputs,
+                      std::vector<tb::TBInputOp *> &inputs,
+                      std::vector<tb::TBInputOp *> &outputs) {
+  for (auto const &op : bgraph.operators) {
+    if (op->op_type != mirage::type::TB_INPUT_OP) {
+      continue;
+    }
+    auto *ip = static_cast<tb::TBInputOp *>(op);
+    if ((int)inputs.size() < num_inputs) {
+      inputs.push_back(ip);
+    } else {
+      outputs.push_back(ip);
+    }
+  }
+}
+
+} // namespace
+
+AnnotatedGraph build_annotated_graph(mirage::kernel::Graph const &kn_graph,
+                                     TaskConfigMap const &task_configs) {
+  AnnotatedGraph ag;
+
+  // ---------------------------------------------------------------------
+  // Step (a): DAG construction with most-recent-writer rule.
+  // ---------------------------------------------------------------------
+  // last_writer[guid] = (layer_idx, out_slot). Updated after each layer's
+  // inputs are bound, so reads before the write see the previous writer.
+  std::unordered_map<size_t, std::pair<int, int>> last_writer;
+
+  // Map KNCustomizedOp* -> layer index so downstream passes can locate by op.
+  std::unordered_map<KNCustomizedOp const *, int> op_to_layer;
+
+  for (auto const &op : kn_graph.operators) {
+    if (op->op_type == mirage::type::KN_INPUT_OP) {
+      continue;
+    }
+    if (op->op_type != mirage::type::KN_CUSTOMIZED_OP) {
+      continue;
+    }
+
+    auto const *cur_op = dynamic_cast<KNCustomizedOp const *>(op);
+    auto it = task_configs.find(op);
+    if (it == task_configs.end()) {
+      throw std::runtime_error(
+          "build_annotated_graph: missing task_config for customized op");
+    }
+    int num_inputs = std::get<0>(it->second);
+    int num_outputs = std::get<1>(it->second);
+    mirage::runtime::TaskType task_type = std::get<2>(it->second);
+    int variant_id = std::get<3>(it->second);
+
+    std::vector<tb::TBInputOp *> input_ops, output_ops;
+    split_bgraph_ops(cur_op->bgraph, num_inputs, input_ops, output_ops);
+    if ((int)input_ops.size() != num_inputs ||
+        (int)output_ops.size() != num_outputs) {
+      throw std::runtime_error(
+          "build_annotated_graph: bgraph inputs/outputs count mismatch");
+    }
+
+    int layer_idx = (int)ag.layers.size();
+    LayerInfo li;
+    li.op = cur_op;
+    li.task_type = task_type;
+    li.variant_id = variant_id;
+    li.num_inputs = num_inputs;
+    li.num_outputs = num_outputs;
+    ag.layers.push_back(li);
+    op_to_layer[cur_op] = layer_idx;
+
+    // Read inputs: bind each to its current last_writer (if any).
+    for (int in_slot = 0; in_slot < num_inputs; in_slot++) {
+      auto *ip = input_ops[in_slot];
+      size_t guid = ip->dtensor.guid;
+      auto wit = last_writer.find(guid);
+      if (wit == last_writer.end()) {
+        // Graph input — no edge in the DAG.
+        continue;
+      }
+      int prod_layer = wit->second.first;
+      int out_slot = wit->second.second;
+
+      EdgeInfo e;
+      e.prod_layer = prod_layer;
+      e.cons_layer = layer_idx;
+      e.out_slot = out_slot;
+      e.in_slot = in_slot;
+      e.tensor_guid = guid;
+      e.input_map = ip->input_map;
+
+      // Recover output_map from producer's output_op at out_slot.
+      auto const *prod_op = ag.layers[prod_layer].op;
+      std::vector<tb::TBInputOp *> prod_inputs, prod_outputs;
+      split_bgraph_ops(prod_op->bgraph,
+                       ag.layers[prod_layer].num_inputs,
+                       prod_inputs,
+                       prod_outputs);
+      if (out_slot < 0 || out_slot >= (int)prod_outputs.size()) {
+        throw std::runtime_error(
+            "build_annotated_graph: invalid out_slot for producer");
+      }
+      e.output_map = prod_outputs[out_slot]->input_map;
+
+      int edge_idx = (int)ag.edges.size();
+      ag.edges.push_back(e);
+      ag.layers[layer_idx].in_edges.push_back(edge_idx);
+      ag.layers[prod_layer].out_edges.push_back(edge_idx);
+    }
+
+    // Write outputs: update last_writer after inputs are bound.
+    for (int out_slot = 0; out_slot < num_outputs; out_slot++) {
+      size_t guid = output_ops[out_slot]->dtensor.guid;
+      last_writer[guid] = {layer_idx, out_slot};
+    }
+  }
+
+  int const V = (int)ag.layers.size();
+
+  // ---------------------------------------------------------------------
+  // Step (b): cycle detection via Kahn's algorithm.
+  // ---------------------------------------------------------------------
+  {
+    std::vector<int> in_deg(V, 0);
+    for (auto const &e : ag.edges) {
+      in_deg[e.cons_layer]++;
+    }
+    std::queue<int> q;
+    for (int i = 0; i < V; i++) {
+      if (in_deg[i] == 0) {
+        q.push(i);
+      }
+    }
+    int processed = 0;
+    while (!q.empty()) {
+      int u = q.front();
+      q.pop();
+      processed++;
+      for (int eidx : ag.layers[u].out_edges) {
+        int v = ag.edges[eidx].cons_layer;
+        if (--in_deg[v] == 0) {
+          q.push(v);
+        }
+      }
+    }
+    if (processed != V) {
+      std::ostringstream msg;
+      msg << "build_annotated_graph: cycle detected; offenders:";
+      for (int i = 0; i < V; i++) {
+        if (in_deg[i] > 0) {
+          msg << " layer " << i;
+        }
+      }
+      throw std::runtime_error(msg.str());
+    }
+  }
+
+  // ---------------------------------------------------------------------
+  // Step (c): residual stripping.
+  // Strip direct edge u->v whenever any path u->w->...->v of length >=2 exists.
+  // Single-shot: compute reachable[u] on the original edge set, then test each
+  // edge in isolation.
+  // ---------------------------------------------------------------------
+  std::vector<std::unordered_set<int>> reachable(V);
+  for (int s = 0; s < V; s++) {
+    // BFS from s
+    std::queue<int> q;
+    q.push(s);
+    std::vector<char> seen(V, 0);
+    seen[s] = 1;
+    while (!q.empty()) {
+      int u = q.front();
+      q.pop();
+      for (int eidx : ag.layers[u].out_edges) {
+        int v = ag.edges[eidx].cons_layer;
+        if (!seen[v]) {
+          seen[v] = 1;
+          reachable[s].insert(v);
+          q.push(v);
+        }
+      }
+    }
+  }
+
+  {
+    std::vector<char> strip_flag(ag.edges.size(), 0);
+    for (size_t eidx = 0; eidx < ag.edges.size(); eidx++) {
+      auto const &e = ag.edges[eidx];
+      int u = e.prod_layer, v = e.cons_layer;
+      // Does any intermediate w (successor of u other than v) reach v?
+      for (int oe : ag.layers[u].out_edges) {
+        if ((size_t)oe == eidx) {
+          continue;
+        }
+        int w = ag.edges[oe].cons_layer;
+        if (w == v) {
+          continue;
+        }
+        if (reachable[w].count(v) > 0) {
+          strip_flag[eidx] = 1;
+          break;
+        }
+      }
+    }
+    // Remove stripped edges from per-layer in_edges / out_edges. Keep the
+    // edge records in ag.edges (indices remain valid); mark stripped.
+    for (size_t eidx = 0; eidx < ag.edges.size(); eidx++) {
+      if (strip_flag[eidx]) {
+        ag.edges[eidx].is_residual_stripped = true;
+        ag.stripped_residual_edges.push_back(ag.edges[eidx]);
+      }
+    }
+    for (int i = 0; i < V; i++) {
+      auto &in_e = ag.layers[i].in_edges;
+      in_e.erase(std::remove_if(in_e.begin(),
+                                in_e.end(),
+                                [&](int e) {
+                                  return ag.edges[e].is_residual_stripped;
+                                }),
+                 in_e.end());
+      auto &out_e = ag.layers[i].out_edges;
+      out_e.erase(std::remove_if(out_e.begin(),
+                                 out_e.end(),
+                                 [&](int e) {
+                                   return ag.edges[e].is_residual_stripped;
+                                 }),
+                  out_e.end());
+    }
+  }
+
+  // ---------------------------------------------------------------------
+  // Step (d): per-layer role classification (post-strip).
+  // A layer is a fork producer only if it has edges to >=2 DISTINCT consumer
+  // layers (multiple tensors to the same consumer is not a fork — it's just
+  // a multi-output dependency). Symmetric for join.
+  // ---------------------------------------------------------------------
+  for (int i = 0; i < V; i++) {
+    std::unordered_set<int> distinct_cons, distinct_prod;
+    for (int eidx : ag.layers[i].out_edges) {
+      distinct_cons.insert(ag.edges[eidx].cons_layer);
+    }
+    for (int eidx : ag.layers[i].in_edges) {
+      distinct_prod.insert(ag.edges[eidx].prod_layer);
+    }
+    ag.layers[i].is_fork_producer = distinct_cons.size() >= 2;
+    ag.layers[i].is_join_consumer = distinct_prod.size() >= 2;
+  }
+
+  // ---------------------------------------------------------------------
+  // Step (e): case 2 / 3 validation.
+  //   is_fork_consumer[L] := any in-edge comes from a fork-producer
+  //   is_join_producer[L] := any out-edge goes to a join-consumer
+  //   Case 2: is_join_consumer && is_fork_consumer  -> needs two trigger_events
+  //   Case 3: is_join_producer && is_fork_producer  -> needs two dependent_events
+  // ---------------------------------------------------------------------
+  std::vector<char> is_fork_consumer(V, 0), is_join_producer(V, 0);
+  for (int i = 0; i < V; i++) {
+    for (int eidx : ag.layers[i].in_edges) {
+      if (ag.layers[ag.edges[eidx].prod_layer].is_fork_producer) {
+        is_fork_consumer[i] = 1;
+        break;
+      }
+    }
+    for (int eidx : ag.layers[i].out_edges) {
+      if (ag.layers[ag.edges[eidx].cons_layer].is_join_consumer) {
+        is_join_producer[i] = 1;
+        break;
+      }
+    }
+  }
+  for (int i = 0; i < V; i++) {
+    if (ag.layers[i].is_join_consumer && is_fork_consumer[i]) {
+      std::ostringstream msg;
+      msg << "build_annotated_graph: layer " << i
+          << " is both a join-consumer and a fork-consumer (case 2); "
+             "a task cannot have two trigger_events.";
+      throw std::runtime_error(msg.str());
+    }
+    if (is_join_producer[i] && ag.layers[i].is_fork_producer) {
+      std::ostringstream msg;
+      msg << "build_annotated_graph: layer " << i
+          << " is both a join-producer and a fork-producer (case 3); "
+             "a task cannot have two dependent_events.";
+      throw std::runtime_error(msg.str());
+    }
+  }
+
+  // ---------------------------------------------------------------------
+  // Step (f): topological ordering (Kahn's). Tiebreaker: prefer the smallest
+  // layer index, which preserves original insertion order when unconstrained.
+  // ---------------------------------------------------------------------
+  {
+    std::vector<int> in_deg(V, 0);
+    for (int i = 0; i < V; i++) {
+      in_deg[i] = (int)ag.layers[i].in_edges.size();
+    }
+    // min-heap priority queue by layer index
+    std::priority_queue<int, std::vector<int>, std::greater<int>> pq;
+    for (int i = 0; i < V; i++) {
+      if (in_deg[i] == 0) {
+        pq.push(i);
+      }
+    }
+    while (!pq.empty()) {
+      int u = pq.top();
+      pq.pop();
+      ag.ordered_layers.push_back(u);
+      for (int eidx : ag.layers[u].out_edges) {
+        int v = ag.edges[eidx].cons_layer;
+        if (--in_deg[v] == 0) {
+          pq.push(v);
+        }
+      }
+    }
+    if ((int)ag.ordered_layers.size() != V) {
+      throw std::runtime_error(
+          "build_annotated_graph: topo order incomplete after strip");
+    }
+  }
+
+  // ---------------------------------------------------------------------
+  // Step (g): per-edge GCD event_dim + producer/consumer task_views.
+  // ---------------------------------------------------------------------
+  for (auto &e : ag.edges) {
+    if (e.is_residual_stripped) {
+      continue;
+    }
+    auto const *prod_op = ag.layers[e.prod_layer].op;
+    auto const *cons_op = ag.layers[e.cons_layer].op;
+    auto prod_part = build_partition(prod_op->bgraph.grid_dim, e.output_map);
+    auto cons_part = build_partition(cons_op->bgraph.grid_dim, e.input_map);
+    for (int d = 0; d < (int)mirage::config::MAX_TENSOR_DIMS; d++) {
+      e.event_dim[d] = std::gcd(prod_part[d], cons_part[d]);
+    }
+    e.producer_side_view.event_dim = e.event_dim;
+    e.producer_side_view.grid_dim = prod_op->bgraph.grid_dim;
+    e.producer_side_view.axis_map = e.output_map;
+    e.producer_side_view.last3 =
+        derive_last3(e.event_dim, prod_op->bgraph.grid_dim, e.output_map);
+
+    e.consumer_side_view.event_dim = e.event_dim;
+    e.consumer_side_view.grid_dim = cons_op->bgraph.grid_dim;
+    e.consumer_side_view.axis_map = e.input_map;
+    e.consumer_side_view.last3 =
+        derive_last3(e.event_dim, cons_op->bgraph.grid_dim, e.input_map);
+  }
+
+  // ---------------------------------------------------------------------
+  // Step (h): fork LCM pass. For each fork-producer layer, LCM across
+  // branches' producer-side last3 on grid axes. Absorb the factor into each
+  // branch's event_dim (reducing it), then recompute consumer-side last3.
+  // ---------------------------------------------------------------------
+  for (int i = 0; i < V; i++) {
+    if (!ag.layers[i].is_fork_producer) {
+      continue;
+    }
+    ForkGroupInfo fg;
+    fg.producer_layer = i;
+    fg.outgoing_edges = ag.layers[i].out_edges;
+
+    // N-way LCM per grid axis.
+    std::array<int, 3> lcm_last3{};
+    for (int g = 0; g < 3; g++) {
+      int acc = 1;
+      for (int eidx : fg.outgoing_edges) {
+        acc = (int)std::lcm<long long>(acc, ag.edges[eidx].producer_side_view.last3[g]);
+      }
+      lcm_last3[g] = acc;
+    }
+    // Safety: lcm_last3 must divide producer grid_dim.
+    dim3 const &pg = ag.layers[i].op->bgraph.grid_dim;
+    if (lcm_last3[0] > (int)pg.x || (int)pg.x % lcm_last3[0] != 0 ||
+        lcm_last3[1] > (int)pg.y || (int)pg.y % lcm_last3[1] != 0 ||
+        lcm_last3[2] > (int)pg.z || (int)pg.z % lcm_last3[2] != 0) {
+      std::ostringstream msg;
+      msg << "build_annotated_graph: fork LCM last3 ("
+          << lcm_last3[0] << "," << lcm_last3[1] << "," << lcm_last3[2]
+          << ") does not divide producer grid_dim (" << pg.x << "," << pg.y
+          << "," << pg.z << ") at layer " << i;
+      throw std::runtime_error(msg.str());
+    }
+    fg.lcm_last3 = lcm_last3;
+
+    int fg_id = (int)ag.fork_groups.size();
+    for (size_t b = 0; b < fg.outgoing_edges.size(); b++) {
+      int eidx = fg.outgoing_edges[b];
+      auto &e = ag.edges[eidx];
+      e.fork_group_id = fg_id;
+      // Reduce event_dim on tensor dims corresponding to producer's grid axes
+      // where the scale factor lives.
+      for (int g = 0; g < 3; g++) {
+        int branch_last = e.producer_side_view.last3[g];
+        int scale = lcm_last3[g] / std::max(branch_last, 1);
+        if (scale <= 1) {
+          continue;
+        }
+        int d = axis_lookup(e.output_map, g);
+        if (d < 0 || d >= (int)mirage::config::MAX_TENSOR_DIMS) {
+          // Replicated axis cannot absorb a factor; this means branch.last3[g]
+          // already equals grid[g] and another branch demands more along g,
+          // which would require > grid[g]. Our safety check above rules this
+          // out (LCM divides grid).
+          continue;
+        }
+        int &ev = e.event_dim[d];
+        if (ev % scale != 0) {
+          throw std::runtime_error(
+              "build_annotated_graph: fork LCM scale doesn't divide event_dim");
+        }
+        ev /= scale;
+      }
+      // Recompute producer-side view with lcm_last3 (unified across branches).
+      e.producer_side_view.event_dim = e.event_dim;
+      e.producer_side_view.last3 = lcm_last3;
+      // Recompute consumer-side view with new event_dim via consumer's
+      // input_map.
+      auto const *cons_op = ag.layers[e.cons_layer].op;
+      e.consumer_side_view.event_dim = e.event_dim;
+      e.consumer_side_view.grid_dim = cons_op->bgraph.grid_dim;
+      e.consumer_side_view.axis_map = e.input_map;
+      e.consumer_side_view.last3 =
+          derive_last3(e.event_dim, cons_op->bgraph.grid_dim, e.input_map);
+    }
+    ag.fork_groups.push_back(fg);
+  }
+
+  // ---------------------------------------------------------------------
+  // Step (i): join LCM pass. Symmetric — unify consumer-side last3 on the
+  // join-consumer's grid axes across incoming branches.
+  // ---------------------------------------------------------------------
+  for (int i = 0; i < V; i++) {
+    if (!ag.layers[i].is_join_consumer) {
+      continue;
+    }
+    JoinGroupInfo jg;
+    jg.consumer_layer = i;
+    jg.incoming_edges = ag.layers[i].in_edges;
+
+    std::array<int, 3> lcm_last3{};
+    for (int g = 0; g < 3; g++) {
+      int acc = 1;
+      for (int eidx : jg.incoming_edges) {
+        acc = (int)std::lcm<long long>(acc, ag.edges[eidx].consumer_side_view.last3[g]);
+      }
+      lcm_last3[g] = acc;
+    }
+    dim3 const &cg = ag.layers[i].op->bgraph.grid_dim;
+    if (lcm_last3[0] > (int)cg.x || (int)cg.x % lcm_last3[0] != 0 ||
+        lcm_last3[1] > (int)cg.y || (int)cg.y % lcm_last3[1] != 0 ||
+        lcm_last3[2] > (int)cg.z || (int)cg.z % lcm_last3[2] != 0) {
+      std::ostringstream msg;
+      msg << "build_annotated_graph: join LCM last3 doesn't divide consumer "
+             "grid_dim at layer " << i;
+      throw std::runtime_error(msg.str());
+    }
+    jg.lcm_last3 = lcm_last3;
+
+    int jg_id = (int)ag.join_groups.size();
+    for (size_t b = 0; b < jg.incoming_edges.size(); b++) {
+      int eidx = jg.incoming_edges[b];
+      auto &e = ag.edges[eidx];
+      e.join_group_id = jg_id;
+      for (int g = 0; g < 3; g++) {
+        int branch_last = e.consumer_side_view.last3[g];
+        int scale = lcm_last3[g] / std::max(branch_last, 1);
+        if (scale <= 1) {
+          continue;
+        }
+        int d = axis_lookup(e.input_map, g);
+        if (d < 0 || d >= (int)mirage::config::MAX_TENSOR_DIMS) {
+          continue;
+        }
+        int &ev = e.event_dim[d];
+        if (ev % scale != 0) {
+          throw std::runtime_error(
+              "build_annotated_graph: join LCM scale doesn't divide event_dim");
+        }
+        ev /= scale;
+      }
+      e.consumer_side_view.event_dim = e.event_dim;
+      e.consumer_side_view.last3 = lcm_last3;
+      auto const *prod_op = ag.layers[e.prod_layer].op;
+      e.producer_side_view.event_dim = e.event_dim;
+      e.producer_side_view.grid_dim = prod_op->bgraph.grid_dim;
+      e.producer_side_view.axis_map = e.output_map;
+      e.producer_side_view.last3 =
+          derive_last3(e.event_dim, prod_op->bgraph.grid_dim, e.output_map);
+    }
+    ag.join_groups.push_back(jg);
+  }
+
+  // ---------------------------------------------------------------------
+  // Step (j): finalize — tag immediate fork-consumer layers with their
+  // parent fork group + branch index.
+  // ---------------------------------------------------------------------
+  for (int fg_id = 0; fg_id < (int)ag.fork_groups.size(); fg_id++) {
+    auto const &fg = ag.fork_groups[fg_id];
+    for (size_t b = 0; b < fg.outgoing_edges.size(); b++) {
+      int eidx = fg.outgoing_edges[b];
+      int cons = ag.edges[eidx].cons_layer;
+      ag.layers[cons].fork_parent_group = fg_id;
+      ag.layers[cons].fork_branch_index = (int)b;
+    }
+  }
+
+  return ag;
+}
+
+std::string maybe_dump_annotated_graph(AnnotatedGraph const &ag) {
+  char const *env = std::getenv("MIRAGE_DUMP_ANNOTATED_GRAPH");
+  if (env == nullptr || std::string(env) == "0") {
+    return "";
+  }
+  std::ostringstream os;
+  os << "AnnotatedGraph: " << ag.layers.size() << " layers, "
+     << ag.edges.size() << " edges ("
+     << ag.stripped_residual_edges.size() << " residuals stripped), "
+     << ag.fork_groups.size() << " fork groups, "
+     << ag.join_groups.size() << " join groups\n";
+  for (int i = 0; i < (int)ag.layers.size(); i++) {
+    auto const &L = ag.layers[i];
+    os << "  layer " << i << " in=" << L.in_edges.size()
+       << " out=" << L.out_edges.size()
+       << (L.is_fork_producer ? " [FORK]" : "")
+       << (L.is_join_consumer ? " [JOIN]" : "")
+       << (L.fork_parent_group >= 0 ? " [fork-consumer]" : "")
+       << "\n";
+  }
+  return os.str();
+}
+
+} // namespace kernel
+} // namespace mirage

--- a/src/kernel/annotated_graph.cc
+++ b/src/kernel/annotated_graph.cc
@@ -35,8 +35,10 @@ int grid_lookup(dim3 const &d, int g) {
 }
 
 // Compute last3 for a task_view: last3[g] = grid[g] / event_dim[axis_map[g]]
-// when axis_map[g] >= 0 (axis participates in event partition); else
-// last3[g] = grid[g] (replicated / unmapped axis).
+// when axis_map[g] >= 0 (axis partitions a tensor dim that carries events);
+// else last3[g] = grid[g] (the axis is replicated across the tensor, so
+// every block on this axis observes the whole tensor and falls into the
+// same event slot — the whole axis is inside one "task block").
 std::array<int, 3> derive_last3(
     std::array<int, mirage::config::MAX_TENSOR_DIMS> const &event_dim,
     dim3 const &grid,
@@ -102,9 +104,18 @@ AnnotatedGraph build_annotated_graph(mirage::kernel::Graph const &kn_graph,
 
   // ---------------------------------------------------------------------
   // Step (a): DAG construction with most-recent-writer rule.
+  //
+  // Why not identify edges by guid alone: qwen3 (and most real MPK models)
+  // reuses DTensor buffers across layers — the same guid can be written by
+  // multiple customized ops over the course of the graph. Pure guid matching
+  // would create spurious cycles (later writer reads the same guid that
+  // an earlier reader in a "down" edge also reads).
+  //
+  // Rule: when layer L reads tensor g, bind the edge to whichever producer
+  // wrote g MOST RECENTLY before L. After L is processed, L's outputs update
+  // last_writer. Subsequent reads see L as the new writer. This is exactly
+  // SSA-style def-use: we're implicitly renaming the reused buffer.
   // ---------------------------------------------------------------------
-  // last_writer[guid] = (layer_idx, out_slot). Updated after each layer's
-  // inputs are bound, so reads before the write see the previous writer.
   std::unordered_map<size_t, std::pair<int, int>> last_writer;
 
   // Map KNCustomizedOp* -> layer index so downstream passes can locate by op.
@@ -235,9 +246,24 @@ AnnotatedGraph build_annotated_graph(mirage::kernel::Graph const &kn_graph,
 
   // ---------------------------------------------------------------------
   // Step (c): residual stripping.
-  // Strip direct edge u->v whenever any path u->w->...->v of length >=2 exists.
-  // Single-shot: compute reachable[u] on the original edge set, then test each
-  // edge in isolation.
+  //
+  // A "residual" edge u->v is the direct shortcut in a transformer-like
+  // pattern: u forks to a computed path u->w->...->v and also directly to
+  // v (where v adds the residual). We strip the direct edge because the
+  // longer path's chain of events transitively forces u to complete before
+  // v starts, so the direct edge contributes no scheduling information —
+  // keeping it would just force v to be classified as a join-consumer and
+  // potentially propagate a case-2 violation.
+  //
+  // Single-shot semantics matter: if we stripped iteratively we might drop
+  // the longer path before the direct edge, leaving the direct edge intact
+  // (and the pattern undetected). So we compute reachability ONCE on the
+  // original edge set, then mark all residuals to strip, then remove them
+  // atomically.
+  //
+  // Cost: O(V * (V+E)) for the BFS; for qwen3 (~300 layers, ~400 edges)
+  // this is sub-millisecond and doesn't merit a smarter transitive-reduction
+  // algorithm. Revisit if V grows past ~50k.
   // ---------------------------------------------------------------------
   std::vector<std::unordered_set<int>> reachable(V);
   for (int s = 0; s < V; s++) {
@@ -308,9 +334,14 @@ AnnotatedGraph build_annotated_graph(mirage::kernel::Graph const &kn_graph,
 
   // ---------------------------------------------------------------------
   // Step (d): per-layer role classification (post-strip).
-  // A layer is a fork producer only if it has edges to >=2 DISTINCT consumer
-  // layers (multiple tensors to the same consumer is not a fork — it's just
-  // a multi-output dependency). Symmetric for join.
+  //
+  // Why "distinct" layers (not raw edge count): a layer can produce >1
+  // output tensor, all feeding the same consumer (e.g. a fused attention
+  // layer with 2 outputs that both feed the next block). Counting out_edges
+  // raw would flag this as a fork with trivially redundant branches,
+  // creating a false case-3 violation when the real dependency model is a
+  // plain chain. This showed up when dry-running qwen3 and was the cause
+  // of the first wave of spurious compile errors.
   // ---------------------------------------------------------------------
   for (int i = 0; i < V; i++) {
     std::unordered_set<int> distinct_cons, distinct_prod;
@@ -326,10 +357,26 @@ AnnotatedGraph build_annotated_graph(mirage::kernel::Graph const &kn_graph,
 
   // ---------------------------------------------------------------------
   // Step (e): case 2 / 3 validation.
-  //   is_fork_consumer[L] := any in-edge comes from a fork-producer
-  //   is_join_producer[L] := any out-edge goes to a join-consumer
-  //   Case 2: is_join_consumer && is_fork_consumer  -> needs two trigger_events
-  //   Case 3: is_join_producer && is_fork_producer  -> needs two dependent_events
+  //
+  // FullTaskDesc has exactly one `trigger_event` slot (the event a task
+  // fires on completion) and one `dependent_event` slot (the event a task
+  // waits for, post-prelaunch). The disallowed combinations are the ones
+  // that would need two of either slot on the same task:
+  //
+  //   Case 2 (join-consumer + fork-consumer): X's tasks would need to be
+  //     triggered by TWO events (the upstream fork event and the join
+  //     event at X itself). Not representable.
+  //   Case 3 (join-producer + fork-producer): L's tasks would need to
+  //     FIRE two events (the fork event at L and the downstream join
+  //     event). Not representable.
+  //
+  // Note: cases 2 and 3 always co-occur — a case-2 violation at X implies
+  // one of X's producers is a case-3 violator (its edge to X makes it a
+  // join-producer, and its multiple consumers make it a fork-producer).
+  // We detect whichever comes first in layer order and reject.
+  //
+  // is_fork_consumer[L] := any in-edge comes from a fork-producer.
+  // is_join_producer[L] := any out-edge goes to a join-consumer.
   // ---------------------------------------------------------------------
   std::vector<char> is_fork_consumer(V, 0), is_join_producer(V, 0);
   for (int i = 0; i < V; i++) {
@@ -424,9 +471,24 @@ AnnotatedGraph build_annotated_graph(mirage::kernel::Graph const &kn_graph,
   }
 
   // ---------------------------------------------------------------------
-  // Step (h): fork LCM pass. For each fork-producer layer, LCM across
-  // branches' producer-side last3 on grid axes. Absorb the factor into each
-  // branch's event_dim (reducing it), then recompute consumer-side last3.
+  // Step (h): fork LCM pass.
+  //
+  // For each fork producer F, unify the producer-side last3 across all
+  // outgoing branches. The "factor" we gain on last3 (= lcm / branch_last3)
+  // is absorbed by REDUCING each branch's event_dim on the tensor dim that
+  // maps to that grid axis; so the number of events shrinks and each event
+  // now triggers a larger block of producer/consumer tasks.
+  //
+  // Why grid-axis LCM: F's grid is shared across branches, but each branch
+  // has its own bridging tensor (possibly different output slots of F) and
+  // its own consumer grid/input_map. Grid-axis space is the common frame;
+  // tensor-dim space is per-edge. LCM on grid axes + propagation through
+  // output_map/input_map gives a consistent per-branch event_dim.
+  //
+  // Safety: lcm_last3[g] must divide F.grid_dim[g]. This is guaranteed
+  // for well-formed inputs because each branch_last3[g] divides grid_dim[g]
+  // (it's grid_dim / event_dim where event_dim is a GCD of divisors of
+  // grid_dim), and the LCM of divisors of N is a divisor of N.
   // ---------------------------------------------------------------------
   for (int i = 0; i < V; i++) {
     if (!ag.layers[i].is_fork_producer) {

--- a/src/kernel/annotated_graph.cc
+++ b/src/kernel/annotated_graph.cc
@@ -58,8 +58,8 @@ std::array<int, 3> derive_last3(
 }
 
 // Build per-tensor-dim partition vector from a layer's grid_dim and a map.
-std::array<int, mirage::config::MAX_TENSOR_DIMS> build_partition(
-    dim3 const &grid, int3 const &m) {
+std::array<int, mirage::config::MAX_TENSOR_DIMS>
+    build_partition(dim3 const &grid, int3 const &m) {
   std::array<int, mirage::config::MAX_TENSOR_DIMS> part{};
   for (int d = 0; d < (int)mirage::config::MAX_TENSOR_DIMS; d++) {
     part[d] = 1;
@@ -316,18 +316,16 @@ AnnotatedGraph build_annotated_graph(mirage::kernel::Graph const &kn_graph,
     }
     for (int i = 0; i < V; i++) {
       auto &in_e = ag.layers[i].in_edges;
-      in_e.erase(std::remove_if(in_e.begin(),
-                                in_e.end(),
-                                [&](int e) {
-                                  return ag.edges[e].is_residual_stripped;
-                                }),
+      in_e.erase(std::remove_if(
+                     in_e.begin(),
+                     in_e.end(),
+                     [&](int e) { return ag.edges[e].is_residual_stripped; }),
                  in_e.end());
       auto &out_e = ag.layers[i].out_edges;
-      out_e.erase(std::remove_if(out_e.begin(),
-                                 out_e.end(),
-                                 [&](int e) {
-                                   return ag.edges[e].is_residual_stripped;
-                                 }),
+      out_e.erase(std::remove_if(
+                      out_e.begin(),
+                      out_e.end(),
+                      [&](int e) { return ag.edges[e].is_residual_stripped; }),
                   out_e.end());
     }
   }
@@ -503,7 +501,8 @@ AnnotatedGraph build_annotated_graph(mirage::kernel::Graph const &kn_graph,
     for (int g = 0; g < 3; g++) {
       int acc = 1;
       for (int eidx : fg.outgoing_edges) {
-        acc = (int)std::lcm<long long>(acc, ag.edges[eidx].producer_side_view.last3[g]);
+        acc = (int)std::lcm<long long>(
+            acc, ag.edges[eidx].producer_side_view.last3[g]);
       }
       lcm_last3[g] = acc;
     }
@@ -513,8 +512,8 @@ AnnotatedGraph build_annotated_graph(mirage::kernel::Graph const &kn_graph,
         lcm_last3[1] > (int)pg.y || (int)pg.y % lcm_last3[1] != 0 ||
         lcm_last3[2] > (int)pg.z || (int)pg.z % lcm_last3[2] != 0) {
       std::ostringstream msg;
-      msg << "build_annotated_graph: fork LCM last3 ("
-          << lcm_last3[0] << "," << lcm_last3[1] << "," << lcm_last3[2]
+      msg << "build_annotated_graph: fork LCM last3 (" << lcm_last3[0] << ","
+          << lcm_last3[1] << "," << lcm_last3[2]
           << ") does not divide producer grid_dim (" << pg.x << "," << pg.y
           << "," << pg.z << ") at layer " << i;
       throw std::runtime_error(msg.str());
@@ -580,7 +579,8 @@ AnnotatedGraph build_annotated_graph(mirage::kernel::Graph const &kn_graph,
     for (int g = 0; g < 3; g++) {
       int acc = 1;
       for (int eidx : jg.incoming_edges) {
-        acc = (int)std::lcm<long long>(acc, ag.edges[eidx].consumer_side_view.last3[g]);
+        acc = (int)std::lcm<long long>(
+            acc, ag.edges[eidx].consumer_side_view.last3[g]);
       }
       lcm_last3[g] = acc;
     }
@@ -590,7 +590,8 @@ AnnotatedGraph build_annotated_graph(mirage::kernel::Graph const &kn_graph,
         lcm_last3[2] > (int)cg.z || (int)cg.z % lcm_last3[2] != 0) {
       std::ostringstream msg;
       msg << "build_annotated_graph: join LCM last3 doesn't divide consumer "
-             "grid_dim at layer " << i;
+             "grid_dim at layer "
+          << i;
       throw std::runtime_error(msg.str());
     }
     jg.lcm_last3 = lcm_last3;
@@ -652,19 +653,16 @@ std::string maybe_dump_annotated_graph(AnnotatedGraph const &ag) {
     return "";
   }
   std::ostringstream os;
-  os << "AnnotatedGraph: " << ag.layers.size() << " layers, "
-     << ag.edges.size() << " edges ("
-     << ag.stripped_residual_edges.size() << " residuals stripped), "
-     << ag.fork_groups.size() << " fork groups, "
+  os << "AnnotatedGraph: " << ag.layers.size() << " layers, " << ag.edges.size()
+     << " edges (" << ag.stripped_residual_edges.size()
+     << " residuals stripped), " << ag.fork_groups.size() << " fork groups, "
      << ag.join_groups.size() << " join groups\n";
   for (int i = 0; i < (int)ag.layers.size(); i++) {
     auto const &L = ag.layers[i];
     os << "  layer " << i << " in=" << L.in_edges.size()
-       << " out=" << L.out_edges.size()
-       << (L.is_fork_producer ? " [FORK]" : "")
+       << " out=" << L.out_edges.size() << (L.is_fork_producer ? " [FORK]" : "")
        << (L.is_join_consumer ? " [JOIN]" : "")
-       << (L.fork_parent_group >= 0 ? " [fork-consumer]" : "")
-       << "\n";
+       << (L.fork_parent_group >= 0 ? " [fork-consumer]" : "") << "\n";
   }
   return os.str();
 }

--- a/src/kernel/runtime.cc
+++ b/src/kernel/runtime.cc
@@ -272,8 +272,7 @@ void register_mugraph(
   // tasks interleaved per fork event.
   std::vector<bool> bundle_emitted(ag.fork_groups.size(), false);
 
-  auto get_tensor_desc =
-      [](tb::TBInputOp *const &tb_op) -> TensorDesc {
+  auto get_tensor_desc = [](tb::TBInputOp *const &tb_op) -> TensorDesc {
     TensorDesc desc;
     assert(tb_op->output_tensors.size() == 1);
     tb::STensor stensor = tb_op->output_tensors[0];
@@ -311,13 +310,12 @@ void register_mugraph(
 
   // Build the bid-lex ordered task vector for a layer (same metadata logic as
   // the original code).
-  auto build_tasks_bid_lex =
-      [&](kn::KNCustomizedOp const *cur_op,
-          TaskType task_type,
-          int variant_id,
-          int num_subtasks,
-          std::vector<tb::TBInputOp *> const &input_ops,
-          std::vector<tb::TBInputOp *> const &output_ops)
+  auto build_tasks_bid_lex = [&](kn::KNCustomizedOp const *cur_op,
+                                 TaskType task_type,
+                                 int variant_id,
+                                 int num_subtasks,
+                                 std::vector<tb::TBInputOp *> const &input_ops,
+                                 std::vector<tb::TBInputOp *> const &output_ops)
       -> std::vector<FullTaskDesc> {
     std::vector<FullTaskDesc> tasks;
     tb::Graph const &bgraph = cur_op->bgraph;
@@ -458,8 +456,7 @@ void register_mugraph(
     return bid.x * grid.y * grid.z + bid.y * grid.z + bid.z;
   };
 
-  auto axis_of_tensor_dim =
-      [](int3 const &m, int tensor_dim) -> int {
+  auto axis_of_tensor_dim = [](int3 const &m, int tensor_dim) -> int {
     if (m.x == tensor_dim) {
       return 0;
     }
@@ -505,10 +502,11 @@ void register_mugraph(
 
   // Given an event index (ex, ey, ez) in a grid-axis event frame with last3
   // block size, returns (lo, hi) on that grid.
-  auto grid_subrange_for_event =
-      [](int ex, int ey, int ez,
-         std::array<int, 3> const &last3,
-         dim3 grid) -> std::pair<dim3, dim3> {
+  auto grid_subrange_for_event = [](int ex,
+                                    int ey,
+                                    int ez,
+                                    std::array<int, 3> const &last3,
+                                    dim3 grid) -> std::pair<dim3, dim3> {
     dim3 lo(ex * last3[0], ey * last3[1], ez * last3[2]);
     dim3 hi((ex + 1) * last3[0], (ey + 1) * last3[1], (ez + 1) * last3[2]);
     (void)grid;
@@ -531,8 +529,9 @@ void register_mugraph(
           dim3 cons_grid) -> std::pair<dim3, dim3> {
     int c_ev[3] = {0, 0, 0};
     for (int g_c = 0; g_c < 3; g_c++) {
-      int d = (g_c == 0 ? edge.input_map.x
-                        : g_c == 1 ? edge.input_map.y : edge.input_map.z);
+      int d = (g_c == 0   ? edge.input_map.x
+               : g_c == 1 ? edge.input_map.y
+                          : edge.input_map.z);
       if (d < 0 || d >= (int)mirage::config::MAX_TENSOR_DIMS) {
         c_ev[g_c] = 0;
         continue;
@@ -541,8 +540,9 @@ void register_mugraph(
       if (g_p < 0) {
         c_ev[g_c] = 0;
       } else {
-        c_ev[g_c] = (g_p == 0 ? p_ev_idx.x
-                              : g_p == 1 ? p_ev_idx.y : p_ev_idx.z);
+        c_ev[g_c] = (g_p == 0   ? p_ev_idx.x
+                     : g_p == 1 ? p_ev_idx.y
+                                : p_ev_idx.z);
       }
     }
     (void)cons_grid;
@@ -564,8 +564,9 @@ void register_mugraph(
           dim3 prod_grid) -> std::pair<dim3, dim3> {
     int p_ev[3] = {0, 0, 0};
     for (int g_p = 0; g_p < 3; g_p++) {
-      int d = (g_p == 0 ? edge.output_map.x
-                        : g_p == 1 ? edge.output_map.y : edge.output_map.z);
+      int d = (g_p == 0   ? edge.output_map.x
+               : g_p == 1 ? edge.output_map.y
+                          : edge.output_map.z);
       if (d < 0 || d >= (int)mirage::config::MAX_TENSOR_DIMS) {
         p_ev[g_p] = 0;
         continue;
@@ -574,8 +575,9 @@ void register_mugraph(
       if (g_c < 0) {
         p_ev[g_p] = 0;
       } else {
-        p_ev[g_p] = (g_c == 0 ? c_ev_idx.x
-                              : g_c == 1 ? c_ev_idx.y : c_ev_idx.z);
+        p_ev[g_p] = (g_c == 0   ? c_ev_idx.x
+                     : g_c == 1 ? c_ev_idx.y
+                                : c_ev_idx.z);
       }
     }
     (void)prod_grid;
@@ -659,8 +661,12 @@ void register_mugraph(
 
     // ---- First layer (no in-edges after residual stripping): lex emit.
     if (L.in_edges.empty() && L.fork_parent_group < 0) {
-      std::vector<FullTaskDesc> tasks = build_tasks_bid_lex(
-          cur_op, task_type, variant_id, cur_num_subtasks, input_ops, output_ops);
+      std::vector<FullTaskDesc> tasks = build_tasks_bid_lex(cur_op,
+                                                            task_type,
+                                                            variant_id,
+                                                            cur_num_subtasks,
+                                                            input_ops,
+                                                            output_ops);
       dim3 b;
       for (b.x = 0; b.x < cur_grid.x; b.x++) {
         for (b.y = 0; b.y < cur_grid.y; b.y++) {
@@ -745,11 +751,15 @@ void register_mugraph(
             for (size_t b = 0; b < fg.outgoing_edges.size(); b++) {
               EdgeInfo const &e = ag.edges[fg.outgoing_edges[b]];
               LayerInfo const &B = ag.layers[e.cons_layer];
-              auto [c_lo, c_hi] =
-                  consumer_subrange_from_fork_event(p_ev, e, B.op->bgraph.grid_dim);
-              push_bids_lex(c_lo, c_hi, B.op->bgraph.grid_dim,
-                            branch_num_subtasks[b], branch_is_multigpu[b],
-                            branch_tasks[b], layer_task_maps[e.cons_layer]);
+              auto [c_lo, c_hi] = consumer_subrange_from_fork_event(
+                  p_ev, e, B.op->bgraph.grid_dim);
+              push_bids_lex(c_lo,
+                            c_hi,
+                            B.op->bgraph.grid_dim,
+                            branch_num_subtasks[b],
+                            branch_is_multigpu[b],
+                            branch_tasks[b],
+                            layer_task_maps[e.cons_layer]);
             }
             event_desc.last_task_id = all_tasks.size();
             // Set trigger_event on producer tasks in the producer sub-range.
@@ -760,10 +770,12 @@ void register_mugraph(
                       (ey + 1) * fg.lcm_last3[1],
                       (ez + 1) * fg.lcm_last3[2]);
             bool nvshmem_event_flag = layer_is_multigpu[fg.producer_layer];
-            set_producer_triggers(p_lo, p_hi,
+            set_producer_triggers(p_lo,
+                                  p_hi,
                                   layer_task_maps[fg.producer_layer],
                                   all_events.size(),
-                                  nvshmem_event_flag, event_desc);
+                                  nvshmem_event_flag,
+                                  event_desc);
             if (nvshmem_event_flag) {
               nvshmem_events_idx.insert(all_events.size());
             }
@@ -779,8 +791,8 @@ void register_mugraph(
       for (int eidx : fg.outgoing_edges) {
         EdgeInfo const &e = ag.edges[eidx];
         all_task_maps.emplace(
-            const_cast<kn::KNOperator *>(
-                static_cast<kn::KNOperator const *>(ag.layers[e.cons_layer].op)),
+            const_cast<kn::KNOperator *>(static_cast<kn::KNOperator const *>(
+                ag.layers[e.cons_layer].op)),
             layer_task_maps[e.cons_layer]);
       }
       bundle_emitted[fg_id] = true;
@@ -797,8 +809,12 @@ void register_mugraph(
       int jg_id = ag.edges[L.in_edges[0]].join_group_id;
       assert(jg_id >= 0);
       JoinGroupInfo const &jg = ag.join_groups[jg_id];
-      std::vector<FullTaskDesc> tasks = build_tasks_bid_lex(
-          cur_op, task_type, variant_id, cur_num_subtasks, input_ops, output_ops);
+      std::vector<FullTaskDesc> tasks = build_tasks_bid_lex(cur_op,
+                                                            task_type,
+                                                            variant_id,
+                                                            cur_num_subtasks,
+                                                            input_ops,
+                                                            output_ops);
       int ex_max = cur_grid.x / std::max(jg.lcm_last3[0], 1);
       int ey_max = cur_grid.y / std::max(jg.lcm_last3[1], 1);
       int ez_max = cur_grid.z / std::max(jg.lcm_last3[2], 1);
@@ -811,8 +827,13 @@ void register_mugraph(
             event_desc.first_task_id = all_tasks.size();
             auto [c_lo, c_hi] =
                 grid_subrange_for_event(ex, ey, ez, jg.lcm_last3, cur_grid);
-            push_bids_lex(c_lo, c_hi, cur_grid, cur_num_subtasks,
-                          cur_is_multigpu, tasks, layer_task_maps[layer_idx]);
+            push_bids_lex(c_lo,
+                          c_hi,
+                          cur_grid,
+                          cur_num_subtasks,
+                          cur_is_multigpu,
+                          tasks,
+                          layer_task_maps[layer_idx]);
             event_desc.last_task_id = all_tasks.size();
             bool any_nvshmem = false;
             for (int eidx : jg.incoming_edges) {
@@ -821,10 +842,12 @@ void register_mugraph(
               any_nvshmem = any_nvshmem || nvshmem_event_flag;
               auto [p_lo, p_hi] = producer_subrange_from_join_event(
                   c_ev, e, ag.layers[e.prod_layer].op->bgraph.grid_dim);
-              set_producer_triggers(p_lo, p_hi,
+              set_producer_triggers(p_lo,
+                                    p_hi,
                                     layer_task_maps[e.prod_layer],
                                     all_events.size(),
-                                    nvshmem_event_flag, event_desc);
+                                    nvshmem_event_flag,
+                                    event_desc);
             }
             if (any_nvshmem) {
               nvshmem_events_idx.insert(all_events.size());

--- a/src/kernel/runtime.cc
+++ b/src/kernel/runtime.cc
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+#include "mirage/kernel/annotated_graph.h"
 #include "mirage/kernel/graph.h"
 #include "mirage/kernel/task_register.h"
 #include "mirage/transpiler/utils.h"
@@ -232,6 +233,20 @@ void register_mugraph(
     std::unordered_map<kn::KNOperator const *,
                        std::tuple<int, int, TaskType, int>> const
         &task_configs) {
+  // Build the AnnotatedGraph. This replaces the old chain-only matching
+  // (based on guid equality between pre_output_ops and current input_ops)
+  // with a full DAG analysis: residual stripping, fork/join classification,
+  // per-edge event_dim via GCD, and N-way LCM unification at fork/join
+  // boundaries. Any error (cycle, disallowed role combination, ill-formed
+  // LCM) aborts compilation here so we fail early with a clear message
+  // instead of silently producing a wrong schedule.
+  AnnotatedGraph ag = build_annotated_graph(graph, task_configs);
+  if (char const *env = std::getenv("MIRAGE_DUMP_ANNOTATED_GRAPH");
+      env != nullptr && std::string(env) != "0") {
+    std::string dump = maybe_dump_annotated_graph(ag);
+    std::fprintf(stderr, "%s", dump.c_str());
+  }
+
   // push a begin-graph task and a event to launch dependent asks
   {
     EventDesc e(EVENT_LAUNCH_DEPENDENT_TASKS, 1, 0, 0);
@@ -240,142 +255,77 @@ void register_mugraph(
     all_tasks.push_back(t);
     all_events.push_back(e);
   }
-  std::vector<tb::TBInputOp *> pre_output_ops;
-  kn::KNCustomizedOp const *pre_op = nullptr;
-  std::map<dim3, std::vector<TaskId>, Dim3Comparator> pre_task_map;
+
   std::unordered_set<size_t> nvshmem_events_idx;
-  bool prev_op_is_multigpu = false;
-  for (auto const &op : graph.operators) {
-    if (op->op_type == type::KNOperatorType::KN_INPUT_OP) {
-      continue;
+  int const V = (int)ag.layers.size();
+  // Per-layer task map: bid -> task_id(s). Indexed by layer index instead of
+  // KNOperator* so that downstream edges can look up a producer's tasks by
+  // layer index (the AnnotatedGraph's natural key). We still populate
+  // `all_task_maps` at the end for the legacy KNOperator*-keyed consumers
+  // (print_task_graph).
+  std::vector<std::map<dim3, std::vector<TaskId>, Dim3Comparator>>
+      layer_task_maps(V);
+  std::vector<bool> layer_is_multigpu(V, false);
+  // Each fork group's consumer-bundle is emitted exactly once — when we
+  // encounter branch 0 (the head) in the topo walk. Other branches of the
+  // same group are skipped because the head already laid out ALL branches'
+  // tasks interleaved per fork event.
+  std::vector<bool> bundle_emitted(ag.fork_groups.size(), false);
+
+  auto get_tensor_desc =
+      [](tb::TBInputOp *const &tb_op) -> TensorDesc {
+    TensorDesc desc;
+    assert(tb_op->output_tensors.size() == 1);
+    tb::STensor stensor = tb_op->output_tensors[0];
+    kn::KNInputOp *kernel_input_op =
+        static_cast<kn::KNInputOp *>(tb_op->dtensor.owner_op);
+    desc.num_dims = stensor.num_dims;
+    desc.data_type = stensor.data_type;
+    for (int d = stensor.num_dims - 1; d >= 0; d--) {
+      desc.dim[d] = stensor.dim[d];
+      desc.stride[d] = kernel_input_op->input_strides[d];
     }
-    std::tuple<int, int, TaskType, int> task_config =
-        task_configs.find(op)->second;
-    assert(op->op_type == type::KNOperatorType::KN_CUSTOMIZED_OP);
-    // Customized op
-    kn::KNCustomizedOp const *cur_op =
-        dynamic_cast<kn::KNCustomizedOp const *>(op);
+    return desc;
+  };
+
+  // Split a customized op's bgraph into input_ops / output_ops (same quirk
+  // as before: outputs live as TBInputOps after the num_inputs mark).
+  auto split_ops = [](kn::KNCustomizedOp const *op,
+                      int num_inputs,
+                      int num_outputs,
+                      std::vector<tb::TBInputOp *> &input_ops,
+                      std::vector<tb::TBInputOp *> &output_ops) {
+    input_ops.clear();
+    output_ops.clear();
+    for (auto const &sub_op : op->bgraph.operators) {
+      assert(sub_op->op_type == mirage::type::TB_INPUT_OP);
+      if ((int)input_ops.size() < num_inputs) {
+        input_ops.push_back(static_cast<tb::TBInputOp *>(sub_op));
+      } else {
+        output_ops.push_back(static_cast<tb::TBInputOp *>(sub_op));
+      }
+    }
+    assert((int)input_ops.size() == num_inputs);
+    assert((int)output_ops.size() == num_outputs);
+  };
+
+  // Build the bid-lex ordered task vector for a layer (same metadata logic as
+  // the original code).
+  auto build_tasks_bid_lex =
+      [&](kn::KNCustomizedOp const *cur_op,
+          TaskType task_type,
+          int variant_id,
+          int num_subtasks,
+          std::vector<tb::TBInputOp *> const &input_ops,
+          std::vector<tb::TBInputOp *> const &output_ops)
+      -> std::vector<FullTaskDesc> {
+    std::vector<FullTaskDesc> tasks;
     tb::Graph const &bgraph = cur_op->bgraph;
     dim3 bid;
-    std::vector<tb::TBInputOp *> input_ops;
-    std::vector<tb::TBInputOp *> output_ops;
-    int num_inputs = std::get<0>(task_config);
-    int num_outputs = std::get<1>(task_config);
-    TaskType task_type = std::get<2>(task_config);
-    int variant_id = std::get<3>(task_config);
-    assert(bgraph.operators.size() == (size_t)num_inputs + num_outputs);
-    for (auto const &op : bgraph.operators) {
-      assert(op->op_type == mirage::type::TB_INPUT_OP);
-      if (input_ops.size() < (size_t)num_inputs) {
-        input_ops.push_back(static_cast<tb::TBInputOp *>(op));
-      } else {
-        output_ops.push_back(static_cast<tb::TBInputOp *>(op));
-      }
-    }
-
-    auto add_events_for_denpendency =
-        [&](std::vector<FullTaskDesc> const &cur_op_tasks,
-            bool nvshmem_event,
-            bool multigpu_task)
-        -> std::map<dim3, std::vector<TaskId>, Dim3Comparator> {
-      std::map<dim3, std::vector<TaskId>, Dim3Comparator> cur_task_map;
-      std::vector<int> producer_partition(mirage::config::MAX_TENSOR_DIMS, 1);
-      std::vector<int> consumer_partition(mirage::config::MAX_TENSOR_DIMS, 1);
-      int num_shared_tensors = 0;
-      int3 input_map = make_int3(-1, -1, -1);
-      int3 output_map = make_int3(-1, -1, -1);
-      for (auto const &input : input_ops) {
-        for (auto const &output : pre_output_ops) {
-          if (input->dtensor.guid == output->dtensor.guid) {
-            input_map = input->input_map;
-            output_map = output->input_map;
-            num_shared_tensors++;
-          }
-        }
-      }
-      // When consecutive ops share no tensors (e.g., enorm and hnorm in MTP
-      // which read independent inputs), create a full barrier event connecting
-      // all producer tasks to all consumer tasks. The -1 initialized maps
-      // ensure no dimension partitioning, so a single event covers everything.
-      // assert(num_shared_tensors >= 1); // relaxed: allow barrier-only deps
-      for (int d = 0; d < mirage::config::MAX_TENSOR_DIMS; d++) {
-        // ! Note: If two block dimensions are mapped to the same tensor dim,
-        // ! then the partitioning will be incorrect.
-        if (d == input_map.x) {
-          consumer_partition[d] = bgraph.grid_dim.x;
-        }
-        if (d == input_map.y) {
-          consumer_partition[d] = bgraph.grid_dim.y;
-        }
-        if (d == input_map.z) {
-          consumer_partition[d] = bgraph.grid_dim.z;
-        }
-        if (d == output_map.x) {
-          producer_partition[d] = pre_op->bgraph.grid_dim.x;
-        }
-        if (d == output_map.y) {
-          producer_partition[d] = pre_op->bgraph.grid_dim.y;
-        }
-        if (d == output_map.z) {
-          producer_partition[d] = pre_op->bgraph.grid_dim.z;
-        }
-      }
-      // Step 2.2: create events and add tasks
-      // number of events is the product of gcd of producer/consumer
-      std::vector<int> event_dims(mirage::config::MAX_TENSOR_DIMS, 1);
-      for (int d = 0; d < mirage::config::MAX_TENSOR_DIMS; d++) {
-        event_dims[d] = std::gcd(producer_partition[d], consumer_partition[d]);
-      }
-      dfs_create_events_add_tasks(0,         /*depth*/
-                                  my_gpu_id, /*my_gpu_id*/
-                                  num_gpus,
-                                  event_dims,              /*event_dims*/
-                                  input_map,               /*input_map*/
-                                  output_map,              /*output_map*/
-                                  bgraph.grid_dim,         /*consumer_grid_dim*/
-                                  pre_op->bgraph.grid_dim, /*producer_grid_dim*/
-                                  dim3(0, 0, 0),           /*consumer_lo_bid*/
-                                  bgraph.grid_dim,         /*consumer_hi_bid*/
-                                  dim3(0, 0, 0),           /*producer_lo_bid*/
-                                  pre_op->bgraph.grid_dim, /*producer_hi_bid*/
-                                  all_events,
-                                  all_tasks,
-                                  cur_op_tasks,
-                                  pre_task_map, /*pre_task_map*/
-                                  cur_task_map /*cur_task_map)*/,
-                                  nvshmem_events_idx,
-                                  nvshmem_event,
-                                  multigpu_task);
-      return cur_task_map;
-    };
-
-    auto get_tensor_desc =
-        [](threadblock::TBInputOp *const &tb_op) -> TensorDesc {
-      TensorDesc desc;
-      assert(tb_op->output_tensors.size() == 1);
-      tb::STensor stensor = tb_op->output_tensors[0];
-      kn::KNInputOp *kernel_input_op =
-          static_cast<kn::KNInputOp *>(tb_op->dtensor.owner_op);
-      desc.num_dims = stensor.num_dims;
-      desc.data_type = stensor.data_type;
-      for (int d = stensor.num_dims - 1; d >= 0; d--) {
-        desc.dim[d] = stensor.dim[d];
-        desc.stride[d] = kernel_input_op->input_strides[d];
-      }
-      return desc;
-    };
-
-    int cur_op_num_subtasks = get_num_subtasks(num_gpus, task_type);
-    bool cur_op_is_multigpu = (task_type == TASK_NVSHMEM_ALLGATHER_STRIDED_PUT);
-
-    std::vector<FullTaskDesc> tasks;
-    // Step 1: add all tasks based on their blockIdx
-    // (bid.x, bid.y, bid.z) ordering
     for (bid.x = 0; bid.x < bgraph.grid_dim.x; bid.x++) {
       for (bid.y = 0; bid.y < bgraph.grid_dim.y; bid.y++) {
         for (bid.z = 0; bid.z < bgraph.grid_dim.z; bid.z++) {
-          for (int subtask_id = 0; subtask_id < cur_op_num_subtasks;
-               subtask_id++) {
+          for (int subtask_id = 0; subtask_id < num_subtasks; subtask_id++) {
             FullTaskDesc task(task_type, variant_id);
             // Set request_id for attention and paged_attention
             if ((task_type == TASK_ATTENTION_1) ||
@@ -501,44 +451,469 @@ void register_mugraph(
         }
       }
     }
-    // Step 2: create events between operators
-    std::map<dim3, std::vector<TaskId>, Dim3Comparator> cur_task_map;
-    std::map<dim3, TaskId, Dim3Comparator> cur_task_map_single;
-    if (pre_op == nullptr) {
-      dim3 bid;
-      for (bid.x = 0; bid.x < bgraph.grid_dim.x; bid.x++) {
-        for (bid.y = 0; bid.y < bgraph.grid_dim.y; bid.y++) {
-          for (bid.z = 0; bid.z < bgraph.grid_dim.z; bid.z++) {
-            cur_task_map[bid] = {all_tasks.size()};
+    return tasks;
+  };
 
-            int offset = bid.x * bgraph.grid_dim.y * bgraph.grid_dim.z +
-                         bid.y * bgraph.grid_dim.z + bid.z;
+  auto bid_offset = [](dim3 bid, dim3 grid) -> int {
+    return bid.x * grid.y * grid.z + bid.y * grid.z + bid.z;
+  };
 
-            first_tasks.push_back(all_tasks.size());
-            all_tasks.push_back(tasks[offset]);
+  auto axis_of_tensor_dim =
+      [](int3 const &m, int tensor_dim) -> int {
+    if (m.x == tensor_dim) {
+      return 0;
+    }
+    if (m.y == tensor_dim) {
+      return 1;
+    }
+    if (m.z == tensor_dim) {
+      return 2;
+    }
+    return -1;
+  };
+
+  // Given a (lo, hi) on the consumer grid represented as dim3, push each bid
+  // (lex order) into all_tasks, recording in task_map. Honors multigpu
+  // num_subtasks in the pre-built tasks vector.
+  auto push_bids_lex =
+      [&](dim3 lo,
+          dim3 hi,
+          dim3 grid,
+          int num_subtasks,
+          bool is_multigpu,
+          std::vector<FullTaskDesc> const &bid_lex_tasks,
+          std::map<dim3, std::vector<TaskId>, Dim3Comparator> &task_map) {
+        dim3 b;
+        for (b.x = lo.x; b.x < hi.x; b.x++) {
+          for (b.y = lo.y; b.y < hi.y; b.y++) {
+            for (b.z = lo.z; b.z < hi.z; b.z++) {
+              int off = bid_offset(b, grid);
+              if (is_multigpu) {
+                task_map[b] = std::vector<TaskId>();
+                for (int i = 0; i < num_subtasks; i++) {
+                  task_map[b].push_back(all_tasks.size());
+                  all_tasks.push_back(bid_lex_tasks[off * num_subtasks + i]);
+                }
+              } else {
+                task_map[b] = std::vector<TaskId>{(TaskId)all_tasks.size()};
+                all_tasks.push_back(bid_lex_tasks[off]);
+              }
+            }
+          }
+        }
+      };
+
+  // Given an event index (ex, ey, ez) in a grid-axis event frame with last3
+  // block size, returns (lo, hi) on that grid.
+  auto grid_subrange_for_event =
+      [](int ex, int ey, int ez,
+         std::array<int, 3> const &last3,
+         dim3 grid) -> std::pair<dim3, dim3> {
+    dim3 lo(ex * last3[0], ey * last3[1], ez * last3[2]);
+    dim3 hi((ex + 1) * last3[0], (ey + 1) * last3[1], (ez + 1) * last3[2]);
+    (void)grid;
+    return {lo, hi};
+  };
+
+  // Map a fork-event index (in producer grid axis frame via lcm_last3) to
+  // a consumer branch's bid sub-range.
+  //
+  // The translation goes: producer grid axis -> (via output_map) tensor
+  // dim -> (via input_map) consumer grid axis. For each consumer grid axis
+  // g_c: find which tensor dim d = input_map[g_c], then which producer
+  // grid axis g_p has output_map[g_p] == d. The event index on g_p
+  // equals the event index on g_c. Multiply by post-LCM consumer last3
+  // to get the bid offset. Axes unmapped on either side collapse to 0
+  // (a single event slot along that axis).
+  auto consumer_subrange_from_fork_event =
+      [&](int3 const &p_ev_idx,
+          EdgeInfo const &edge,
+          dim3 cons_grid) -> std::pair<dim3, dim3> {
+    int c_ev[3] = {0, 0, 0};
+    for (int g_c = 0; g_c < 3; g_c++) {
+      int d = (g_c == 0 ? edge.input_map.x
+                        : g_c == 1 ? edge.input_map.y : edge.input_map.z);
+      if (d < 0 || d >= (int)mirage::config::MAX_TENSOR_DIMS) {
+        c_ev[g_c] = 0;
+        continue;
+      }
+      int g_p = axis_of_tensor_dim(edge.output_map, d);
+      if (g_p < 0) {
+        c_ev[g_c] = 0;
+      } else {
+        c_ev[g_c] = (g_p == 0 ? p_ev_idx.x
+                              : g_p == 1 ? p_ev_idx.y : p_ev_idx.z);
+      }
+    }
+    (void)cons_grid;
+    dim3 lo(c_ev[0] * edge.consumer_side_view.last3[0],
+            c_ev[1] * edge.consumer_side_view.last3[1],
+            c_ev[2] * edge.consumer_side_view.last3[2]);
+    dim3 hi((c_ev[0] + 1) * edge.consumer_side_view.last3[0],
+            (c_ev[1] + 1) * edge.consumer_side_view.last3[1],
+            (c_ev[2] + 1) * edge.consumer_side_view.last3[2]);
+    return {lo, hi};
+  };
+
+  // Map a join-event index (expressed in consumer grid axis frame via
+  // jg.lcm_last3) to a producer's bid sub-range, via input_map/output_map
+  // and the edge's post-LCM producer-side last3.
+  auto producer_subrange_from_join_event =
+      [&](int3 const &c_ev_idx,
+          EdgeInfo const &edge,
+          dim3 prod_grid) -> std::pair<dim3, dim3> {
+    int p_ev[3] = {0, 0, 0};
+    for (int g_p = 0; g_p < 3; g_p++) {
+      int d = (g_p == 0 ? edge.output_map.x
+                        : g_p == 1 ? edge.output_map.y : edge.output_map.z);
+      if (d < 0 || d >= (int)mirage::config::MAX_TENSOR_DIMS) {
+        p_ev[g_p] = 0;
+        continue;
+      }
+      int g_c = axis_of_tensor_dim(edge.input_map, d);
+      if (g_c < 0) {
+        p_ev[g_p] = 0;
+      } else {
+        p_ev[g_p] = (g_c == 0 ? c_ev_idx.x
+                              : g_c == 1 ? c_ev_idx.y : c_ev_idx.z);
+      }
+    }
+    (void)prod_grid;
+    dim3 lo(p_ev[0] * edge.producer_side_view.last3[0],
+            p_ev[1] * edge.producer_side_view.last3[1],
+            p_ev[2] * edge.producer_side_view.last3[2]);
+    dim3 hi((p_ev[0] + 1) * edge.producer_side_view.last3[0],
+            (p_ev[1] + 1) * edge.producer_side_view.last3[1],
+            (p_ev[2] + 1) * edge.producer_side_view.last3[2]);
+    return {lo, hi};
+  };
+
+  // Walk producer bids in [lo, hi), set trigger_event, count num_triggers.
+  // Handles NVSHMEM multigpu (task_ids.size() == num_gpus - 1) exactly like
+  // the chain dfs does.
+  auto set_producer_triggers =
+      [&](dim3 lo,
+          dim3 hi,
+          std::map<dim3, std::vector<TaskId>, Dim3Comparator> const &prod_map,
+          size_t event_pos,
+          bool nvshmem_event,
+          EventDesc &event_desc) {
+        dim3 b;
+        for (b.x = lo.x; b.x < hi.x; b.x++) {
+          for (b.y = lo.y; b.y < hi.y; b.y++) {
+            for (b.z = lo.z; b.z < hi.z; b.z++) {
+              auto it = prod_map.find(b);
+              assert(it != prod_map.end());
+              std::vector<TaskId> const &task_ids = it->second;
+              if (all_tasks[task_ids[0]].task_type ==
+                  TASK_NVSHMEM_ALLGATHER_STRIDED_PUT) {
+                assert(task_ids.size() == (size_t)num_gpus - 1);
+                for (int tgt = 0; tgt < num_gpus; tgt++) {
+                  if (tgt == my_gpu_id) {
+                    continue;
+                  }
+                  size_t idx = tgt < my_gpu_id ? tgt : tgt - 1;
+                  all_tasks[task_ids[idx]].trigger_event =
+                      get_event_id(tgt, event_pos, nvshmem_event);
+                  event_desc.num_triggers++;
+                }
+              } else {
+                assert(task_ids.size() == 1);
+                all_tasks[task_ids[0]].trigger_event =
+                    get_event_id(my_gpu_id, event_pos, nvshmem_event);
+                event_desc.num_triggers++;
+              }
+            }
+          }
+        }
+      };
+
+  // -------------------------------------------------------------------
+  // Pass: iterate ordered_layers, emitting tasks + events per layer role.
+  // -------------------------------------------------------------------
+  for (int layer_idx : ag.ordered_layers) {
+    LayerInfo const &L = ag.layers[layer_idx];
+    kn::KNCustomizedOp const *cur_op = L.op;
+    TaskType task_type = L.task_type;
+    int variant_id = L.variant_id;
+    int num_inputs = L.num_inputs;
+    int num_outputs = L.num_outputs;
+    tb::Graph const &bgraph = cur_op->bgraph;
+    dim3 cur_grid = bgraph.grid_dim;
+
+    std::vector<tb::TBInputOp *> input_ops, output_ops;
+    split_ops(cur_op, num_inputs, num_outputs, input_ops, output_ops);
+
+    int cur_num_subtasks = get_num_subtasks(num_gpus, task_type);
+    bool cur_is_multigpu = (task_type == TASK_NVSHMEM_ALLGATHER_STRIDED_PUT);
+    layer_is_multigpu[layer_idx] = cur_is_multigpu;
+
+    // Skip non-head branches of a fork-consumer bundle. The head (branch
+    // index 0) emits tasks for ALL branches interleaved per fork event so
+    // each fork event's consumer-range is contiguous in all_tasks. If we
+    // let each branch run here, their tasks would land in separate blocks
+    // and no single EventDesc could span them.
+    if (L.fork_parent_group >= 0 && L.fork_branch_index != 0) {
+      continue;
+    }
+
+    // ---- First layer (no in-edges after residual stripping): lex emit.
+    if (L.in_edges.empty() && L.fork_parent_group < 0) {
+      std::vector<FullTaskDesc> tasks = build_tasks_bid_lex(
+          cur_op, task_type, variant_id, cur_num_subtasks, input_ops, output_ops);
+      dim3 b;
+      for (b.x = 0; b.x < cur_grid.x; b.x++) {
+        for (b.y = 0; b.y < cur_grid.y; b.y++) {
+          for (b.z = 0; b.z < cur_grid.z; b.z++) {
+            int off = bid_offset(b, cur_grid);
+            if (cur_is_multigpu) {
+              layer_task_maps[layer_idx][b] = std::vector<TaskId>();
+              for (int i = 0; i < cur_num_subtasks; i++) {
+                layer_task_maps[layer_idx][b].push_back(all_tasks.size());
+                first_tasks.push_back(all_tasks.size());
+                all_tasks.push_back(tasks[off * cur_num_subtasks + i]);
+              }
+            } else {
+              layer_task_maps[layer_idx][b] =
+                  std::vector<TaskId>{(TaskId)all_tasks.size()};
+              first_tasks.push_back(all_tasks.size());
+              all_tasks.push_back(tasks[off]);
+            }
           }
         }
       }
-    } else {
-      bool cur_task_trigger_nvshmem_event = prev_op_is_multigpu;
-      cur_task_map = add_events_for_denpendency(
-          tasks, cur_task_trigger_nvshmem_event, cur_op_is_multigpu);
+      all_task_maps.emplace(const_cast<kn::KNOperator *>(
+                                static_cast<kn::KNOperator const *>(cur_op)),
+                            layer_task_maps[layer_idx]);
+      continue;
     }
-    pre_output_ops = output_ops;
-    pre_op = cur_op;
-    pre_task_map = cur_task_map;
-    all_task_maps.emplace(op, cur_task_map);
-    prev_op_is_multigpu = cur_op_is_multigpu;
+
+    // ---- Fork consumer bundle (head branch only reaches here).
+    if (L.fork_parent_group >= 0) {
+      int fg_id = L.fork_parent_group;
+      if (bundle_emitted[fg_id]) {
+        continue;
+      }
+      ForkGroupInfo const &fg = ag.fork_groups[fg_id];
+      LayerInfo const &P = ag.layers[fg.producer_layer];
+      tb::Graph const &pgraph = P.op->bgraph;
+      // Build bid-lex tasks for every branch in advance.
+      std::vector<std::vector<FullTaskDesc>> branch_tasks;
+      std::vector<std::vector<tb::TBInputOp *>> branch_inputs, branch_outputs;
+      std::vector<int> branch_num_subtasks;
+      std::vector<bool> branch_is_multigpu;
+      branch_tasks.reserve(fg.outgoing_edges.size());
+      branch_inputs.reserve(fg.outgoing_edges.size());
+      branch_outputs.reserve(fg.outgoing_edges.size());
+      for (int eidx : fg.outgoing_edges) {
+        EdgeInfo const &e = ag.edges[eidx];
+        LayerInfo const &B = ag.layers[e.cons_layer];
+        std::vector<tb::TBInputOp *> b_in, b_out;
+        split_ops(B.op, B.num_inputs, B.num_outputs, b_in, b_out);
+        int b_ns = get_num_subtasks(num_gpus, B.task_type);
+        bool b_mg = (B.task_type == TASK_NVSHMEM_ALLGATHER_STRIDED_PUT);
+        branch_num_subtasks.push_back(b_ns);
+        branch_is_multigpu.push_back(b_mg);
+        branch_inputs.push_back(b_in);
+        branch_outputs.push_back(b_out);
+        branch_tasks.push_back(build_tasks_bid_lex(
+            B.op, B.task_type, B.variant_id, b_ns, b_in, b_out));
+      }
+      // Fork event grid (in producer grid axis frame) is
+      // (p_grid / lcm_last3) per axis. The loop below walks events in
+      // (ex, ey, ez) order; this order is the one that defines task_ids
+      // for consumer tasks, so downstream event emission iterating in the
+      // same order yields contiguous consumer ranges by construction.
+      int ex_max = pgraph.grid_dim.x / std::max(fg.lcm_last3[0], 1);
+      int ey_max = pgraph.grid_dim.y / std::max(fg.lcm_last3[1], 1);
+      int ez_max = pgraph.grid_dim.z / std::max(fg.lcm_last3[2], 1);
+      for (int ex = 0; ex < ex_max; ex++) {
+        for (int ey = 0; ey < ey_max; ey++) {
+          for (int ez = 0; ez < ez_max; ez++) {
+            int3 p_ev{ex, ey, ez};
+            EventDesc event_desc;
+            event_desc.num_triggers = 0;
+            // Mark the start of this fork event's consumer range. All
+            // tasks pushed between here and last_task_id below will be
+            // triggered by this one EventDesc — hence the contiguity
+            // requirement that forces interleaving of branch tasks.
+            event_desc.first_task_id = all_tasks.size();
+            // Emit branch consumer tasks interleaved: for this single fork
+            // event, push branch 0's per-event sub-block, then branch 1's,
+            // ..., then branch N-1's. This keeps all tasks triggered by
+            // this event contiguous in all_tasks.
+            for (size_t b = 0; b < fg.outgoing_edges.size(); b++) {
+              EdgeInfo const &e = ag.edges[fg.outgoing_edges[b]];
+              LayerInfo const &B = ag.layers[e.cons_layer];
+              auto [c_lo, c_hi] =
+                  consumer_subrange_from_fork_event(p_ev, e, B.op->bgraph.grid_dim);
+              push_bids_lex(c_lo, c_hi, B.op->bgraph.grid_dim,
+                            branch_num_subtasks[b], branch_is_multigpu[b],
+                            branch_tasks[b], layer_task_maps[e.cons_layer]);
+            }
+            event_desc.last_task_id = all_tasks.size();
+            // Set trigger_event on producer tasks in the producer sub-range.
+            dim3 p_lo(ex * fg.lcm_last3[0],
+                      ey * fg.lcm_last3[1],
+                      ez * fg.lcm_last3[2]);
+            dim3 p_hi((ex + 1) * fg.lcm_last3[0],
+                      (ey + 1) * fg.lcm_last3[1],
+                      (ez + 1) * fg.lcm_last3[2]);
+            bool nvshmem_event_flag = layer_is_multigpu[fg.producer_layer];
+            set_producer_triggers(p_lo, p_hi,
+                                  layer_task_maps[fg.producer_layer],
+                                  all_events.size(),
+                                  nvshmem_event_flag, event_desc);
+            if (nvshmem_event_flag) {
+              nvshmem_events_idx.insert(all_events.size());
+            }
+            event_desc.event_type =
+                event_desc.last_task_id >= event_desc.first_task_id + 8
+                    ? EVENT_LAUNCH_MASSIVE_TASKS
+                    : EVENT_LAUNCH_TASKS;
+            all_events.push_back(event_desc);
+          }
+        }
+      }
+      // Register each branch's task_map in all_task_maps.
+      for (int eidx : fg.outgoing_edges) {
+        EdgeInfo const &e = ag.edges[eidx];
+        all_task_maps.emplace(
+            const_cast<kn::KNOperator *>(
+                static_cast<kn::KNOperator const *>(ag.layers[e.cons_layer].op)),
+            layer_task_maps[e.cons_layer]);
+      }
+      bundle_emitted[fg_id] = true;
+      continue;
+    }
+
+    // ---- Join consumer: emit the single consumer layer's tasks in
+    // join-event-major order (one contiguous sub-block per join event),
+    // then create ONE EventDesc per join event with num_triggers accumulated
+    // from ALL incoming edges (each incoming producer contributes a slice
+    // of bids that fire this same event). Consumer tasks are in one layer,
+    // so their ranges are naturally contiguous without any interleaving.
+    if (L.is_join_consumer) {
+      int jg_id = ag.edges[L.in_edges[0]].join_group_id;
+      assert(jg_id >= 0);
+      JoinGroupInfo const &jg = ag.join_groups[jg_id];
+      std::vector<FullTaskDesc> tasks = build_tasks_bid_lex(
+          cur_op, task_type, variant_id, cur_num_subtasks, input_ops, output_ops);
+      int ex_max = cur_grid.x / std::max(jg.lcm_last3[0], 1);
+      int ey_max = cur_grid.y / std::max(jg.lcm_last3[1], 1);
+      int ez_max = cur_grid.z / std::max(jg.lcm_last3[2], 1);
+      for (int ex = 0; ex < ex_max; ex++) {
+        for (int ey = 0; ey < ey_max; ey++) {
+          for (int ez = 0; ez < ez_max; ez++) {
+            int3 c_ev{ex, ey, ez};
+            EventDesc event_desc;
+            event_desc.num_triggers = 0;
+            event_desc.first_task_id = all_tasks.size();
+            auto [c_lo, c_hi] =
+                grid_subrange_for_event(ex, ey, ez, jg.lcm_last3, cur_grid);
+            push_bids_lex(c_lo, c_hi, cur_grid, cur_num_subtasks,
+                          cur_is_multigpu, tasks, layer_task_maps[layer_idx]);
+            event_desc.last_task_id = all_tasks.size();
+            bool any_nvshmem = false;
+            for (int eidx : jg.incoming_edges) {
+              EdgeInfo const &e = ag.edges[eidx];
+              bool nvshmem_event_flag = layer_is_multigpu[e.prod_layer];
+              any_nvshmem = any_nvshmem || nvshmem_event_flag;
+              auto [p_lo, p_hi] = producer_subrange_from_join_event(
+                  c_ev, e, ag.layers[e.prod_layer].op->bgraph.grid_dim);
+              set_producer_triggers(p_lo, p_hi,
+                                    layer_task_maps[e.prod_layer],
+                                    all_events.size(),
+                                    nvshmem_event_flag, event_desc);
+            }
+            if (any_nvshmem) {
+              nvshmem_events_idx.insert(all_events.size());
+            }
+            event_desc.event_type =
+                event_desc.last_task_id >= event_desc.first_task_id + 8
+                    ? EVENT_LAUNCH_MASSIVE_TASKS
+                    : EVENT_LAUNCH_TASKS;
+            all_events.push_back(event_desc);
+          }
+        }
+      }
+      all_task_maps.emplace(const_cast<kn::KNOperator *>(
+                                static_cast<kn::KNOperator const *>(cur_op)),
+                            layer_task_maps[layer_idx]);
+      continue;
+    }
+
+    // ---- Chain layer (single distinct producer, not fork-consumer-bundle,
+    // not join). This path exercises the exact same dfs_create_events_add_tasks
+    // the old code used, just with edge info sourced from AnnotatedGraph
+    // rather than rediscovered via guid matching. For graphs that are
+    // already chains (qwen3 today), this produces bit-identical output to
+    // the previous implementation.
+    //
+    // There may be multiple in-edges to this layer from the SAME producer
+    // (multi-tensor bridge — e.g. a producer with 2 output tensors both
+    // feeding this consumer). We use the FIRST non-stripped in-edge as the
+    // event driver; the other edges share the same (prod, cons) pair and
+    // hence the same event grid, so a single event covers them implicitly.
+    assert(!L.in_edges.empty());
+    EdgeInfo const &edge = ag.edges[L.in_edges[0]];
+    LayerInfo const &P = ag.layers[edge.prod_layer];
+    std::vector<FullTaskDesc> tasks = build_tasks_bid_lex(
+        cur_op, task_type, variant_id, cur_num_subtasks, input_ops, output_ops);
+    std::vector<int> event_dims_v(mirage::config::MAX_TENSOR_DIMS, 1);
+    for (int d = 0; d < (int)mirage::config::MAX_TENSOR_DIMS; d++) {
+      event_dims_v[d] = edge.event_dim[d];
+    }
+    bool cur_task_trigger_nvshmem_event = layer_is_multigpu[edge.prod_layer];
+    dfs_create_events_add_tasks(0,
+                                my_gpu_id,
+                                num_gpus,
+                                event_dims_v,
+                                edge.input_map,
+                                edge.output_map,
+                                cur_grid,
+                                P.op->bgraph.grid_dim,
+                                dim3(0, 0, 0),
+                                cur_grid,
+                                dim3(0, 0, 0),
+                                P.op->bgraph.grid_dim,
+                                all_events,
+                                all_tasks,
+                                tasks,
+                                layer_task_maps[edge.prod_layer],
+                                layer_task_maps[layer_idx],
+                                nvshmem_events_idx,
+                                cur_task_trigger_nvshmem_event,
+                                cur_is_multigpu);
+    all_task_maps.emplace(const_cast<kn::KNOperator *>(
+                              static_cast<kn::KNOperator const *>(cur_op)),
+                          layer_task_maps[layer_idx]);
   }
 
-  // Update the trigger event for all tasks in pre_task_map
-  for (auto const &it : pre_task_map) {
-    assert(it.second.size() == 1);
-    all_tasks[it.second[0]].trigger_event =
-        get_event_id(my_gpu_id, all_events.size(), false /*nvshmem_event*/);
+  // Update the trigger event for all tasks in every LEAF layer's task map
+  // (drives EVENT_END_OF_TASK_GRAPH).
+  //
+  // For chain graphs this is the single final layer (what the old code
+  // handled). For DAGs with multiple terminal branches (e.g. an unjoined
+  // fork where each branch ends at its own output), EVERY leaf layer's
+  // tasks must contribute their completion to the END event; otherwise
+  // the non-last leaves' tasks end up with trigger_event = INVALID and
+  // the runtime can't correctly count graph completion. This was a bug
+  // caught by the fork unit test.
+  size_t end_num_triggers = 0;
+  for (int i = 0; i < V; i++) {
+    if (!ag.layers[i].out_edges.empty()) {
+      continue;
+    }
+    for (auto const &it : layer_task_maps[i]) {
+      assert(it.second.size() == 1);
+      all_tasks[it.second[0]].trigger_event =
+          get_event_id(my_gpu_id, all_events.size(), false /*nvshmem_event*/);
+      end_num_triggers++;
+    }
   }
   all_events.push_back(
-      EventDesc(EVENT_END_OF_TASK_GRAPH, pre_task_map.size(), 0, 0));
+      EventDesc(EVENT_END_OF_TASK_GRAPH, end_num_triggers, 0, 0));
 
   // Prelaunch all tasks at the begining of an iteration
   all_events[1].first_task_id = 2;
@@ -922,6 +1297,24 @@ TaskGraphResult print_task_graph(
              {"task_offset", -1}});
   }
   // generate all other tasks
+  // Global buffer of (task_id -> json_task).
+  //
+  // The old code wrote `json_tasks[task_id - starting_task_id] = ...` with
+  // json_tasks sized to a single op's grid volume, assuming each op's
+  // tasks were a contiguous block in all_tasks. With DAG-level fork
+  // emission, a fork-consumer layer's tasks are INTERLEAVED with its
+  // siblings (e.g. layer B's tasks live at indices 18, 20, 22, ...; layer
+  // C's at 19, 21, 23, ...). Writing into a per-op vector with task_id -
+  // starting_task_id offsets then overflows (layer B's offset 30 into a
+  // vector sized 16), causing heap corruption — the double-free we saw
+  // the first time the fork test ran.
+  //
+  // Fix: buffer every task's json by global task_id; after visiting every
+  // op, flush in strict task_id order so that the JSON's "all_tasks"
+  // array index matches the runtime's all_tasks vector index.
+  std::vector<json> global_json_tasks(all_tasks.size());
+  std::vector<char> global_json_filled(all_tasks.size(), 0);
+
   size_t task_pos = 2;
   for (auto const &op : graph.operators) {
     if (op->op_type == type::KNOperatorType::KN_INPUT_OP) {
@@ -955,12 +1348,11 @@ TaskGraphResult print_task_graph(
 
     unsigned cur_op_num_subtasks = get_num_subtasks(num_gpus, task_type);
 
-    // There is no guarantee that the tasks are added in (x,y,z) order,
-    // so, to keep the final tasks array in order, we need to re-order them
-    // here. ! tgbody-based gen is still prone to ordering issue.
-    std::vector<json> json_tasks(bgraph.grid_dim.x * bgraph.grid_dim.y *
-                                 bgraph.grid_dim.z * cur_op_num_subtasks);
-    TaskId starting_task_id = task_pos;
+    // Tasks may be non-contiguous in all_tasks (DAG fork interleaving), so we
+    // write directly into the global task-id-indexed buffer.
+    size_t op_total_subtasks = (size_t)bgraph.grid_dim.x * bgraph.grid_dim.y *
+                               bgraph.grid_dim.z * cur_op_num_subtasks;
+    (void)op_total_subtasks;
     for (bid.x = 0; bid.x < bgraph.grid_dim.x; bid.x++) {
       for (bid.y = 0; bid.y < bgraph.grid_dim.y; bid.y++) {
         for (bid.z = 0; bid.z < bgraph.grid_dim.z; bid.z++) {
@@ -1235,19 +1627,26 @@ TaskGraphResult print_task_graph(
 
             tgbody.e("all_tasks.push_back(task_desc);");
             tgbody.e("}");
-            // json_task_graph["all_tasks"].push_back(json_task);
-            json_tasks[task_id - starting_task_id] = json_task;
+            assert((size_t)task_id < global_json_tasks.size());
+            assert(!global_json_filled[task_id]);
+            global_json_tasks[task_id] = json_task;
+            global_json_filled[task_id] = 1;
           } // subtask_id
         }   // bid.z
       }     // bid.y
     }       // bid.x
 
-    for (int i = 0; i < json_tasks.size(); i++) {
-      json_task_graph["all_tasks"].push_back(json_tasks[i]);
-    }
-    task_pos += json_tasks.size();
+    task_pos += op_total_subtasks;
   }
   assert(task_pos == all_tasks.size());
+
+  // Flush tasks 2..N-1 in task_id order. Tasks 0 (TASK_TERMINATE) and 1
+  // (TASK_BEGIN_TASK_GRAPH) are prelude and handled by the generated
+  // construct_task_graph loader (not in JSON all_tasks).
+  for (size_t task_id = 2; task_id < all_tasks.size(); task_id++) {
+    assert(global_json_filled[task_id]);
+    json_task_graph["all_tasks"].push_back(global_json_tasks[task_id]);
+  }
   // Add all events
   for (auto const &event : all_events) {
     tgbody.e(

--- a/tests/runtime_python/test_mode/test_case2_case3_negative_testmode.py
+++ b/tests/runtime_python/test_mode/test_case2_case3_negative_testmode.py
@@ -1,0 +1,195 @@
+"""
+Negative tests for disallowed role combinations detected by the
+AnnotatedGraph pre-pass.
+
+Each scenario runs in a child process because the C++ compile error is a
+std::runtime_error that propagates past the Python binding and calls
+std::terminate(). Running in a subprocess lets us inspect its stderr and
+exit code instead of crashing the test runner.
+
+  - Case 2: a layer is both a join-consumer AND a fork-consumer (would need
+    two trigger_events on one task). MUST abort compile with "case 2".
+  - Case 3: a layer is both a fork-producer AND a join-producer (would need
+    two dependent_events on one task). MUST abort compile with "case 3".
+"""
+
+import os
+import subprocess
+import sys
+import textwrap
+
+
+_COMMON_HEADER = """
+import torch
+import mirage
+from mirage.mpk.persistent_kernel import PersistentKernel
+
+
+def _make_pk():
+    num_workers, num_schedulers = mirage.get_configurations_from_gpu(0)
+    params = PersistentKernel.get_default_init_parameters()
+    params["test_mode"] = True
+    params["num_workers"] = num_workers
+    params["num_local_schedulers"] = num_schedulers
+    params["mpi_rank"] = 0
+    params["world_size"] = 1
+    params["max_num_batched_tokens"] = 8
+    params["max_num_batched_requests"] = 8
+    return PersistentKernel(**params)
+"""
+
+
+_CASE2_CHILD = _COMMON_HEADER + """
+device = "cuda"
+dtype = torch.bfloat16
+batch_size = 8
+hidden = 4096
+torch.manual_seed(0)
+
+x_in  = torch.randn(batch_size, hidden, dtype=dtype, device=device) * 0.1
+w_l1  = torch.randn(hidden, dtype=dtype, device=device) * 0.1
+w_m   = torch.randn(hidden, dtype=dtype, device=device) * 0.1
+w_b   = torch.randn(hidden, hidden, dtype=dtype, device=device) * 0.01
+w_c   = torch.randn(hidden, dtype=dtype, device=device) * 0.1
+x_l1  = torch.zeros(batch_size, hidden, dtype=dtype, device=device)
+x_m   = torch.zeros(batch_size, hidden, dtype=dtype, device=device)
+x_b   = torch.zeros(batch_size, hidden, dtype=dtype, device=device)
+x_c   = torch.zeros(batch_size, hidden, dtype=dtype, device=device)
+
+pk = _make_pk()
+dt = {
+  'x_in': pk.attach_input(x_in,  name='x_in'),
+  'w_l1': pk.attach_input(w_l1,  name='w_l1'),
+  'w_m':  pk.attach_input(w_m,   name='w_m'),
+  'w_b':  pk.attach_input(w_b,   name='w_b'),
+  'w_c':  pk.attach_input(w_c,   name='w_c'),
+  'x_l1': pk.attach_input(x_l1,  name='x_l1'),
+  'x_m':  pk.attach_input(x_m,   name='x_m'),
+  'x_b':  pk.attach_input(x_b,   name='x_b'),
+  'x_c':  pk.attach_input(x_c,   name='x_c'),
+}
+target_cc = pk.target_cc
+block_dim = (256, 1, 1) if target_cc >= 90 else (128, 1, 1)
+linear_grid_x = hidden // 96 if hidden % 96 == 0 else hidden // 64
+
+pk.rmsnorm_layer(input=dt['x_in'], weight=dt['w_l1'], output=dt['x_l1'],
+                 grid_dim=(batch_size, 1, 1), block_dim=block_dim)
+pk.rmsnorm_layer(input=dt['x_in'], weight=dt['w_m'], output=dt['x_m'],
+                 grid_dim=(batch_size, 1, 1), block_dim=block_dim)
+# B = linear_with_residual(x_l1, w_b, x_m) -> join consumer + fork consumer
+pk.linear_with_residual_layer(
+    input=dt['x_l1'], weight=dt['w_b'], residual=dt['x_m'], output=dt['x_b'],
+    grid_dim=(linear_grid_x, batch_size, 1), block_dim=block_dim)
+# C = rmsnorm(x_l1) -> the second fork branch from L1
+pk.rmsnorm_layer(input=dt['x_l1'], weight=dt['w_c'], output=dt['x_c'],
+                 grid_dim=(batch_size, 1, 1), block_dim=block_dim)
+
+import os as _os
+pk.compile(output_dir=_os.path.dirname(_os.path.abspath(__file__) if '__file__' in dir() else '.'))
+"""
+
+
+_CASE3_CHILD = _COMMON_HEADER + """
+device = "cuda"
+dtype = torch.bfloat16
+batch_size = 8
+hidden = 4096
+torch.manual_seed(0)
+
+x_in  = torch.randn(batch_size, hidden, dtype=dtype, device=device) * 0.1
+w_l   = torch.randn(hidden, dtype=dtype, device=device) * 0.1
+w_z   = torch.randn(hidden, dtype=dtype, device=device) * 0.1
+w_j   = torch.randn(hidden, hidden, dtype=dtype, device=device) * 0.01
+w_k   = torch.randn(hidden, dtype=dtype, device=device) * 0.1
+x_l   = torch.zeros(batch_size, hidden, dtype=dtype, device=device)
+x_z   = torch.zeros(batch_size, hidden, dtype=dtype, device=device)
+x_j   = torch.zeros(batch_size, hidden, dtype=dtype, device=device)
+x_k   = torch.zeros(batch_size, hidden, dtype=dtype, device=device)
+
+pk = _make_pk()
+dt = {
+  'x_in': pk.attach_input(x_in,  name='x_in'),
+  'w_l':  pk.attach_input(w_l,   name='w_l'),
+  'w_z':  pk.attach_input(w_z,   name='w_z'),
+  'w_j':  pk.attach_input(w_j,   name='w_j'),
+  'w_k':  pk.attach_input(w_k,   name='w_k'),
+  'x_l':  pk.attach_input(x_l,   name='x_l'),
+  'x_z':  pk.attach_input(x_z,   name='x_z'),
+  'x_j':  pk.attach_input(x_j,   name='x_j'),
+  'x_k':  pk.attach_input(x_k,   name='x_k'),
+}
+target_cc = pk.target_cc
+block_dim = (256, 1, 1) if target_cc >= 90 else (128, 1, 1)
+linear_grid_x = hidden // 96 if hidden % 96 == 0 else hidden // 64
+
+# L is a fork producer (L -> J, L -> K).
+pk.rmsnorm_layer(input=dt['x_in'], weight=dt['w_l'], output=dt['x_l'],
+                 grid_dim=(batch_size, 1, 1), block_dim=block_dim)
+# Z is another producer feeding the join at J.
+pk.rmsnorm_layer(input=dt['x_in'], weight=dt['w_z'], output=dt['x_z'],
+                 grid_dim=(batch_size, 1, 1), block_dim=block_dim)
+# J is a join consumer: two distinct producers (L and Z).
+pk.linear_with_residual_layer(
+    input=dt['x_l'], weight=dt['w_j'], residual=dt['x_z'], output=dt['x_j'],
+    grid_dim=(linear_grid_x, batch_size, 1), block_dim=block_dim)
+# K is the other fork branch from L.
+pk.rmsnorm_layer(input=dt['x_l'], weight=dt['w_k'], output=dt['x_k'],
+                 grid_dim=(batch_size, 1, 1), block_dim=block_dim)
+
+# L has out-edges to J (join-consumer) and K -> L is join-producer AND
+# fork-producer -> Case 3.
+import os as _os
+pk.compile(output_dir=_os.path.dirname(_os.path.abspath(__file__) if '__file__' in dir() else '.'))
+"""
+
+
+def _run_child(source, case_name):
+    """
+    Cases 2 and 3 are mathematically coupled: whenever a layer X is a
+    join-consumer AND a fork-consumer (case 2), one of X's producers is
+    necessarily both a fork-producer and a join-producer (case 3). The two
+    violations co-occur for any disallowed topology. We therefore accept
+    either error text.
+    """
+    result = subprocess.run(
+        [sys.executable, "-c", source],
+        capture_output=True,
+        text=True,
+        env=dict(os.environ, CUDA_VISIBLE_DEVICES="0"),
+        timeout=120,
+    )
+    combined = (result.stdout or "") + (result.stderr or "")
+    saw_case2 = "case 2" in combined
+    saw_case3 = "case 3" in combined
+    if (saw_case2 or saw_case3) and result.returncode != 0:
+        marker = "case 2" if saw_case2 else "case 3"
+        first_error_line = next(
+            (line for line in combined.splitlines() if marker in line),
+            "<error line not found>")
+        print(f"PASSED: {case_name}: child aborted with disallowed-pattern error")
+        print(f"    {first_error_line.strip()}")
+        return True
+    print(f"FAILED: {case_name}")
+    print(f"  returncode = {result.returncode}")
+    print(f"  stdout:\n{result.stdout}")
+    print(f"  stderr:\n{result.stderr}")
+    return False
+
+
+def test_case2_negative():
+    ok = _run_child(_CASE2_CHILD,
+                    "case 2 scenario (join-consumer + fork-consumer at B)")
+    if not ok:
+        sys.exit(1)
+
+
+def test_case3_negative():
+    ok = _run_child(_CASE3_CHILD,
+                    "case 3 scenario (fork-producer + join-producer at L)")
+    if not ok:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    test_case2_negative()
+    test_case3_negative()

--- a/tests/runtime_python/test_mode/test_diamond_fork_join_testmode.py
+++ b/tests/runtime_python/test_mode/test_diamond_fork_join_testmode.py
@@ -1,0 +1,149 @@
+"""
+Diamond fork+join test with GEMM branches.
+
+Graph:
+        x_input --A(rmsnorm)--> x_a
+                                 |
+                   +-------------+-------------+
+                   |                           |
+                   v                           v
+            B(linear, w_b) -> x_b      C(linear, w_c) -> x_c
+                   |                           |
+                   +-------------+-------------+
+                                 v
+               D(linear_with_residual, input=x_b, residual=x_c) -> x_d
+
+Role classification:
+  - A: is_fork_producer (B and C are distinct downstream consumers)
+  - D: is_join_consumer (B and C are distinct upstream producers)
+  - B: is_fork_consumer (reads x_a from fork producer A)
+       AND is_join_producer (writes x_b that feeds join consumer D)
+       -> CASE 4 (allowed): trigger_event from fork event, dependent_event
+          to join event. Two different slots, no conflict.
+  - C: same as B (case 4)
+
+This exercises:
+  - Both fork and join in a single compilation.
+  - The case-4 role combination on the two middle layers.
+  - GEMM (linear) computation on the parallel branches, which uses a 2D
+    grid (hidden-tiling x batch) different from rmsnorm's 1D batch grid,
+    so the fork/join LCM math runs on non-trivial grid shapes.
+
+Note on event-grid: linear's input_map for its activation input is
+(-1, -1, -1) (replicated across all grid axes), which means the fork
+event_dim between A and B/C collapses to 1-per-axis after LCM. Similarly
+the join event_dim between B and D (via linear_with_residual's `input`
+slot, also replicated) collapses. This is the expected outcome: when
+any branch reads the producer's output with full replication, the
+entire producer must be done before any consumer task starts, so a
+single event per boundary is correct.
+"""
+
+import torch
+import sys
+import os
+
+import mirage
+from mirage.mpk.persistent_kernel import PersistentKernel
+
+
+def torch_rmsnorm(x, weight, eps=1e-5):
+    variance = x.to(torch.float32).pow(2).mean(dim=-1, keepdim=True)
+    x_normed = x * torch.rsqrt(variance + eps)
+    return (x_normed * weight).to(x.dtype)
+
+
+def test_diamond_fork_join_testmode():
+    device = "cuda"
+    dtype = torch.bfloat16
+    batch_size = 8
+    hidden = 4096
+
+    torch.manual_seed(3)
+    x_input = torch.randn(batch_size, hidden, dtype=dtype, device=device) * 0.1
+    w_a = torch.randn(hidden, dtype=dtype, device=device) * 0.1
+    # Scale weights down so that linear output stays in a comfortable range
+    # for bf16 accumulation.
+    w_b = torch.randn(hidden, hidden, dtype=dtype, device=device) * 0.01
+    w_c = torch.randn(hidden, hidden, dtype=dtype, device=device) * 0.01
+    w_d = torch.randn(hidden, hidden, dtype=dtype, device=device) * 0.01
+
+    x_a = torch.zeros(batch_size, hidden, dtype=dtype, device=device)
+    x_b = torch.zeros(batch_size, hidden, dtype=dtype, device=device)
+    x_c = torch.zeros(batch_size, hidden, dtype=dtype, device=device)
+    x_d = torch.zeros(batch_size, hidden, dtype=dtype, device=device)
+
+    num_workers, num_schedulers = mirage.get_configurations_from_gpu(0)
+    params = PersistentKernel.get_default_init_parameters()
+    params["test_mode"] = True
+    params["num_workers"] = num_workers
+    params["num_local_schedulers"] = num_schedulers
+    params["mpi_rank"] = 0
+    params["world_size"] = 1
+    params["max_num_batched_tokens"] = batch_size
+    params["max_num_batched_requests"] = batch_size
+    pk = PersistentKernel(**params)
+
+    x_input_dt = pk.attach_input(x_input, name="x_input")
+    w_a_dt = pk.attach_input(w_a, name="w_a")
+    w_b_dt = pk.attach_input(w_b, name="w_b")
+    w_c_dt = pk.attach_input(w_c, name="w_c")
+    w_d_dt = pk.attach_input(w_d, name="w_d")
+    x_a_dt = pk.attach_input(x_a, name="x_a")
+    x_b_dt = pk.attach_input(x_b, name="x_b")
+    x_c_dt = pk.attach_input(x_c, name="x_c")
+    x_d_dt = pk.attach_input(x_d, name="x_d")
+
+    target_cc = pk.target_cc
+    block_dim = (256, 1, 1) if target_cc >= 90 else (128, 1, 1)
+    linear_grid_x = hidden // 96 if hidden % 96 == 0 else hidden // 64
+
+    # A: rmsnorm (fork producer). x_a = rmsnorm(x_input, w_a)
+    pk.rmsnorm_layer(input=x_input_dt, weight=w_a_dt, output=x_a_dt,
+                     grid_dim=(batch_size, 1, 1), block_dim=block_dim)
+    # B: linear branch 1. x_b = x_a @ w_b.T
+    pk.linear_layer(input=x_a_dt, weight=w_b_dt, output=x_b_dt,
+                    grid_dim=(linear_grid_x, batch_size, 1), block_dim=block_dim)
+    # C: linear branch 2. x_c = x_a @ w_c.T
+    pk.linear_layer(input=x_a_dt, weight=w_c_dt, output=x_c_dt,
+                    grid_dim=(linear_grid_x, batch_size, 1), block_dim=block_dim)
+    # D: join consumer. x_d = x_b @ w_d.T + x_c
+    pk.linear_with_residual_layer(
+        input=x_b_dt, weight=w_d_dt, residual=x_c_dt, output=x_d_dt,
+        grid_dim=(linear_grid_x, batch_size, 1), block_dim=block_dim)
+
+    print("Compiling diamond fork+join test kernel...")
+    folder_path = os.path.dirname(__file__)
+    pk.compile(output_dir=folder_path)
+
+    print("Running diamond fork+join test kernel...")
+    pk.run_test_mode()
+    torch.cuda.synchronize()
+
+    ref_a = torch_rmsnorm(x_input, w_a)
+    ref_b = (ref_a.float() @ w_b.float().T).to(dtype)
+    ref_c = (ref_a.float() @ w_c.float().T).to(dtype)
+    ref_d = (ref_b.float() @ w_d.float().T).to(dtype) + ref_c
+
+    def max_diff(a, b):
+        return (a - b).abs().max().item()
+
+    diff_a = max_diff(x_a, ref_a)
+    diff_b = max_diff(x_b, ref_b)
+    diff_c = max_diff(x_c, ref_c)
+    diff_d = max_diff(x_d, ref_d)
+    print(f"diff A = {diff_a}, B = {diff_b}, C = {diff_c}, D = {diff_d}")
+
+    # GEMM accumulation in bf16 has higher noise than rmsnorm; scale tol
+    # with number of GEMMs chained.
+    if diff_a < 0.1 and diff_b < 0.5 and diff_c < 0.5 and diff_d < 1.0:
+        print("PASSED: diamond_fork_join test_mode produces correct output")
+    else:
+        print(f"FAILED: diffs A={diff_a} B={diff_b} C={diff_c} D={diff_d}")
+        sys.exit(1)
+
+    pk.finalize()
+
+
+if __name__ == "__main__":
+    test_diamond_fork_join_testmode()

--- a/tests/runtime_python/test_mode/test_fork_point_testmode.py
+++ b/tests/runtime_python/test_mode/test_fork_point_testmode.py
@@ -1,0 +1,105 @@
+"""
+Fork-point test for the AnnotatedGraph pre-pass and fork emission.
+
+Graph:
+      x_input --rmsnorm(A)--> x_a --rmsnorm(B)--> x_b
+                                \\--rmsnorm(C)--> x_c
+
+A's output x_a is consumed by TWO distinct downstream layers (B and C), which
+is the canonical fork pattern. We verify:
+  1. Compilation succeeds (pre-pass detects 1 fork group, 2 outgoing edges).
+  2. Output matches a PyTorch reference.
+"""
+
+import torch
+import sys
+import os
+
+import mirage
+from mirage.mpk.persistent_kernel import PersistentKernel
+
+
+def torch_rmsnorm(x, weight, eps=1e-5):
+    variance = x.to(torch.float32).pow(2).mean(dim=-1, keepdim=True)
+    x_normed = x * torch.rsqrt(variance + eps)
+    return (x_normed * weight).to(x.dtype)
+
+
+def test_fork_point_testmode():
+    device = "cuda"
+    dtype = torch.bfloat16
+    batch_size = 16
+    hidden_dim = 4096
+
+    torch.manual_seed(0)
+    x_input = torch.randn(batch_size, hidden_dim, dtype=dtype, device=device)
+    w_a = torch.randn(hidden_dim, dtype=dtype, device=device)
+    w_b = torch.randn(hidden_dim, dtype=dtype, device=device)
+    w_c = torch.randn(hidden_dim, dtype=dtype, device=device)
+
+    x_a = torch.zeros(batch_size, hidden_dim, dtype=dtype, device=device)
+    x_b = torch.zeros(batch_size, hidden_dim, dtype=dtype, device=device)
+    x_c = torch.zeros(batch_size, hidden_dim, dtype=dtype, device=device)
+
+    num_workers, num_schedulers = mirage.get_configurations_from_gpu(0)
+    params = PersistentKernel.get_default_init_parameters()
+    params["test_mode"] = True
+    params["num_workers"] = num_workers
+    params["num_local_schedulers"] = num_schedulers
+    params["mpi_rank"] = 0
+    params["world_size"] = 1
+    pk = PersistentKernel(**params)
+
+    x_input_dt = pk.attach_input(x_input, name="x_input")
+    w_a_dt = pk.attach_input(w_a, name="w_a")
+    w_b_dt = pk.attach_input(w_b, name="w_b")
+    w_c_dt = pk.attach_input(w_c, name="w_c")
+    x_a_dt = pk.attach_input(x_a, name="x_a")
+    x_b_dt = pk.attach_input(x_b, name="x_b")
+    x_c_dt = pk.attach_input(x_c, name="x_c")
+
+    target_cc = pk.target_cc
+    block_dim = (256, 1, 1) if target_cc >= 90 else (128, 1, 1)
+
+    # Layer A: x_input -> x_a  (fork producer: x_a feeds both B and C)
+    pk.rmsnorm_layer(input=x_input_dt, weight=w_a_dt, output=x_a_dt,
+                     grid_dim=(batch_size, 1, 1), block_dim=block_dim)
+    # Layer B: x_a -> x_b  (fork branch 1)
+    pk.rmsnorm_layer(input=x_a_dt, weight=w_b_dt, output=x_b_dt,
+                     grid_dim=(batch_size, 1, 1), block_dim=block_dim)
+    # Layer C: x_a -> x_c  (fork branch 2)
+    pk.rmsnorm_layer(input=x_a_dt, weight=w_c_dt, output=x_c_dt,
+                     grid_dim=(batch_size, 1, 1), block_dim=block_dim)
+
+    print("Compiling fork-point test kernel...")
+    folder_path = os.path.dirname(__file__)
+    pk.compile(output_dir=folder_path)
+
+    print("Running fork-point test kernel...")
+    pk.run_test_mode()
+    torch.cuda.synchronize()
+
+    ref_a = torch_rmsnorm(x_input, w_a)
+    ref_b = torch_rmsnorm(ref_a, w_b)
+    ref_c = torch_rmsnorm(ref_a, w_c)
+
+    def max_diff(a, b):
+        return (a - b).abs().max().item()
+
+    diff_a = max_diff(x_a, ref_a)
+    diff_b = max_diff(x_b, ref_b)
+    diff_c = max_diff(x_c, ref_c)
+    print(f"diff A = {diff_a}, diff B = {diff_b}, diff C = {diff_c}")
+
+    tol = 0.1
+    if max(diff_a, diff_b, diff_c) < tol:
+        print("PASSED: fork_point test_mode produces correct output on both branches")
+    else:
+        print(f"FAILED: one or more branch outputs exceed tolerance {tol}")
+        sys.exit(1)
+
+    pk.finalize()
+
+
+if __name__ == "__main__":
+    test_fork_point_testmode()

--- a/tests/runtime_python/test_mode/test_grid_dim_sweep_testmode.py
+++ b/tests/runtime_python/test_mode/test_grid_dim_sweep_testmode.py
@@ -1,0 +1,133 @@
+"""
+Grid-dim sweep test for the fork-point emission.
+
+Re-runs the basic fork pattern (A -> {B, C}) under several (batch_size,
+hidden) configurations. Varying batch_size directly changes the number of
+fork events emitted (one per batch item when grid_dim.x = batch_size), so
+this exercises the fork emission / prelaunch conversion / JSON task flush
+across meaningfully different task-id layouts.
+
+Parameters covered:
+  (batch_size=4,  hidden=4096) -> 4 fork events, 12 tasks total (3 layers x 4)
+  (batch_size=8,  hidden=4096) -> 8 fork events, 24 tasks
+  (batch_size=16, hidden=4096) -> 16 fork events, 48 tasks
+  (batch_size=8,  hidden=2048) -> 8 fork events at a narrower hidden dim
+
+Each config is compiled and executed in its own PersistentKernel so state
+from one config does not leak into the next.
+"""
+
+import torch
+import sys
+import os
+
+import mirage
+from mirage.mpk.persistent_kernel import PersistentKernel
+
+
+def torch_rmsnorm(x, weight, eps=1e-5):
+    variance = x.to(torch.float32).pow(2).mean(dim=-1, keepdim=True)
+    x_normed = x * torch.rsqrt(variance + eps)
+    return (x_normed * weight).to(x.dtype)
+
+
+def _run_one_config(batch_size, hidden, tag):
+    device = "cuda"
+    dtype = torch.bfloat16
+    torch.manual_seed(42 + batch_size * 100 + hidden)
+
+    x_input = torch.randn(batch_size, hidden, dtype=dtype, device=device)
+    w_a = torch.randn(hidden, dtype=dtype, device=device)
+    w_b = torch.randn(hidden, dtype=dtype, device=device)
+    w_c = torch.randn(hidden, dtype=dtype, device=device)
+    x_a = torch.zeros(batch_size, hidden, dtype=dtype, device=device)
+    x_b = torch.zeros(batch_size, hidden, dtype=dtype, device=device)
+    x_c = torch.zeros(batch_size, hidden, dtype=dtype, device=device)
+
+    num_workers, num_schedulers = mirage.get_configurations_from_gpu(0)
+    params = PersistentKernel.get_default_init_parameters()
+    params["test_mode"] = True
+    params["num_workers"] = num_workers
+    params["num_local_schedulers"] = num_schedulers
+    params["mpi_rank"] = 0
+    params["world_size"] = 1
+    params["max_num_batched_tokens"] = batch_size
+    params["max_num_batched_requests"] = batch_size
+    pk = PersistentKernel(**params)
+
+    x_input_dt = pk.attach_input(x_input, name="x_input")
+    w_a_dt = pk.attach_input(w_a, name="w_a")
+    w_b_dt = pk.attach_input(w_b, name="w_b")
+    w_c_dt = pk.attach_input(w_c, name="w_c")
+    x_a_dt = pk.attach_input(x_a, name="x_a")
+    x_b_dt = pk.attach_input(x_b, name="x_b")
+    x_c_dt = pk.attach_input(x_c, name="x_c")
+
+    target_cc = pk.target_cc
+    block_dim = (256, 1, 1) if target_cc >= 90 else (128, 1, 1)
+
+    pk.rmsnorm_layer(input=x_input_dt, weight=w_a_dt, output=x_a_dt,
+                     grid_dim=(batch_size, 1, 1), block_dim=block_dim)
+    pk.rmsnorm_layer(input=x_a_dt, weight=w_b_dt, output=x_b_dt,
+                     grid_dim=(batch_size, 1, 1), block_dim=block_dim)
+    pk.rmsnorm_layer(input=x_a_dt, weight=w_c_dt, output=x_c_dt,
+                     grid_dim=(batch_size, 1, 1), block_dim=block_dim)
+
+    print(f"[{tag}] Compiling...")
+    folder_path = os.path.dirname(__file__)
+    pk.compile(output_dir=folder_path)
+
+    print(f"[{tag}] Running...")
+    pk.run_test_mode()
+    torch.cuda.synchronize()
+
+    ref_a = torch_rmsnorm(x_input, w_a)
+    ref_b = torch_rmsnorm(ref_a, w_b)
+    ref_c = torch_rmsnorm(ref_a, w_c)
+
+    def max_diff(a, b):
+        return (a - b).abs().max().item()
+
+    diff_a = max_diff(x_a, ref_a)
+    diff_b = max_diff(x_b, ref_b)
+    diff_c = max_diff(x_c, ref_c)
+
+    tol = 0.2
+    ok = diff_a < tol and diff_b < tol and diff_c < tol
+    status = "OK" if ok else "FAIL"
+    print(f"[{tag}] diff A={diff_a:.5f}, B={diff_b:.5f}, C={diff_c:.5f} {status}")
+
+    pk.finalize()
+    return ok
+
+
+def test_grid_dim_sweep_testmode():
+    configs = [
+        (4, 4096, "b=4 h=4096"),
+        (8, 4096, "b=8 h=4096"),
+        (16, 4096, "b=16 h=4096"),
+        (8, 2048, "b=8 h=2048"),
+    ]
+    results = []
+    for batch, hidden, tag in configs:
+        print(f"\n=== {tag} ===")
+        try:
+            ok = _run_one_config(batch, hidden, tag)
+        except Exception as e:
+            print(f"[{tag}] exception: {e}")
+            ok = False
+        results.append((tag, ok))
+
+    print("\nSummary:")
+    for tag, ok in results:
+        print(f"  {tag}: {'PASS' if ok else 'FAIL'}")
+
+    if all(ok for _, ok in results):
+        print("PASSED: grid_dim_sweep all configs produce correct output")
+    else:
+        print("FAILED: at least one config failed")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    test_grid_dim_sweep_testmode()

--- a/tests/runtime_python/test_mode/test_join_point_testmode.py
+++ b/tests/runtime_python/test_mode/test_join_point_testmode.py
@@ -1,0 +1,119 @@
+"""
+Join-point test for the AnnotatedGraph pre-pass and join emission.
+
+Graph (two independent inputs, no path between them):
+   x1_input --A(rmsnorm)--> x_a
+                              \\
+                               \\
+                                `-> C: linear_with_residual(input=x_a,
+                                                            weight=w_c,
+                                                            residual=x_b,
+                                                            output=x_c)
+                               /
+                              /
+   x2_input --B(rmsnorm)--> x_b
+
+C has two distinct producers (A and B), and since x1_input and x2_input are
+independent (no path between A and B), no residual stripping applies. C is a
+join-consumer (is_join_consumer == true) and the join event unifies A and B.
+
+We verify compilation succeeds (1 join group, 2 incoming edges) and output
+matches a PyTorch reference.
+"""
+
+import torch
+import sys
+import os
+
+import mirage
+from mirage.mpk.persistent_kernel import PersistentKernel
+
+
+def torch_rmsnorm(x, weight, eps=1e-5):
+    variance = x.to(torch.float32).pow(2).mean(dim=-1, keepdim=True)
+    x_normed = x * torch.rsqrt(variance + eps)
+    return (x_normed * weight).to(x.dtype)
+
+
+def test_join_point_testmode():
+    device = "cuda"
+    dtype = torch.bfloat16
+    batch_size = 8
+    hidden = 4096
+
+    torch.manual_seed(2)
+    x1_input = torch.randn(batch_size, hidden, dtype=dtype, device=device) * 0.1
+    x2_input = torch.randn(batch_size, hidden, dtype=dtype, device=device) * 0.1
+    w_a = torch.randn(hidden, dtype=dtype, device=device) * 0.1
+    w_b = torch.randn(hidden, dtype=dtype, device=device) * 0.1
+    w_c = torch.randn(hidden, hidden, dtype=dtype, device=device) * 0.01
+
+    x_a = torch.zeros(batch_size, hidden, dtype=dtype, device=device)
+    x_b = torch.zeros(batch_size, hidden, dtype=dtype, device=device)
+    x_c = torch.zeros(batch_size, hidden, dtype=dtype, device=device)
+
+    num_workers, num_schedulers = mirage.get_configurations_from_gpu(0)
+    params = PersistentKernel.get_default_init_parameters()
+    params["test_mode"] = True
+    params["num_workers"] = num_workers
+    params["num_local_schedulers"] = num_schedulers
+    params["mpi_rank"] = 0
+    params["world_size"] = 1
+    params["max_num_batched_tokens"] = batch_size
+    params["max_num_batched_requests"] = batch_size
+    pk = PersistentKernel(**params)
+
+    x1_dt = pk.attach_input(x1_input, name="x1_input")
+    x2_dt = pk.attach_input(x2_input, name="x2_input")
+    w_a_dt = pk.attach_input(w_a, name="w_a")
+    w_b_dt = pk.attach_input(w_b, name="w_b")
+    w_c_dt = pk.attach_input(w_c, name="w_c")
+    x_a_dt = pk.attach_input(x_a, name="x_a")
+    x_b_dt = pk.attach_input(x_b, name="x_b")
+    x_c_dt = pk.attach_input(x_c, name="x_c")
+
+    target_cc = pk.target_cc
+    block_dim = (256, 1, 1) if target_cc >= 90 else (128, 1, 1)
+
+    pk.rmsnorm_layer(input=x1_dt, weight=w_a_dt, output=x_a_dt,
+                     grid_dim=(batch_size, 1, 1), block_dim=block_dim)
+    pk.rmsnorm_layer(input=x2_dt, weight=w_b_dt, output=x_b_dt,
+                     grid_dim=(batch_size, 1, 1), block_dim=block_dim)
+
+    linear_grid_x = hidden // 96 if hidden % 96 == 0 else hidden // 64
+    pk.linear_with_residual_layer(
+        input=x_a_dt, weight=w_c_dt, residual=x_b_dt, output=x_c_dt,
+        grid_dim=(linear_grid_x, batch_size, 1), block_dim=block_dim)
+
+    print("Compiling join-point test kernel...")
+    folder_path = os.path.dirname(__file__)
+    pk.compile(output_dir=folder_path)
+
+    print("Running join-point test kernel...")
+    pk.run_test_mode()
+    torch.cuda.synchronize()
+
+    ref_a = torch_rmsnorm(x1_input, w_a)
+    ref_b = torch_rmsnorm(x2_input, w_b)
+    ref_c = (ref_a.float() @ w_c.float().T).to(dtype) + ref_b
+
+    def max_diff(a, b):
+        return (a - b).abs().max().item()
+
+    diff_a = max_diff(x_a, ref_a)
+    diff_b = max_diff(x_b, ref_b)
+    diff_c = max_diff(x_c, ref_c)
+    print(f"diff A = {diff_a}, diff B = {diff_b}, diff C = {diff_c}")
+
+    tol_c = 0.5
+    if diff_a < 0.1 and diff_b < 0.1 and diff_c < tol_c:
+        print("PASSED: join_point test_mode produces correct output")
+    else:
+        print(f"FAILED: diffs A={diff_a} B={diff_b} C={diff_c}")
+        sys.exit(1)
+
+    pk.finalize()
+
+
+if __name__ == "__main__":
+    test_join_point_testmode()

--- a/tests/runtime_python/test_mode/test_residual_stripping_testmode.py
+++ b/tests/runtime_python/test_mode/test_residual_stripping_testmode.py
@@ -1,0 +1,117 @@
+"""
+Residual-stripping test for the AnnotatedGraph pre-pass.
+
+Graph:
+   x_input --A(rmsnorm)--> x_a --B(rmsnorm)--> x_b
+                              \\______________________________
+                                                              \\
+   C: linear_with_residual(input=x_b, weight=w_c, residual=x_a, output=x_c)
+
+The edge A -> C (via x_a as residual) is a direct shortcut that coexists with
+the longer path A -> B -> C. Our pre-pass strips that direct edge as a
+"false parallel path". After stripping:
+  - A has 1 out-edge (to B) -> not a fork
+  - C has 1 in-edge (from B)  -> not a join
+  - The graph collapses to a simple chain A -> B -> C
+  - The residual tensor x_a is still read by C at runtime, but scheduling
+    dependency is purely through the B->C event (transitively covers A->B->C).
+
+We verify the graph compiles (no case 2/3 errors despite the multi-input
+consumer) and the output matches a PyTorch reference.
+"""
+
+import torch
+import sys
+import os
+
+import mirage
+from mirage.mpk.persistent_kernel import PersistentKernel
+
+
+def torch_rmsnorm(x, weight, eps=1e-5):
+    variance = x.to(torch.float32).pow(2).mean(dim=-1, keepdim=True)
+    x_normed = x * torch.rsqrt(variance + eps)
+    return (x_normed * weight).to(x.dtype)
+
+
+def test_residual_stripping_testmode():
+    device = "cuda"
+    dtype = torch.bfloat16
+    batch_size = 8
+    hidden = 4096
+
+    torch.manual_seed(1)
+    x_input = torch.randn(batch_size, hidden, dtype=dtype, device=device) * 0.1
+    w_a = torch.randn(hidden, dtype=dtype, device=device) * 0.1
+    w_b = torch.randn(hidden, dtype=dtype, device=device) * 0.1
+    w_c = torch.randn(hidden, hidden, dtype=dtype, device=device) * 0.01
+
+    x_a = torch.zeros(batch_size, hidden, dtype=dtype, device=device)
+    x_b = torch.zeros(batch_size, hidden, dtype=dtype, device=device)
+    x_c = torch.zeros(batch_size, hidden, dtype=dtype, device=device)
+
+    num_workers, num_schedulers = mirage.get_configurations_from_gpu(0)
+    params = PersistentKernel.get_default_init_parameters()
+    params["test_mode"] = True
+    params["num_workers"] = num_workers
+    params["num_local_schedulers"] = num_schedulers
+    params["mpi_rank"] = 0
+    params["world_size"] = 1
+    params["max_num_batched_tokens"] = batch_size
+    params["max_num_batched_requests"] = batch_size
+    pk = PersistentKernel(**params)
+
+    x_input_dt = pk.attach_input(x_input, name="x_input")
+    w_a_dt = pk.attach_input(w_a, name="w_a")
+    w_b_dt = pk.attach_input(w_b, name="w_b")
+    w_c_dt = pk.attach_input(w_c, name="w_c")
+    x_a_dt = pk.attach_input(x_a, name="x_a")
+    x_b_dt = pk.attach_input(x_b, name="x_b")
+    x_c_dt = pk.attach_input(x_c, name="x_c")
+
+    target_cc = pk.target_cc
+    block_dim = (256, 1, 1) if target_cc >= 90 else (128, 1, 1)
+
+    pk.rmsnorm_layer(input=x_input_dt, weight=w_a_dt, output=x_a_dt,
+                     grid_dim=(batch_size, 1, 1), block_dim=block_dim)
+    pk.rmsnorm_layer(input=x_a_dt, weight=w_b_dt, output=x_b_dt,
+                     grid_dim=(batch_size, 1, 1), block_dim=block_dim)
+
+    # C: residual reads x_a directly (shortcut), input comes from x_b.
+    linear_grid_x = hidden // 96 if hidden % 96 == 0 else hidden // 64
+    pk.linear_with_residual_layer(
+        input=x_b_dt, weight=w_c_dt, residual=x_a_dt, output=x_c_dt,
+        grid_dim=(linear_grid_x, batch_size, 1), block_dim=block_dim)
+
+    print("Compiling residual-stripping test kernel...")
+    folder_path = os.path.dirname(__file__)
+    pk.compile(output_dir=folder_path)
+
+    print("Running residual-stripping test kernel...")
+    pk.run_test_mode()
+    torch.cuda.synchronize()
+
+    ref_a = torch_rmsnorm(x_input, w_a)
+    ref_b = torch_rmsnorm(ref_a, w_b)
+    ref_c = (ref_b.float() @ w_c.float().T).to(dtype) + ref_a
+
+    def max_diff(a, b):
+        return (a - b).abs().max().item()
+
+    diff_a = max_diff(x_a, ref_a)
+    diff_b = max_diff(x_b, ref_b)
+    diff_c = max_diff(x_c, ref_c)
+    print(f"diff A = {diff_a}, diff B = {diff_b}, diff C = {diff_c}")
+
+    tol_c = 0.5  # linear_with_residual has higher numerical error
+    if diff_a < 0.1 and diff_b < 0.1 and diff_c < tol_c:
+        print("PASSED: residual_stripping test_mode produces correct output")
+    else:
+        print(f"FAILED: diffs A={diff_a} B={diff_b} C={diff_c}")
+        sys.exit(1)
+
+    pk.finalize()
+
+
+if __name__ == "__main__":
+    test_residual_stripping_testmode()


### PR DESCRIPTION
## Summary

`register_mugraph` previously assumed a strictly linear chain of layers, matched pairwise by `DTensor::guid` equality. This PR generalizes it to arbitrary DAGs with fork/join points, residual connections, and multiple heads/leaves, without changing the Python layer API.

- Adds a new C++ pre-pass (`build_annotated_graph`) that builds and validates a real DAG, strips residual edges, classifies fork/join layers, and runs N-way LCM unification at fork and join boundaries.
- Rewrites `register_mugraph` as a thin emitter over the annotated graph: chain layers use the existing `dfs_create_events_add_tasks`; fork-consumers emit interleaved per fork event; join-consumers emit event-major with `num_triggers` summed across incoming producers.
- Patches `print_task_graph` to buffer emitted JSON by global `task_id` (the old per-op contiguous layout breaks under interleaved fork emission).

## Key design choices

### Edge identity: most-recent-prior-writer, not guid
qwen3 (and most MPK models) reuse physical `DTensor` buffers (e.g. `x = attn_out; x = mlp_out`). Matching edges purely by `guid` creates spurious cycles. Instead, when layer L reads guid g, we pin the edge to the producer that wrote g **most recently before L**. After L is processed, its outputs update `last_writer`. This is SSA-style renaming and trivially avoids false cycles.

### `task_view` is per-side, not per-layer
Each layer carries a **consumer-side** `TaskView` (drives `trigger_event` via the upstream event that triggers the task post-prelaunch) and a **producer-side** `TaskView` (drives `dependent_event` via the event the task fires on completion). Fork LCM mutates producer-side views; join LCM mutates consumer-side views; they never conflict because they write to disjoint slots on `FullTaskDesc`.

### Task-view 7-tuple and LCM on grid axes
Each `TaskView` is `(event_dim[4], last3[3])`:
- `event_dim` indexes **tensor dims** (the event grid lives in the bridging tensor's dim space, invariant to how each side's grid maps to it).
- `last3` indexes **grid axes** (the block of tasks per event is a sub-cuboid of the owning layer's bid grid).

Fork LCM is taken on grid-axis space because the producer's grid is shared across all branches, while bridging tensors and consumer grids differ. LCM is associative, so the pass is a simple left-fold across N branches. Symmetric for join.

### Residual stripping (aggressive rule)
For every edge `u→v`, if there exists any path `u→…→v` of length ≥ 2 on the original graph, the direct `u→v` is dropped. Safety is provided by the longer path's transitive event chain. Single-shot semantics: reachability is computed once on the unstripped graph so we don't accidentally drop the longer path first and leave the direct edge behind. This collapses transformer residuals into plain chains; qwen3 has 72 such edges in its full graph.

### Consumer-side contiguity
`EventDesc.first_task_id..last_task_id` demands a **contiguous** consumer range. The producer side has no such requirement — producer tasks are linked purely via the scalar `trigger_event` per task and an integer `num_triggers` count. This asymmetry drives the fork emission strategy: to keep one EventDesc per fork event, the fork-consumer tasks of different branches must be **interleaved per fork event** in `all_tasks`.

## Prohibited patterns

`FullTaskDesc` has exactly one `trigger_event` and one `dependent_event` slot. The pre-pass rejects two combinations with a hard compile-time error:

| Case | Pattern on a single layer L | Reason disallowed |
|------|------------------------------|-------------------|
| **Case 2** | `is_join_consumer` **AND** `is_fork_consumer` | L would need two `trigger_event`s — the upstream fork event AND the join event at L itself |
| **Case 3** | `is_join_producer` **AND** `is_fork_producer` | L would need to fire two `dependent_event`s — the fork event at L AND the downstream join event |

Cases 1 (`join-consumer + fork-producer`) and 4 (`join-producer + fork-consumer`) are **allowed** because they use the two slots on different sides of the task.

Note: cases 2 and 3 mathematically co-occur. A case-2 violation at X implies one of X's producers is a case-3 violator and vice versa, because the case-3 layer's edge to the case-2 layer is exactly what makes both simultaneously. The classifier detects whichever comes first in layer order.

### \"Distinct consumers/producers\" counting
`is_fork_producer` requires ≥ 2 **distinct** consumer layers, not ≥ 2 out-edges. A layer with two output tensors both feeding the same next op (common in fused GEMMs) is not a fork — it stays a plain chain-edge group from the dependency perspective. Symmetric for `is_join_consumer`. Without this rule the pre-pass flags qwen3 as case-3 immediately.

## Scheduling logic per role

The emission loop walks `ag.ordered_layers` (Kahn's topological order). Each layer dispatches based on its role:

- **First layer** (no incoming edges after stripping): tasks pushed in lex-bid order; each task becomes a \"first task\" that the runtime prelaunches at iteration start.
- **Chain layer** (single distinct producer, no fork/join role): calls `dfs_create_events_add_tasks` with edge info sourced from `AnnotatedGraph`. For chain-only graphs this produces bit-identical output to the pre-existing code path — qwen3 regression baseline.
- **Fork-consumer bundle head**: the layer at `fork_branch_index == 0` of a fork group triggers emission of **all** branches' tasks interleaved per fork event. For each fork event (in producer grid-axis frame via `lcm_last3`):
  1. For each branch b: push branch b's per-event consumer sub-cuboid of tasks. After this inner loop, tasks from all branches for this fork event are contiguous in `all_tasks`.
  2. Create exactly **one** `EventDesc` for the fork event with `first_task_id..last_task_id` spanning the interleaved range.
  3. Walk the producer bid sub-range (derived from `lcm_last3`) and set `trigger_event` on each producer task.
- **Fork-consumer non-head branches**: skipped in the outer loop (the head already emitted them).
- **Join consumer**: tasks emitted in join-event-major order (one contiguous sub-block per join event). For each join event:
  1. Push the consumer sub-cuboid.
  2. Create one `EventDesc`.
  3. For each incoming edge, map the consumer event index back to the producer bid range via `output_map`/`input_map` and accumulate `num_triggers` across all producers; set `trigger_event` on each producer task to the join event.

## Multiple heads and multiple leaves

- **Multiple heads** (≥ 2 layers with no incoming edges): each such layer is emitted via the first-layer branch, all of its tasks are appended to `first_tasks`, and the runtime prelaunches them in parallel at iteration start. No constraint on how many heads exist.
- **Multiple leaves** (≥ 2 layers with no outgoing edges): the end-of-graph postlude was rewritten to iterate **every** layer with an empty `out_edges` list, sum their task counts into `EVENT_END_OF_TASK_GRAPH.num_triggers`, and set each leaf task's `trigger_event` to the end event. The old code only handled `ordered_layers.back()` which misses all but one leaf in a DAG — this was the first bug caught by the fork unit test.

## Downstream consequence: `print_task_graph`

Interleaved fork-consumer emission means a single op's tasks may occupy non-contiguous `task_id`s in `all_tasks` (e.g. branch B's tasks at indices 18, 20, 22, …; branch C's at 19, 21, 23, …). The old per-op JSON flush wrote into `json_tasks[task_id - starting_task_id]` assuming contiguous per-op layout, causing heap OOB (manifested as a \"double free or corruption\" abort — the crash we hit when the first fork test ran).

Fix: buffer every emitted task's JSON by **global** `task_id` and flush in strict `task_id` order after all ops are processed, so the JSON's `all_tasks` array index matches the runtime's `all_tasks` vector index.

## Validity test results

All tests run via `/test-mode` with `test_mode=True` on an idle B200. Each test also dumps the `AnnotatedGraph` (`MIRAGE_DUMP_ANNOTATED_GRAPH=1`) for correctness inspection.

| Test | DAG classification | Outcome |
|------|--------------------|---------|
| `test_rmsnorm_testmode` (pre-existing) | 1 layer, 0 edges | **PASSED** — single-layer baseline unchanged |
| `test_fork_point_testmode` | 3 layers, 2 edges, **1 fork group** | **PASSED** — diff A = 0.0156, diff B = 0.0313, diff C = 0.0313 |
| `test_join_point_testmode` | 3 layers, 2 edges, **1 join group** | **PASSED** — diffs all ≤ 0.004 |
| `test_residual_stripping_testmode` | 3 layers, 3 edges, **1 residual stripped**, 0 fork/join | **PASSED** — diff A/B = 0.004, diff C = 0.006 |
| `test_diamond_fork_join_testmode` (GEMM branches) | 4 layers, 4 edges, **1 fork + 1 join group**, 2 case-4 middle layers | **PASSED** — diffs all ≤ 0.004 |
| `test_grid_dim_sweep_testmode` | fork pattern at 4 configs: `(b=4,h=4096)`, `(b=8,h=4096)`, `(b=16,h=4096)`, `(b=8,h=2048)` | **PASSED** on all 4 configs |
| `test_case2_case3_negative_testmode` | subprocess per scenario; expected compile-time abort | **PASSED** — both scenarios abort with `build_annotated_graph: layer … is both a … (case N)` |

### qwen3 E2E non-regression

`demo/qwen3/demo.py --use-mirage` on Qwen3-8B, `--max-num-batched-requests 1`:
- AnnotatedGraph: **293 layers, 365 edges, 72 residuals stripped, 0 fork groups, 0 join groups** (qwen3 collapses to a pure chain after residual stripping)
- Generated tokens: correct (coherent LLM output)
- Per-token latency: **4.39 ms** vs. 4.39 ms baseline — within measurement noise

## Files

| File | Change |
|------|--------|
| `include/mirage/kernel/annotated_graph.h` | **new** — public types (`TaskView`, `EdgeInfo`, `ForkGroupInfo`, `JoinGroupInfo`, `LayerInfo`, `AnnotatedGraph`) + `build_annotated_graph` declaration |
| `src/kernel/annotated_graph.cc` | **new** — full pre-pass: DAG build, Kahn cycle check, BFS residual strip, classification, case 2/3 validation, Kahn topo order, per-edge GCD, fork LCM, join LCM |
| `src/kernel/runtime.cc` | rewritten `register_mugraph` + patched `print_task_graph` global JSON buffer |
| `tests/runtime_python/test_mode/test_*_testmode.py` | **new** — six new test files |

## Test plan

- [x] `test_rmsnorm_testmode.py` — non-regression single-layer baseline
- [x] `test_fork_point_testmode.py` — pure fork
- [x] `test_join_point_testmode.py` — pure join
- [x] `test_residual_stripping_testmode.py` — residual stripping
- [x] `test_diamond_fork_join_testmode.py` — fork + join + case-4 layers with GEMM
- [x] `test_grid_dim_sweep_testmode.py` — fork under 4 grid configurations
- [x] `test_case2_case3_negative_testmode.py` — disallowed patterns abort compile
- [x] `demo/qwen3/demo.py --use-mirage` E2E on Qwen3-8B — output correct, latency unchanged