### PR TITLE
fix: two regressions from PR #660 in offline persistent kernel

### DIFF
--- a/include/mirage/persistent_kernel/persistent_kernel.cuh
+++ b/include/mirage/persistent_kernel/persistent_kernel.cuh
@@ -1516,6 +1516,8 @@ extern "C" void
       static_cast<int *>(meta_tensors[8]);
   global_runtime_config.paged_kv_last_page_len_buffer =
       static_cast<int *>(meta_tensors[9]);
+  global_runtime_config.paged_kv_indices_snapshot =
+      static_cast<int *>(meta_tensors[10]);
 #if defined(MODE_ONLINE_PINNED)
   global_runtime_config.pinned_req_ready =
       static_cast<int32_t volatile *>(meta_tensors[11]);
@@ -1795,6 +1797,12 @@ extern "C" void
   // Create events
   cudaEventCreateWithFlags(&global_runtime_config.prepare_done_event,
                            cudaEventDisableTiming);
+#ifdef MODE_OFFLINE
+  cudaEventCreateWithFlags(&global_runtime_config.worker_done_event,
+                           cudaEventDisableTiming);
+  cudaEventCreateWithFlags(&global_runtime_config.scheduler_done_event,
+                           cudaEventDisableTiming);
+#endif
 
   if (is_test_mode) {
     printf(
@@ -1860,6 +1868,17 @@ extern "C" void launch_persistent_kernel(cudaStream_t default_stream) {
                        global_runtime_config.scheduler_stream>>>(
         global_runtime_config);
 
+#ifdef MODE_OFFLINE
+    cudaEventRecord(global_runtime_config.worker_done_event,
+                    global_runtime_config.worker_stream);
+    cudaEventRecord(global_runtime_config.scheduler_done_event,
+                    global_runtime_config.scheduler_stream);
+
+    cudaStreamWaitEvent(
+        default_stream, global_runtime_config.worker_done_event, 0);
+    cudaStreamWaitEvent(
+        default_stream, global_runtime_config.scheduler_done_event, 0);
+#endif
     printf("Finished Launching Persistent Kernel (Async)\n");
   } else {
     printf("a single persistent kernel\n");
@@ -1939,6 +1958,10 @@ extern "C" void finalize_persistent_kernel() {
 #endif
   // Free worker and scheduler streams
   cudaEventDestroy(global_runtime_config.prepare_done_event);
+#ifdef MODE_OFFLINE
+  cudaEventDestroy(global_runtime_config.worker_done_event);
+  cudaEventDestroy(global_runtime_config.scheduler_done_event);
+#endif
   cudaStreamDestroy(global_runtime_config.worker_stream);
   cudaStreamDestroy(global_runtime_config.scheduler_stream);
 }

--- a/include/mirage/persistent_kernel/runtime_header.h
+++ b/include/mirage/persistent_kernel/runtime_header.h
@@ -412,6 +412,7 @@ struct RuntimeConfig {
   bool split_worker_scheduler;
   cudaStream_t worker_stream, scheduler_stream;
   cudaEvent_t prepare_done_event;
+  cudaEvent_t worker_done_event, scheduler_done_event;
 #ifdef USE_NVSHMEM
   nvshmem_team_t *nvshmem_teams;
 #endif


### PR DESCRIPTION
## Summary

PR #660 introduced two bugs that broke `MODE_OFFLINE` persistent kernel execution:

### 1. Illegal memory access — `paged_kv_indices_snapshot` left uninitialized

The assignment `global_runtime_config.paged_kv_indices_snapshot = meta_tensors[10]` was accidentally dropped during the merge. This left the pointer null (uninitialized), and the scheduler's `prepare_next_batch` immediately writes to it after consuming the first `END_OF_TASK_GRAPH` event. Result: `cudaErrorIllegalAddress` at kernel launch.

### 2. Broken timing — `worker_done_event` / `scheduler_done_event` removed

The split worker/scheduler kernels run on private non-blocking streams (`worker_stream`, `scheduler_stream`). Without the done events recording on those streams and the default stream waiting on them, `torch.cuda.Event` timing on the default stream reports `~0 ms` — because `ender.record()` fires immediately after kernel launch rather than after completion.

## Changes

| File | Change |
|---|---|
| `runtime_header.h` | Add back `cudaEvent_t worker_done_event, scheduler_done_event` fields |
| `persistent_kernel.cuh` | Restore `paged_kv_indices_snapshot` initialization (critical crash fix) |
| `persistent_kernel.cuh` | Restore done-event create / record+wait / destroy — all guarded by `#ifdef MODE_OFFLINE` |

### Why `#ifdef MODE_OFFLINE`?

Online serving kernels run indefinitely (they don't exit until shutdown). Unconditional `cudaStreamWaitEvent` on these events would block the default stream forever. Offline kernels naturally terminate after processing all tokens, so the events fire as expected.

## Testing

- **Offline**: Qwen3-8B on B200 — no crash, per-token latency 4.33 ms, correct generation output
- **Online**: `launch_server` + `demo_online.py` — server starts normally, HTTP chat API returns correct responses