### PR TITLE
Update Qwen3 CI workflow: conda env, idle GPU selection, cleanup

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - main
+      - mpk
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci-tests-qwen3.yml
+++ b/.github/workflows/ci-tests-qwen3.yml
@@ -1,6 +1,7 @@
 name: mpk-qwen-ci
 on:
   push:
+    branches: [mpk]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/ci-tests-qwen3.yml
+++ b/.github/workflows/ci-tests-qwen3.yml
@@ -29,7 +29,6 @@ jobs:
       - name: Setup conda environment
         run: |
           conda create -n mirage-ci-${{ github.run_id }} python=3.11 -y
-          conda activate mirage-ci-${{ github.run_id }}
 
       - name: Install mirage
         run: |
@@ -45,6 +44,7 @@ jobs:
         env:
           MIRAGE_HOME: ${{ env.MIRAGE_HOME }}
         run: |
+          conda activate mirage-ci-${{ github.run_id }}
           bash tests/ci-tests/run_ci_tests_qwen3.sh \
             --model-path /raid/catalyst/models/Qwen3-8B
 
@@ -60,6 +60,5 @@ jobs:
       - name: Clean up workspace
         if: always()
         run: |
-          conda deactivate
           conda env remove -n mirage-ci-${{ github.run_id }} -y
           rm -rf "${{ github.workspace }}/*"

--- a/.github/workflows/ci-tests-qwen3.yml
+++ b/.github/workflows/ci-tests-qwen3.yml
@@ -63,4 +63,4 @@ jobs:
         run: |
           conda deactivate
           conda env remove -n mirage-ci-${{ github.run_id }} -y
-          rm -rf "${{ github.workspace }}"
+          rm -rf "${{ github.workspace }}/*"

--- a/.github/workflows/ci-tests-qwen3.yml
+++ b/.github/workflows/ci-tests-qwen3.yml
@@ -19,6 +19,7 @@ jobs:
     env:
       CUBLAS_WORKSPACE_CONFIG: ":16:8"
       PYTHONUNBUFFERED: "1"
+      HF_HOME: "/raid/catalyst/models"
 
     steps:
       - name: Checkout
@@ -47,8 +48,7 @@ jobs:
           MIRAGE_HOME: ${{ env.MIRAGE_HOME }}
         run: |
           conda activate mirage-ci-${{ github.run_id }}
-          bash tests/ci-tests/run_ci_tests_qwen3.sh \
-            --model-path /raid/catalyst/models/Qwen3-8B
+          bash tests/ci-tests/run_ci_tests_qwen3.sh
 
       - name: Upload artifacts on failure
         if: failure()

--- a/.github/workflows/ci-tests-qwen3.yml
+++ b/.github/workflows/ci-tests-qwen3.yml
@@ -10,13 +10,9 @@ concurrency:
 
 jobs:
   gpu-inference:
-    runs-on: [self-hosted, gpu, a100]
+    runs-on: [self-hosted, gpu, b200]
 
     env:
-      HF_HOME: /home/haojia/hf_cache
-      TRANSFORMERS_CACHE: /home/haojia/hf_cache
-      HUGGINGFACE_TOKEN: ${{ secrets.HUGGINGFACE_TOKEN }}
-      CUDA_VISIBLE_DEVICES: "0"
       CUBLAS_WORKSPACE_CONFIG: ":16:8"
       PYTHONUNBUFFERED: "1"
 
@@ -26,30 +22,29 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Setup Python
-        uses: actions/setup-python@v5
+      - name: Setup conda environment
+        uses: conda-incubator/setup-miniconda@v3
         with:
-          python-version: "3.10"
+          python-version: "3.11"
+          activate-environment: mirage-ci
+          auto-activate-base: false
 
-      - name: Install Python deps
+      - name: Install mirage
         run: |
-          python -m pip install --upgrade pip
           pip install -e . -v
-          pip install pytest
 
-      - name: Warm up HF cache (optional)
+      - name: Set Envs
         run: |
-          mkdir -p "$HF_HOME"
-          echo "HF cache at $HF_HOME"
-
-      - name: Set MIRAGE_HOME
-        run: echo "MIRAGE_HOME=$PWD" >> $GITHUB_ENV
+          echo "MIRAGE_HOME=$PWD" >> $GITHUB_ENV
+          CUDA_VISIBLE_DEVICES=$(bash scripts/find_idle_gpus.sh --num-gpus 1)
+          echo "CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES" >> $GITHUB_ENV
 
       - name: Run Qwen3 Torch vs MPK comparison
         env:
           MIRAGE_HOME: ${{ env.MIRAGE_HOME }}
         run: |
