### PR TITLE
Add online serving CI

### DIFF
--- a/.github/workflows/ci-tests-online.yml
+++ b/.github/workflows/ci-tests-online.yml
@@ -1,0 +1,68 @@
+name: mpk-online-ci
+on:
+  push:
+    branches: [mpk]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: mpk-online-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  online-serving:
+    runs-on: [self-hosted, gpu, b200]
+    timeout-minutes: 60
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    env:
+      CUBLAS_WORKSPACE_CONFIG: ":16:8"
+      PYTHONUNBUFFERED: "1"
+      HF_HOME: "/raid/catalyst/models"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup conda environment
+        run: |
+          conda create -n mirage-ci-${{ github.run_id }} python=3.11 -y
+
+      - name: Install mirage
+        run: |
+          conda activate mirage-ci-${{ github.run_id }}
+          pip install -e . -v
+          pip install pytest
+
+      - name: Set Envs
+        run: |
+          echo "MIRAGE_HOME=$PWD" >> $GITHUB_ENV
+          CUDA_VISIBLE_DEVICES=$(bash scripts/find_idle_gpus.sh --num-gpus 1)
+          echo "CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES" >> $GITHUB_ENV
+
+      - name: Run online serving test
+        timeout-minutes: 40
+        env:
+          MIRAGE_HOME: ${{ env.MIRAGE_HOME }}
+        run: |
+          conda activate mirage-ci-${{ github.run_id }}
+          bash tests/ci-tests/run_ci_tests_online.sh
+
+      - name: Upload artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mpk-online-outputs
+          path: |
+            outputs/
+            logs/
+
+      - name: Clean up workspace
+        if: always()
+        run: |
+          conda env remove -n mirage-ci-${{ github.run_id }} -y
+          rm -rf "${{ github.workspace }}/*"

--- a/demo/qwen3/demo_online.py
+++ b/demo/qwen3/demo_online.py
@@ -14,6 +14,7 @@ Then run the demo::
 
 import argparse
 import json
+import sys
 import time
 import threading
 import urllib.request
@@ -62,25 +63,31 @@ def _read_sse(req: urllib.request.Request, timeout: int):
                 return
             try:
                 obj = json.loads(payload)
-                text = obj["choices"][0]["delta"].get("content", "")
-                yield (text, False)
             except json.JSONDecodeError:
                 continue
+            if "error" in obj:
+                raise RuntimeError(obj["error"])
+            text = obj["choices"][0]["delta"].get("content", "")
+            yield (text, False)
     yield ("", True)
 
 
 # ── runners ──────────────────────────────────────────────────────────────────
 
 
-def run_single(prompt: str, timeout: int = 300) -> None:
+def run_single(prompt: str, timeout: int = 300) -> bool:
     t0 = time.monotonic()
     text = chat(prompt, timeout=timeout)
     elapsed = time.monotonic() - t0
     print(f"  {text[:300]}...")
     print(f"\n  Finished in {elapsed:.1f}s")
+    ok = bool(text and text.strip())
+    if not ok:
+        print("  ERROR: empty response")
+    return ok
 
 
-def run_concurrent(prompts: list[str], timeout: int = 300) -> None:
+def run_concurrent(prompts: list[str], timeout: int = 300) -> bool:
     results: list[tuple[int, str] | None] = [None] * len(prompts)
 
     def _worker(idx: int, prompt: str):
@@ -98,21 +105,33 @@ def run_concurrent(prompts: list[str], timeout: int = 300) -> None:
         t.join()
     elapsed = time.monotonic() - t0
 
+    ok = True
     for r in results:
         if r is None:
+            ok = False
             continue
         i, text = r
         print(f"  [{i}]  →  {text[:150].replace(chr(10), ' ')}...")
+        if text.startswith("ERROR:") or not text.strip():
+            ok = False
     print(f"\n  {len(prompts)} requests finished in {elapsed:.1f}s")
+    return ok
 
 
-def run_stream(prompt: str, timeout: int = 300) -> None:
+def run_stream(prompt: str, timeout: int = 300) -> bool:
     print(f"\n[stream] {prompt!r}\n")
+    got = 0
     for text, is_final in chat(prompt, stream=True, timeout=timeout):
         if is_final:
             print("\n\n--- DONE ---")
         else:
             print(text, end="", flush=True)
+            if text:
+                got += 1
+    ok = got > 0
+    if not ok:
+        print("\n  ERROR: stream produced no tokens")
+    return ok
 
 
 # ── main ─────────────────────────────────────────────────────────────────────
@@ -138,7 +157,7 @@ def main() -> None:
         return
 
     if args.stream:
