### PR TITLE
ci: filter idle GPUs by memory usage and add job-level timeout

### DIFF
--- a/.github/workflows/ci-tests-qwen3.yml
+++ b/.github/workflows/ci-tests-qwen3.yml
@@ -12,6 +12,7 @@ concurrency:
 jobs:
   gpu-inference:
     runs-on: [self-hosted, gpu, b200]
+    timeout-minutes: 60
     defaults:
       run:
         shell: bash -l {0}

--- a/scripts/find_idle_gpus.sh
+++ b/scripts/find_idle_gpus.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# Find idle GPUs (0% utilization) and output their indices as comma-separated list.
+# Find idle GPUs (0% utilization and <=50% memory used) and output their
+# indices as comma-separated list.
 # Usage: ./scripts/find_idle_gpus.sh --num-gpus <N>
 
 set -euo pipefail
@@ -29,9 +30,9 @@ if ! command -v nvidia-smi &>/dev/null; then
   exit 1
 fi
 
-IDLE_GPUS=$(nvidia-smi --query-gpu=index,utilization.gpu \
+IDLE_GPUS=$(nvidia-smi --query-gpu=index,utilization.gpu,memory.used,memory.total \
                        --format=csv,noheader,nounits 2>/dev/null \
-            | awk -F ', ' '$2 == 0 {print $1}')
+            | awk -F ', ' '$2 == 0 && $4 > 0 && $3 / $4 <= 0.5 {print $1}')
 
 if [[ -z "$IDLE_GPUS" ]]; then
   echo "Error: no idle GPUs found." >&2


### PR DESCRIPTION
## Summary

Two robustness fixes for the Qwen3 CI on the shared B200 runner, motivated by [run 26846450123](https://github.com/mirage-project/mirage/actions/runs/26846450123) which hung for 2+ hours and blocked the runner queue:

- **`scripts/find_idle_gpus.sh`**: select a GPU only if utilization is 0% **and** memory usage is <=50%. Previously a GPU at 0% util but with its memory fully held by stuck/zombie processes (e.g. after an NVIDIA UVM driver wedge, or an occupying process like vLLM engine) was treated as idle, and the next job would OOM or hang on it.
- **`.github/workflows/ci-tests-qwen3.yml`**: add `timeout-minutes: 60` at the job level so any hung step (the incident above was `conda create` stuck behind a D-state child) fails the job and frees the runner queue instead of blocking for hours.

## Test plan

- Verified `find_idle_gpus.sh` locally on the B200 node: some GPUs at 0% util but ~92% memory used (occupied by zombie processes), the script now skips them and selects truly idle GPU 2 (truly idle).
- Normal CI runs complete in ~4-5 min, well within the 60-min job timeout.