-          bash tests/ci-tests/run_ci_tests_qwen3.sh
+          bash tests/ci-tests/run_ci_tests_qwen3.sh \
+            --model-path /raid/catalyst/models/Qwen3-8B
 
       - name: Upload artifacts on failure
         if: failure()
@@ -59,3 +54,9 @@ jobs:
           path: |
             outputs/
             logs/
+
+      - name: Clean up workspace
+        if: always()
+        run: |
+          conda env remove -n mirage-ci -y
+          rm -rf "${{ github.workspace }}"

--- a/.github/workflows/ci-tests-qwen3.yml
+++ b/.github/workflows/ci-tests-qwen3.yml
@@ -29,7 +29,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: "3.11"
-          activate-environment: mirage-ci
+          activate-environment: mirage-ci-${{ github.run_id }}
           auto-activate-base: false
 
       - name: Install mirage
@@ -61,5 +61,6 @@ jobs:
       - name: Clean up workspace
         if: always()
         run: |
-          conda env remove -n mirage-ci -y
+          conda deactivate
+          conda env remove -n mirage-ci-${{ github.run_id }} -y
           rm -rf "${{ github.workspace }}"

--- a/.github/workflows/ci-tests-qwen3.yml
+++ b/.github/workflows/ci-tests-qwen3.yml
@@ -11,6 +11,9 @@ concurrency:
 jobs:
   gpu-inference:
     runs-on: [self-hosted, gpu, b200]
+    defaults:
+      run:
+        shell: bash -l {0}
 
     env:
       CUBLAS_WORKSPACE_CONFIG: ":16:8"

--- a/.github/workflows/ci-tests-qwen3.yml
+++ b/.github/workflows/ci-tests-qwen3.yml
@@ -44,6 +44,7 @@ jobs:
           echo "CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES" >> $GITHUB_ENV
 
       - name: Run Qwen3 Torch vs MPK comparison
+        timeout-minutes: 10
         env:
           MIRAGE_HOME: ${{ env.MIRAGE_HOME }}
         run: |

--- a/.github/workflows/ci-tests-qwen3.yml
+++ b/.github/workflows/ci-tests-qwen3.yml
@@ -27,11 +27,9 @@ jobs:
           submodules: recursive
 
       - name: Setup conda environment
-        uses: conda-incubator/setup-miniconda@v3
-        with:
-          python-version: "3.11"
-          activate-environment: mirage-ci-${{ github.run_id }}
-          auto-activate-base: false
+        run: |
+          conda create -n mirage-ci-${{ github.run_id }} python=3.11 -y
+          conda activate mirage-ci-${{ github.run_id }}
 
       - name: Install mirage
         run: |

--- a/.github/workflows/ci-tests-qwen3.yml
+++ b/.github/workflows/ci-tests-qwen3.yml
@@ -34,6 +34,7 @@ jobs:
         run: |
           conda activate mirage-ci-${{ github.run_id }}
           pip install -e . -v
+          pip install pytest
 
       - name: Set Envs
         run: |

--- a/.github/workflows/ci-tests-qwen3.yml
+++ b/.github/workflows/ci-tests-qwen3.yml
@@ -32,6 +32,7 @@ jobs:
 
       - name: Install mirage
         run: |
+          conda activate mirage-ci-${{ github.run_id }}
           pip install -e . -v
 
       - name: Set Envs

--- a/.github/workflows/code-format.yml
+++ b/.github/workflows/code-format.yml
@@ -1,5 +1,9 @@
 name: Clang format
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches: [mpk]
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   formatting-check:

--- a/.github/workflows/gpu-tests.yml
+++ b/.github/workflows/gpu-tests.yml
@@ -1,3 +1,6 @@
+# NOTE: This CI workflow is currently unavailable. The gpu-nvidia runner
+# (runs-on cloud service) is no longer functional as of April 2026.
+# Qwen3 CI has been migrated to ci-tests-qwen3.yml on a self-hosted B200 runner.
 name: "GPU Tests"
 on:
   push:

--- a/conda/mirage.yml
+++ b/conda/mirage.yml
@@ -19,6 +19,12 @@ dependencies:
     - cmake
     - cython
     - numpy==2.1.2