-        run_stream("Explain what a GPU is in one sentence.", timeout=args.timeout)
+        ok = run_stream("Explain what a GPU is in one sentence.", timeout=args.timeout)
     elif args.concurrent > 0:
         prompts = [
             "Introduce yourself.",
@@ -149,10 +168,12 @@ def main() -> None:
             "Do you think Attack on Titan really have a good end?"
         ][: args.concurrent]
         print(f"\n=== {len(prompts)} concurrent requests ===\n")
-        run_concurrent(prompts, timeout=args.timeout)
+        ok = run_concurrent(prompts, timeout=args.timeout)
     else:
         print("\n=== Single request ===\n")
-        run_single("Say hello.", timeout=args.timeout)
+        ok = run_single("Say hello.", timeout=args.timeout)
+
+    sys.exit(0 if ok else 1)
 
 
 if __name__ == "__main__":

--- a/python/mirage/engine/launch_server.py
+++ b/python/mirage/engine/launch_server.py
@@ -94,7 +94,7 @@ async def _stream_bridge(
         text, is_final, error = await queue.get()
 
         if error:
-            yield f"data: {{\"error\": \"{error}\"}}\n\n"
+            yield "data: " + json.dumps({"error": error}) + "\n\n"
             break
 
         chunk = json.dumps({

--- a/tests/ci-tests/run_ci_tests_online.sh
+++ b/tests/ci-tests/run_ci_tests_online.sh
@@ -9,7 +9,12 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 export MIRAGE_HOME="${MIRAGE_HOME:-$ROOT}"
 
-PORT="${PORT:-8000}"
+# Pick a free ephemeral port unless one is provided, so we never clash with a
+# service already bound to 8000 on the shared self-hosted runner (which would
+# both block our bind and fool a /docs readiness probe against the wrong app).
+if [[ -z "${PORT:-}" ]]; then
+    PORT="$(python -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); port=s.getsockname()[1]; s.close(); print(port)')"
+fi
 MODEL="${MODEL:-Qwen/Qwen3-8B}"
 MAX_NUM_BATCHED_REQUESTS="${MAX_NUM_BATCHED_REQUESTS:-4}"
 MAX_NUM_BATCHED_TOKENS="${MAX_NUM_BATCHED_TOKENS:-8}"
@@ -36,10 +41,11 @@ wait_for_ready() {
             return 1
         fi
         if python -c "
-import sys, urllib.request
+import sys, json, urllib.request
 try:
-    with urllib.request.urlopen('http://127.0.0.1:${PORT}/docs', timeout=5) as r:
-        sys.exit(0 if r.status == 200 else 1)
+    with urllib.request.urlopen('http://127.0.0.1:${PORT}/openapi.json', timeout=5) as r:
+        spec = json.load(r)
+    sys.exit(0 if '/v1/chat/completions' in spec.get('paths', {}) else 1)
 except Exception:
     sys.exit(1)
 " >/dev/null 2>&1; then

--- a/tests/ci-tests/run_ci_tests_online.sh
+++ b/tests/ci-tests/run_ci_tests_online.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Online-serving CI: launch the OpenAI-compatible HTTP server, wait for the
+# persistent kernel to compile, then drive single / concurrent / streaming
+# requests against it via demo/qwen3/demo_online.py.  Tears the server down on
+# exit.  Any failed mode (empty/errored response) makes demo_online.py exit
+# non-zero, which fails this script and the CI step.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+export MIRAGE_HOME="${MIRAGE_HOME:-$ROOT}"
+
+PORT="${PORT:-8000}"
+MODEL="${MODEL:-Qwen/Qwen3-8B}"
+MAX_NUM_BATCHED_REQUESTS="${MAX_NUM_BATCHED_REQUESTS:-4}"
+MAX_NUM_BATCHED_TOKENS="${MAX_NUM_BATCHED_TOKENS:-8}"
+CONCURRENT="${CONCURRENT:-4}"
+REQUEST_TIMEOUT="${REQUEST_TIMEOUT:-300}"   # per-request timeout (seconds)
+READY_TIMEOUT="${READY_TIMEOUT:-1200}"      # wait for compile + startup (seconds)
+
+DEMO="$ROOT/demo/qwen3/demo_online.py"
+LOG_DIR="${MIRAGE_HOME}/logs"
+SERVER_LOG="${LOG_DIR}/online_server.log"
+mkdir -p "$LOG_DIR"
+
+# Poll the server's /docs endpoint until it answers 200, the server process
+# dies, or the timeout elapses.  The server does not accept connections until
+# its FastAPI lifespan finishes compiling the persistent kernel, so connection
+# errors are expected (and retried) during startup.
+wait_for_ready() {
+    local timeout="$1"
+    local deadline
+    deadline=$(( $(date +%s) + timeout ))
+    while (( $(date +%s) < deadline )); do
+        if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+            echo "Server process (pid=${SERVER_PID}) exited before becoming ready"
+            return 1
+        fi
+        if python -c "
+import sys, urllib.request
+try:
+    with urllib.request.urlopen('http://127.0.0.1:${PORT}/docs', timeout=5) as r:
+        sys.exit(0 if r.status == 200 else 1)
+except Exception:
+    sys.exit(1)
+" >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep 2
+    done
+    echo "Server at 127.0.0.1:${PORT} not ready after ${timeout}s"
+    return 1
+}
+
+echo "MIRAGE_HOME=${MIRAGE_HOME}"
+echo "Launching online server: port=${PORT} model=${MODEL} batched_requests=${MAX_NUM_BATCHED_REQUESTS} batched_tokens=${MAX_NUM_BATCHED_TOKENS}"
+
+python -m mirage.engine.launch_server \
+    --host 127.0.0.1 \
+    --port "$PORT" \
+    --model "$MODEL" \
+    --max-num-batched-requests "$MAX_NUM_BATCHED_REQUESTS" \
+    --max-num-batched-tokens "$MAX_NUM_BATCHED_TOKENS" \
+    > "$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+
+cleanup() {
+    rc=$?
+    if kill -0 "$SERVER_PID" 2>/dev/null; then
+        echo "Stopping server (pid=${SERVER_PID})..."
+        kill -TERM "$SERVER_PID" 2>/dev/null || true
+        for _ in $(seq 1 20); do
+            kill -0 "$SERVER_PID" 2>/dev/null || break
+            sleep 0.5
+        done
+        kill -KILL "$SERVER_PID" 2>/dev/null || true
+    fi
+    wait "$SERVER_PID" 2>/dev/null || true
+    if [[ "$rc" -ne 0 ]]; then
+        echo "=== server log (last 100 lines) ==="
+        tail -n 100 "$SERVER_LOG" 2>/dev/null || true
+        echo "=== end server log ==="
+    fi
+}
+trap cleanup EXIT
+
+# First wait absorbs the kernel compile; later waits return immediately when
+# the server is up, or fast-fail if it has died.
+echo "=== single request ==="
+wait_for_ready "$READY_TIMEOUT"
+python "$DEMO" --port "$PORT" --timeout "$REQUEST_TIMEOUT"
+
+echo "=== ${CONCURRENT} concurrent requests ==="
+wait_for_ready "$READY_TIMEOUT"
+python "$DEMO" --port "$PORT" --timeout "$REQUEST_TIMEOUT" --concurrent "$CONCURRENT"
+
+echo "=== streaming request ==="
+wait_for_ready "$READY_TIMEOUT"
+python "$DEMO" --port "$PORT" --timeout "$REQUEST_TIMEOUT" --stream
+
+echo "Online-serving checks passed."


### PR DESCRIPTION
## Summary
Adds a CI workflow (`mpk-online-ci`) that exercises the **online serving** path end to end: it launches the OpenAI-compatible HTTP server (`mirage.engine.launch_server`) and drives **single**, **concurrent**, and **streaming** requests against it. This complements the existing `mpk-qwen-ci`, which covers the offline token-level correctness/perf path.

## Changes
- **`.github/workflows/ci-tests-online.yml`** — new `mpk-online-ci` workflow, mirroring the Qwen3 CI conventions (`[self-hosted, gpu, b200]` runner, per-run conda env, idle-GPU selection via `find_idle_gpus.sh`, `HF_HOME`/`CUBLAS_WORKSPACE_CONFIG`, artifact upload on failure, workspace cleanup). Job timeout 60 min; serving step 40 min.
- **`tests/ci-tests/run_ci_tests_online.sh`** — launches the server in the background and owns its lifecycle: polls `/docs` until the persistent kernel finishes compiling (with a `kill -0` PID fast-fail), runs `demo_online.py` in all three modes, and tears the server down via an `EXIT` trap (TERM → grace → KILL, dumps the server-log tail on failure).
- **`demo/qwen3/demo_online.py`** — reused as the CI client. Now exits non-zero on empty/errored responses and surfaces a streamed `{"error": ...}` frame as a `RuntimeError`. Interactive behavior is unchanged.
- **`python/mirage/engine/launch_server.py`** — the streaming SSE error frame was hand-built with an f-string, producing invalid JSON whenever the error text contained a quote/backslash/newline (clients then died with a confusing `JSONDecodeError`). Now emitted via `json.dumps`.

## Testing
Validated locally without a GPU against a stdlib mock that replicates `launch_server`'s exact response/SSE shapes:
- `bash -n` / `py_compile` / YAML parse pass.
- `wait_for_ready`: ready → returns immediately; unreachable → times out; dead PID → fast-fails.
- `demo_online.py` single / concurrent×4 / streaming all pass with correct exit codes.
- Error-frame fix verified through the demo's real `_read_sse`: new format surfaces the actual server message; the old f-string format throws `JSONDecodeError`.

The full GPU run happens on the self-hosted b200 runner via this workflow.