+    - accelerate==1.8.0
+    - protobuf
+    - tg4perfetto @ git+https://github.com/flashinfer-ai/tg4perfetto.git
+    - cuda-python
+    - fastapi
+    - uvicorn
     - torch==2.6.0+cu118
     - torchvision==0.21.0+cu118
     - torchaudio==2.6.0+cu118

--- a/demo/qwen3/demo.py
+++ b/demo/qwen3/demo.py
@@ -806,19 +806,19 @@ if __name__ == "__main__":
 
         end_idx = prev_pos + 1
         generated_ids = tokens[:, :end_idx]
+        tokens_generated = max(0, end_idx - prompt_len)
+        per_tok_ms = run_time / max(tokens_generated, 1)
 
         response = tokenizer.batch_decode(generated_ids, skip_special_tokens=True)[0]
         print(response)
         print(
-            "Prompt length {}, generate length {}, per-token latency {} ms".format(
-                prompt_len, cur_pos - prompt_len, run_time / (cur_pos - prompt_len)
+            "Prompt length {}, generate length {}, per-token latency {:.3f} ms".format(
+                prompt_len, tokens_generated, per_tok_ms
             )
         )
-        
+
         # -------- CI dumps outputs to json files ----------
         if save_path and rank == 0:
-            tokens_generated = max(0, end_idx - prompt_len)
-            per_tok_ms = run_time / max(tokens_generated, 1)
             slice_end = min(end_idx, prompt_len + MAX_SAVE_TOKENS)
             token_ids = tokens[0, prompt_len:slice_end].tolist()
             out = {
@@ -849,8 +849,11 @@ if __name__ == "__main__":
         if total_num_requests > 1:
             print(f"Output length of each batch is same: {(step.max() == step.min()).item()}")
 
-        print("Prompt length {}, generate length {}, per-token latency (both prefill and decode): {:.3f} ms".format(
-              prompt_lengths[0], step.max().item() + 1 - prompt_lengths[0], run_time / (step.max().item() + 1)
+        tokens_generated = step.max().item() + 1 - prompt_lengths[0].item()
+        per_tok_ms = run_time / max(tokens_generated, 1)
+
+        print("Prompt length {}, generate length {}, per-token latency: {:.3f} ms".format(
+              prompt_lengths[0], tokens_generated, per_tok_ms
             )
         )
 

--- a/scripts/find_idle_gpus.sh
+++ b/scripts/find_idle_gpus.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Find idle GPUs (0% utilization) and output their indices as comma-separated list.
+# Usage: ./scripts/find_idle_gpus.sh --num-gpus <N>
+
+set -euo pipefail
+
+NUM_GPUS=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --num-gpus)
+      NUM_GPUS="$2"
+      shift 2
+      ;;
+    *)
+      echo "Usage: $0 --num-gpus <N>" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$NUM_GPUS" ]]; then
+  echo "Usage: $0 --num-gpus <N>" >&2
+  exit 1
+fi
+
+if ! command -v nvidia-smi &>/dev/null; then
+  echo "Error: nvidia-smi not found." >&2
+  exit 1
+fi
+
+IDLE_GPUS=$(nvidia-smi --query-gpu=index,utilization.gpu \
+                       --format=csv,noheader,nounits 2>/dev/null \
+            | awk -F ', ' '$2 == 0 {print $1}')
+
+if [[ -z "$IDLE_GPUS" ]]; then
+  echo "Error: no idle GPUs found." >&2
+  exit 1
+fi
+
+IDLE_COUNT=$(echo "$IDLE_GPUS" | wc -l)
+
+if [[ "$NUM_GPUS" -gt "$IDLE_COUNT" ]]; then
+  echo "Error: need $NUM_GPUS idle GPUs, only $IDLE_COUNT available." >&2
+  exit 1
+fi
+
+echo "$IDLE_GPUS" | head -n "$NUM_GPUS" | paste -sd, -

--- a/tests/ci-tests/perf_comparison.py
+++ b/tests/ci-tests/perf_comparison.py
@@ -1,0 +1,46 @@
+"""Print Torch vs MPK latency comparison (informational, never fails)."""
+
+import json
+import os
+import sys
+
+DEFAULT_OUTPUT_DIR = os.path.join("outputs", "qwen3")
+TORCH_OUTPUT = os.path.join(DEFAULT_OUTPUT_DIR, "torch_output.json")
+MPK_OUTPUT = os.path.join(DEFAULT_OUTPUT_DIR, "mpk_output.json")
+
+
+def _load_meta(path: str):
+    if not os.path.exists(path):
+        print(f"Missing output file: {path}")
+        return None
+    with open(path, "r") as f:
+        return json.load(f)
+
+
+def main():
+    torch_meta = _load_meta(TORCH_OUTPUT)
+    mpk_meta = _load_meta(MPK_OUTPUT)
+    if torch_meta is None or mpk_meta is None:
+        return
+
+    torch_lat = torch_meta.get("latency_ms_per_token")
+    mpk_lat = mpk_meta.get("latency_ms_per_token")
+    torch_len = torch_meta.get("generate_length", "?")
+    mpk_len = mpk_meta.get("generate_length", "?")
+
+    if torch_lat is None or mpk_lat is None:
+        print("latency_ms_per_token missing in output JSON, skipping comparison")
+        return
+
+    speedup = torch_lat / mpk_lat if mpk_lat > 0 else float("inf")
+
+    print("")
+    print("==================== Performance Comparison ====================")
+    print(f"  Torch:  {torch_lat:.3f} ms/token  (generated {torch_len} tokens)")
+    print(f"  MPK:    {mpk_lat:.3f} ms/token  (generated {mpk_len} tokens)")
+    print(f"  Speedup: {speedup:.2f}x")
+    print("===============================================================")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ci-tests/run_ci_tests_qwen3.sh
+++ b/tests/ci-tests/run_ci_tests_qwen3.sh
@@ -13,3 +13,6 @@ python "$ROOT/demo/qwen3/demo.py" --use-mirage --save-tokens
 
 echo "Comparing outputs..."
 pytest -q "$ROOT/tests/ci-tests/test_inference_output.py"
+
+echo "Performance comparison..."
+python "$ROOT/tests/ci-tests/perf_comparison.py"

--- a/tests/ci-tests/run_ci_tests_qwen3.sh
+++ b/tests/ci-tests/run_ci_tests_qwen3.sh
@@ -4,27 +4,12 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 export MIRAGE_HOME="${MIRAGE_HOME:-$ROOT}"
 
-MODEL_PATH_ARG=""
-
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --model-path)
-      MODEL_PATH_ARG="--model-path $2"
-      shift 2
-      ;;
-    *)
-      echo "Usage: $0 [--model-path <PATH>]"
-      exit 1
-      ;;
-  esac
-done
-
 echo "MIRAGE_HOME=${MIRAGE_HOME}"
 echo "Running Torch baseline..."
-python "$ROOT/demo/qwen3/demo.py" --save-tokens $MODEL_PATH_ARG
+python "$ROOT/demo/qwen3/demo.py" --save-tokens
 
 echo "Running MPK..."
-python "$ROOT/demo/qwen3/demo.py" --use-mirage --save-tokens $MODEL_PATH_ARG
+python "$ROOT/demo/qwen3/demo.py" --use-mirage --save-tokens
 
 echo "Comparing outputs..."
 pytest -q "$ROOT/tests/ci-tests/test_inference_output.py"

--- a/tests/ci-tests/run_ci_tests_qwen3.sh
+++ b/tests/ci-tests/run_ci_tests_qwen3.sh
@@ -4,12 +4,27 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 export MIRAGE_HOME="${MIRAGE_HOME:-$ROOT}"
 
+MODEL_PATH_ARG=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --model-path)
+      MODEL_PATH_ARG="--model-path $2"
+      shift 2
+      ;;
+    *)
+      echo "Usage: $0 [--model-path <PATH>]"
+      exit 1
+      ;;
+  esac
+done
+
 echo "MIRAGE_HOME=${MIRAGE_HOME}"
 echo "Running Torch baseline..."
-python "$ROOT/demo/qwen3/demo.py" --save-tokens
+python "$ROOT/demo/qwen3/demo.py" --save-tokens $MODEL_PATH_ARG
 
 echo "Running MPK..."
-python "$ROOT/demo/qwen3/demo.py" --use-mirage --save-tokens
+python "$ROOT/demo/qwen3/demo.py" --use-mirage --save-tokens $MODEL_PATH_ARG
 
 echo "Comparing outputs..."
 pytest -q "$ROOT/tests/ci-tests/test_inference_output.py"

--- a/tests/ci-tests/test_inference_output.py
+++ b/tests/ci-tests/test_inference_output.py
@@ -40,26 +40,3 @@ def test_qwen3_torch_vs_mpk_tokens():
             f"torch_generate_len={torch_meta.get('generate_length')}, "
             f"mpk_generate_len={mpk_meta.get('generate_length')}"
         )
-
-
-def test_qwen3_perf_comparison():
-    """Print Torch vs MPK latency comparison (informational, never fails)."""
-    _, torch_meta = _load_tokens(TORCH_OUTPUT)
-    _, mpk_meta = _load_tokens(MPK_OUTPUT)
-
-    torch_lat = torch_meta.get("latency_ms_per_token")
-    mpk_lat = mpk_meta.get("latency_ms_per_token")
-    torch_len = torch_meta.get("generate_length", "?")
-    mpk_len = mpk_meta.get("generate_length", "?")
-
-    if torch_lat is None or mpk_lat is None:
-        pytest.skip("latency_ms_per_token missing in output JSON")
-
-    speedup = torch_lat / mpk_lat if mpk_lat > 0 else float("inf")
-
-    print("")
-    print("==================== Performance Comparison ====================")
-    print(f"  Torch:  {torch_lat:.3f} ms/token  (generated {torch_len} tokens)")
-    print(f"  MPK:    {mpk_lat:.3f} ms/token  (generated {mpk_len} tokens)")
-    print(f"  Speedup: {speedup:.2f}x")
-    print("===============================================================")

--- a/tests/ci-tests/test_inference_output.py
+++ b/tests/ci-tests/test_inference_output.py
@@ -41,3 +41,25 @@ def test_qwen3_torch_vs_mpk_tokens():
             f"mpk_generate_len={mpk_meta.get('generate_length')}"
         )
 
+
+def test_qwen3_perf_comparison():
+    """Print Torch vs MPK latency comparison (informational, never fails)."""
+    _, torch_meta = _load_tokens(TORCH_OUTPUT)
+    _, mpk_meta = _load_tokens(MPK_OUTPUT)
+
+    torch_lat = torch_meta.get("latency_ms_per_token")
+    mpk_lat = mpk_meta.get("latency_ms_per_token")
+    torch_len = torch_meta.get("generate_length", "?")
+    mpk_len = mpk_meta.get("generate_length", "?")
+
+    if torch_lat is None or mpk_lat is None:
+        pytest.skip("latency_ms_per_token missing in output JSON")
+
+    speedup = torch_lat / mpk_lat if mpk_lat > 0 else float("inf")
+
+    print("")
+    print("==================== Performance Comparison ====================")
+    print(f"  Torch:  {torch_lat:.3f} ms/token  (generated {torch_len} tokens)")
+    print(f"  MPK:    {mpk_lat:.3f} ms/token  (generated {mpk_len} tokens)")
+    print(f"  Speedup: {speedup:.2f}x")
+    print("===============================================================")


### PR DESCRIPTION
## Summary

Overhaul the Qwen3 CI pipeline (`ci-tests-qwen3.yml`) for the self-hosted B200 runner, making it more robust and resource-efficient. Also restrict all workflow push triggers to the `mpk` branch to avoid duplicate CI runs on PR branches.

## Changes

### `ci-tests-qwen3.yml`
- Replace `actions/setup-python@v5` with `conda-incubator/setup-miniconda@v3` for proper conda environment management
- Add `defaults: run: shell: bash -l {0}` so conda is initialized in every step
- Isolate conda environments per run using `mirage-ci-${{ github.run_id }}` to prevent cross-run pollution
- Auto-select an idle GPU via the new `find_idle_gpus.sh` script instead of hardcoding `CUDA_VISIBLE_DEVICES`
- Deactivate conda before removing the environment to avoid errors
- Clean up workspace contents between runs to prevent stale artifacts
- Upgrade Python from 3.10 to 3.11 (matching `conda/mirage.yml`)
- Restrict `push` trigger to `mpk` branch to avoid double CI runs on PR branches

### `scripts/find_idle_gpus.sh` (new)
- Finds GPUs with 0% utilization and outputs comma-separated indices
- Supports `--num-gpus <N>` for multi-GPU selection
- Error messages go to stderr, GPU list to stdout (CI-friendly)

### `gpu-tests.yml`
- Mark as unavailable: the runs-on cloud runner (`gpu-nvidia`) is no longer functional as of April 2026
- Update push trigger to `mpk` branch

### `build-test.yml`
- Update push trigger to `mpk` branch

### `code-format.yml`
- Update push trigger to `mpk` branch

### `tests/ci-tests/run_ci_tests_qwen3.sh`
- Add `--model-path` option for loading models from local disk instead of HuggingFace

### `conda/mirage.yml`
- Add missing packages: `accelerate`, `protobuf`, `tg4perfetto`, `cuda-python`, `fastapi`, `uvicorn`