### PR TITLE
test: improve test mode interface (split from dpskv3)

### DIFF
--- a/.claude/skills/add-mpk-task/SKILL.md
+++ b/.claude/skills/add-mpk-task/SKILL.md
@@ -25,16 +25,7 @@ Python (user API)
 
 ### Step 1 — `include/mirage/persistent_kernel/runtime_header.h`
 
-Add a new value to the `TaskType` enum. Pick a number in the appropriate range:
-- **100–149**: Ampere (baseline)
-- **150–198**: Hopper (SM90)
-- **230–298**: Blackwell (SM100)
-- **300–349**: Multi-GPU
-
-```cpp
-// Example: adding TASK_MY_OP in the Ampere range
-TASK_MY_OP = 122,  // pick next available number in your range
-```
+Add a new value to the `TaskType` enum.
 
 ---
 
@@ -93,26 +84,11 @@ __device__ __forceinline__ void my_op_impl(
 
 Add an `#include` for your new file if the architecture's `task_header.cuh` does not already pull it in via a wildcard:
 
-```cpp
-#include "tasks/ampere/my_task.cuh"   // add this line
-```
-
-Also add your `TaskType` to the `task_type_to_name` map in `src/kernel/runtime.cc` (search for the existing map entries like `{TASK_RMS_NORM, "TASK_RMS_NORM"}`):
-
-```cpp
-{TASK_MY_OP, "TASK_MY_OP"},
-```
-
 ---
 
 ### Step 4 — `include/mirage/kernel/task_register.h`
 
 Declare the new registration function in the `TaskRegister` class:
-
-```cpp
-int register_my_op_task(threadblock::Graph const &bgraph,
-                        std::vector<int> const &params);
-```
 
 ---
 
@@ -296,7 +272,9 @@ The runtime handles the mapping from grid coordinates to task metadata during ta
 
 ## Verification
 
-Adding a new task requires **three parts**:
+For each kernel, there should be a dedicated folder in `tests/runtime_python/{arch}/` for it, hosting all verification scripts. Name the folder after the kernel name.
+
+Adding a **standard unit test** for a new task requires **three parts** for verification and benchmarking:
 1. **Kernel correctness** (Steps A–C) — Test the CUDA kernel directly via a pybind11 wrapper
 2. **Pipeline correctness** (Step 8) — Test the full Python API → code generation → runtime path via test mode
 3. **Performance benchmark** (Step 9) — Measure latency/throughput across representative shapes
@@ -321,7 +299,7 @@ __global__ void my_op_kernel_wrapper(void const *input_ptr,
 template <typename T, int BATCH_SIZE, int HIDDEN_DIM>
 void launch_my_op(void const *input_ptr, void const *weight_ptr,
                   void *output_ptr, float eps) {
-  dim3 grid_dim(1, 1, 1);                 // Adjust as needed for testing your op
+  dim3 grid_dim(X, Y, Z);                 // Adjust as needed for testing your op
   dim3 block_dim(128, 1, 1);              // 128 for Ampere; 256 for Hopper/Blackwell
   size_t smem_size = 3 * HIDDEN_DIM * sizeof(T) + 128;  // input + weight + output buffers
 
@@ -400,7 +378,9 @@ A ratio close to 1.0 everywhere (or max abs error within bfloat16 rounding, ~1e-
 
 After verifying the kernel in isolation (Steps A–C), test it through the full MPK compilation pipeline using test mode. This validates the Python layer method (Step 7), task registration (Steps 5–6), code generation, and runtime dispatch end-to-end.
 
-Create `tests/runtime_python/test_mode/test_my_op_testmode.py`. See the `/test-mode` skill for the complete API guide, examples, and debugging tips.
+Per-layer test_mode files live in the same folder as the kernel-wrapper test, at `tests/runtime_python/<arch>/sm100_<layer>/test_<layer>_testmode.py`. Each folder must also contain a `pytorch_reference.py` with the canonical PyTorch reference implementations — both the kernel-wrapper test (Step C) and the test_mode test import from it via `from pytorch_reference import <fn>`. This keeps the two tests aligned on a single source. If `pytorch_reference.py` does not yet exist for the layer, create it (extracting any inline ref from the kernel-wrapper test, then refactoring that test to use the import).
+
+Multi-layer pipeline tests that don't correspond to a single layer (e.g., a fused MLP combining several layers) live in `tests/runtime_python/test_mode/`. See the `/test-mode` skill for the complete API guide, examples, and debugging tips.
 
 ---
 
@@ -409,6 +389,6 @@ Create `tests/runtime_python/test_mode/test_my_op_testmode.py`. See the `/test-m
 Create a benchmark alongside the kernel wrapper test at `tests/runtime_python/blackwell/<task>/bench_<task>.py`. It should:
 
 1. Define at least 3–4 representative shape configurations (small, medium, production-scale).
-2. Warm up the kernel (16+ iterations).
+2. Warm up the kernel.
 3. Measure latency using `torch.cuda.Event(enable_timing=True)` over 100+ repetitions.
 4. Report average time (ms) per configuration.

--- a/.claude/skills/test-mode/SKILL.md
+++ b/.claude/skills/test-mode/SKILL.md
@@ -139,7 +139,7 @@ Same call as production. In test mode the launcher was compiled with `-DMPK_TEST
 - Must be called **after** `compile()`.
 - **Does not synchronize** — call `torch.cuda.synchronize()` before reading output tensors.
 - Optional `default_stream=stream` kwarg if you don't want the current stream.
-- Profiler trace export: pass `params["profiler_tensor"] = torch.zeros(N, dtype=torch.uint64, device="cuda")` and optional `params["trace_name"]` before `compile()`. After `pk()` returns, a `<trace_name>.perfetto-trace` file is written.
+- Profiler export: pass `params["profiler_tensor"]` and optional `params["trace_name"]` before `compile()`. After `pk()` returns, both `<trace_name>.perfetto-trace` and `<trace_name>.csv` are written. See "Profiling" below.
 
 ### `pk.finalize()`
 
@@ -252,6 +252,67 @@ mpirun --np 2 -x LD_PRELOAD -x LD_LIBRARY_PATH -x NVSHMEM_HOME \
 ```
 
 The `LD_PRELOAD` is required so `dlopen()`-loaded launcher modules resolve `nvshmem_selected_device_transport` and other NVSHMEM-versioned symbols. This is an existing NVSHMEM 3.x quirk, unrelated to test mode.
+
+## Profiling
+
+Test mode supports profiling because `pk()` runs the standard `__call__` path. Profiling is opt-in: pass a `profiler_tensor` and the post-run hook writes both a Perfetto trace (for human inspection) and a CSV (for programmatic queries).
+
+```python
+params = PersistentKernel.get_default_init_parameters()
+params["test_mode"] = True
+params["trace_name"] = "rmsnorm_smoke"           # optional; defaults to f"mirage_{mpi_rank}"
+params["profiler_tensor"] = torch.zeros(
+    3000 * 128, dtype=torch.uint64, device="cuda"
+)
+pk = PersistentKernel(**params)
+
+# ... attach tensors, register layers, pk.compile(...) as usual ...
+pk()
+torch.cuda.synchronize()
+# Two files now exist alongside the script:
+#   rmsnorm_smoke.perfetto-trace   ← drag into ui.perfetto.dev
+#   rmsnorm_smoke.csv              ← query with scripts/parse_profile.py
+```
+
+The profiler buffer must be `uint64` on CUDA. `3000 * 128` entries is the conventional size used by the demos and is plenty for short test-mode runs. Each task event consumes 2 entries (BEGIN + END); buffer overflow would surface later as a `RuntimeError("dangling BEGIN ...")` from the CSV writer.
+
+### CSV schema
+
+One row per fully-paired task event (and one row per `kInstant` event with `duration_ns=0`):
+
+| Column | Meaning |
+|---|---|
+| `task_type_id` | `TaskType` enum value (e.g. `253`) |
+| `task_type_name` | Symbolic name (e.g. `TASK_LINEAR_SM100`) |
+| `block_idx`, `group_idx` | Worker that executed the event |
+| `event_no` | Per-worker execution counter |
+| `begin_ts`, `end_ts` | Raw 32-bit `%globaltimer_lo` values (ns, wraps every ~4.3 s) |
+| `duration_ns` | `(end_ts - begin_ts) mod 2^32` |
+
+### Querying the CSV — `scripts/parse_profile.py`
+
+All output is JSON; errors print `{"error": "..."}` and exit 2.
+
+```bash
+# What task types ran, with event counts
+python scripts/parse_profile.py rmsnorm_smoke.csv --list
+
+# Average runtime of one task type
+python scripts/parse_profile.py rmsnorm_smoke.csv TASK_RMS_NORM_HOPPER --stat avg
+
+# Min / max / avg / median in one shot
+python scripts/parse_profile.py rmsnorm_smoke.csv TASK_LINEAR_SM100 --stat all
+
+# Numeric task-type id is also accepted
+python scripts/parse_profile.py rmsnorm_smoke.csv 253 --stat min
+```
+
+Sample output:
+```json
+{"task_type": "TASK_LINEAR_SM100", "count": 7040, "min_ns": 11776, "max_ns": 193856, "avg_ns": 26731.58, "median_ns": 31184.0}
+```
+
+For finer-grained analysis (per-worker breakdown, percentiles, outliers), `pandas.read_csv(...)` the file directly — the schema is stable and column names speak for themselves.
 
 ## Constraints
 

--- a/.claude/skills/test-mode/SKILL.md
+++ b/.claude/skills/test-mode/SKILL.md
@@ -5,7 +5,12 @@ description: Guide for using MPK test mode to unit-test individual layers or mul
 
 # MPK Test Mode
 
-Test mode compiles and runs an MPK task graph **exactly once**, without meta-tensors, batching, or persistent-loop iteration. It exercises the full pipeline — Python layer API, task registration, C++ code generation, nvcc compilation, and runtime dispatch — making it the primary tool for validating that a new layer or task works correctly end-to-end.
+Test mode compiles and runs an MPK task graph **exactly once** and exits. It exercises the full pipeline — Python layer API, task registration, C++ code generation, nvcc compilation, runtime dispatch, and the persistent runtime's metadata setup (`init_kernel` + `prepare_next_batch`) — making it the primary tool for validating that a new layer or task works end-to-end.
+
+Test mode is selected by setting `params["test_mode"] = True` at construction time. Internally this defines `-DMPK_TEST_MODE` for the launcher build, which:
+1. Auto-allocates any meta tensors the test author didn't pass (so paged-attention / embedding / sampling layers see valid `qo_indptr_buffer`, `paged_kv_*`, `input_tokens`, etc.).
+2. Lets `init_request_resources()` and `prepare_next_batch` run normally — the same code paths production uses.
+3. Forces `prepare_next_batch`'s always-finalize shortcut on iter 1, which returns false and terminates the scheduler after exactly one task-graph pass.
 
 ## Quick Start
 
@@ -36,9 +41,9 @@ block_dim = (256, 1, 1) if pk.target_cc >= 90 else (128, 1, 1)
 pk.rmsnorm_layer(input=x_dt, weight=w_dt, output=out_dt,
                  grid_dim=(16, 1, 1), block_dim=block_dim)
 
-# 4. Compile and run
+# 4. Compile and run — same call as production; MPK_TEST_MODE is baked into the .so
 pk.compile(output_dir="./test_output")   # saves .cu and .json for debugging
-pk.run_test_mode()
+pk()
 torch.cuda.synchronize()
 
 # 5. Compare — `out` tensor is now modified in-place
@@ -48,6 +53,21 @@ print("Max diff:", (out - ref).abs().max().item())
 # 6. Cleanup
 pk.finalize()
 ```
+
+## What Test Mode Actually Does
+
+The launcher's first scheduler event is always `EVENT_END_OF_TASK_GRAPH`, so `prepare_next_batch` fires *before* iter 0. Concretely:
+
+```
+init_kernel:           zero step / request_ids / qo_indptr / paged_kv_indptr; seed page_queue
+1st END_OF_TASK_GRAPH (iter_num=0): prepare_next_batch fills meta tensors for iter 0 → returns true
+iter 0:                the test — layer-under-test runs with valid meta tensors
+2nd END_OF_TASK_GRAPH (iter_num=1): prepare_next_batch finalizes (MPK_TEST_MODE always-finalize)
+                                    → no new prefills (next_request_id == total_num_requests)
+                                    → returns false → terminate
+```
+
+So tests of meta-tensor-dependent layers (paged attention, MoE routing, embedding, sampling) work — they read the values that `prepare_next_batch` wrote.
 
 ## API Reference
 
@@ -64,8 +84,10 @@ Commonly overridden keys:
 | `num_local_schedulers` | 4 | Set from `mirage.get_configurations_from_gpu(0)` |
 | `max_num_batched_tokens` | 1 | Set to your test's batch size if the task kernel uses this compile-time constant |
 | `max_num_batched_requests` | 1 | Same as above |
+| `max_num_pages` / `page_size` / `max_seq_length` | 1 | Bump these so `prepare_next_batch` can fit your prefill (`max_num_pages * page_size >= prompt_length`) |
+| `world_size` / `mpi_rank` | 1 / 0 | For multi-GPU tests; set from `mpi4py.MPI.COMM_WORLD` |
 | `use_cutlass_kernel` | False | Set `True` if your layer uses CUTLASS-based kernels |
-| `meta_tensors` | `{}` | Some layers need stubs (e.g., `qo_indptr_buffer`) — see multi-layer example |
+| `meta_tensors` | `{}` | Auto-defaulted; **override only the entries that drive your test scenario** (typically `prompt_lengths` and/or `tokens`) — see "Meta-Tensor Defaults" below |
 
 ### `mirage.get_configurations_from_gpu(rank)`
 
@@ -87,24 +109,67 @@ Generates CUDA code, compiles with nvcc, loads the resulting `.so` module.
 - **Set `output_dir`** to save `test_rank0.cu` and `task_graph_rank0.json` — essential for debugging compilation errors or incorrect results.
 - Compilation can be slow (1–10+ minutes) depending on which task kernels are instantiated.
 
-### `pk.run_test_mode()`
+### `pk()` — Launch the kernel
 
-Launches the compiled task graph **once** on the current CUDA stream.
+Same call as production. In test mode the launcher was compiled with `-DMPK_TEST_MODE` so it terminates after one task-graph pass. The previous `pk.run_test_mode()` method has been removed; use `pk()` directly.
 
-- Only available when `test_mode=True`.
 - Must be called **after** `compile()`.
-- **Does not synchronize** — call `torch.cuda.synchronize()` afterward before reading output tensors.
+- **Does not synchronize** — call `torch.cuda.synchronize()` before reading output tensors.
+- Optional `default_stream=stream` kwarg if you don't want the current stream.
+- Profiler trace export: pass `params["profiler_tensor"] = torch.zeros(N, dtype=torch.uint64, device="cuda")` and optional `params["trace_name"]` before `compile()`. After `pk()` returns, a `<trace_name>.perfetto-trace` file is written.
 
 ### `pk.finalize()`
 
 Frees GPU resources (queues, events, task/event storage). Call when done.
 
-## Multi-Layer Pipeline Example
+## Meta-Tensor Defaults
 
-`tests/runtime_python/test_mode/test_qwen3_mlp_testmode.py` demonstrates chaining multiple layers:
+Test mode auto-allocates any of the 10 meta tensors that you don't pass:
+
+| Key | Default shape | Default dtype | Default content |
+|---|---|---|---|
+| `tokens` | `(1, max_seq_length)` | `int64` | zeros |
+| `step` | `(total_num_requests,)` | `int32` | zeros |
+| `prompt_lengths` | `(total_num_requests,)` | `int32` | filled with `max_num_batched_tokens` |
+| `input_tokens` | `(max_num_batched_tokens,)` | `int64` | zeros (filled by `prepare_next_batch`) |
+| `output_tokens` | `(max_num_batched_tokens,)` | `int64` | zeros |
+| `num_new_tokens` | `(1,)` | `int32` | zeros |
+| `qo_indptr_buffer` | `(max_num_batched_requests + 1,)` | `int32` | zeros (filled by `prepare_next_batch`) |
+| `paged_kv_indptr_buffer` | `(max_num_batched_requests + 1,)` | `int32` | zeros (filled by `prepare_next_batch`) |
+| `paged_kv_indices_buffer` | `(max_num_pages,)` | `int32` | zeros (filled by `prepare_next_batch`) |
+| `paged_kv_last_page_len_buffer` | `(max_num_batched_requests,)` | `int32` | zeros (filled by `prepare_next_batch`) |
+
+`total_num_requests` is derived from `tokens.shape[0]` (defaults to 1).
+
+**Override only what your test scenario requires.** Typical patterns:
 
 ```python
-# Gate+Up linear → SiLU-Mul → Down+Residual  (Qwen3 dense MLP)
+# Single prefill of length N (controls qo_indptr_buffer / paged_kv_* via prepare_next_batch)
+params["meta_tensors"] = {
+    "prompt_lengths": torch.tensor([N], dtype=torch.int32, device="cuda"),
+}
+
+# Specific prompt content (e.g. for embedding-layer tests that read input_tokens)
+params["meta_tensors"] = {
+    "prompt_lengths": torch.tensor([N], dtype=torch.int32, device="cuda"),
+    "tokens": torch.tensor([[101, 7592, 2088, ...]], dtype=torch.int64, device="cuda"),
+}
+
+# Multi-request batch — total_num_requests inferred from tokens.shape[0]
+params["meta_tensors"] = {
+    "tokens": torch.zeros((4, max_seq_length), dtype=torch.int64, device="cuda"),
+    "prompt_lengths": torch.tensor([16, 8, 32, 4], dtype=torch.int32, device="cuda"),
+}
+```
+
+The shape/dtype assertions that production runs through (e.g. `tokens.shape[1] == max_seq_length`, `prompt_lengths.dtype == int32`) all run in test mode too — defaults satisfy them by construction; user overrides will fail loudly if they don't match.
+
+## Multi-Layer Pipeline Example
+
+Multiple layers can be chained with intermediate tensors. From the Qwen3 dense MLP pattern:
+
+```python
+# Gate+Up linear → SiLU-Mul → Down+Residual
 
 # Attach weights separately, then shuffle for interleaved gate/up layout
 w_gate_dt = pk.attach_input(w_gate, name="w_gate")
@@ -130,35 +195,71 @@ pk.linear_with_residual_layer(input=silu_out_dt, weight=w_down_dt,
                               grid_dim=(hidden_size // 64, 1, 1), block_dim=block_dim)
 ```
 
-**Key pattern:** intermediate tensors (`mlp_mid`, `silu_out`) are pre-allocated and attached via `attach_input` so they can be inspected after execution if needed.
+**Key pattern:** intermediate tensors (`mlp_mid`, `silu_out`) are pre-allocated and attached via `attach_input` so they can be inspected after execution if needed. For a runnable multi-task test see `tests/runtime_python/test_mode/test_diamond_fork_join_testmode.py`.
 
-**Meta-tensor stubs:** some layers (e.g., `linear_with_residual_layer`) may reference `qo_indptr_buffer` at compile time. Pass a minimal stub:
+## Multi-GPU Tests
+
+Test mode supports `world_size > 1`. Each rank is independent — auto-defaults are deterministic functions of kernel params, so they produce identical values on every rank.
+
 ```python
-params["meta_tensors"] = {
-    "qo_indptr_buffer": torch.zeros(batch_size + 1, dtype=torch.int32, device="cuda")
-}
+from mpi4py import MPI
+comm = MPI.COMM_WORLD
+world_size = comm.Get_size()
+rank = comm.Get_rank()
+torch.cuda.set_device(rank)
+
+params = PersistentKernel.get_default_init_parameters()
+params["test_mode"] = True
+params["world_size"] = world_size
+params["mpi_rank"] = rank
+# ... rest of setup is the same as single-GPU
+pk = PersistentKernel(**params)
+# ... attach + register layers (incl. NVSHMEM ops like pk.allreduce_layer)
+pk.compile(output_dir=...)
+pk()
+torch.cuda.synchronize()
 ```
+
+**Launch convention:**
+
+```bash
+LD_PRELOAD=$NVSHMEM_HOME/lib/libnvshmem_host.so \
+mpirun --np 2 -x LD_PRELOAD -x LD_LIBRARY_PATH -x NVSHMEM_HOME \
+    python tests/runtime_python/test_mode/test_multigpu_rmsnorm_testmode.py
+```
+
+The `LD_PRELOAD` is required so `dlopen()`-loaded launcher modules resolve `nvshmem_selected_device_transport` and other NVSHMEM-versioned symbols. This is an existing NVSHMEM 3.x quirk, unrelated to test mode.
 
 ## Constraints
 
-- **One execution pass** — the task graph runs once and terminates. No iteration, no `prepare_next_batch`.
-- **Meta-tensors optional** — pass `{}` or minimal stubs. Missing pointers become null; the kernel must not dereference them.
+- **One execution pass** — the task graph runs once and `prepare_next_batch` returns false on its second call. No multi-iteration scheduling.
+- **Meta tensors auto-allocated** — pass overrides only for entries your test scenario depends on. Defaults are sized from kernel-level params (`max_num_batched_tokens`, `max_num_batched_requests`, `max_num_pages`, `max_seq_length`, etc.), so bump those if your test needs larger buffers.
+- **`MPK_TEST_MODE` is a compile-time flag** — switching `test_mode` between True and False requires re-running `pk.compile()`; the same launcher .so isn't reusable across modes.
 
 ## Debugging Tips
 
 **Compilation fails:**
 - Check `<output_dir>/test_rank0.cu` for the generated code. Search for your task name in the `_execute_task()` function.
-- Check `<output_dir>/task_graph_rank0.json` for the task graph. This file might be extremely long, dont read it in a raw fashion. Use `scripts/parse_task_graph.py` to read the task graph.
+- Check `<output_dir>/task_graph_rank0.json` for the task graph. This file might be extremely long; don't read it raw — use `scripts/parse_task_graph.py`.
 
 **Incorrect dimension splitting:**
-- The MPK layers require `input_map` for each associated tensor to specify how dimensions are split across the grid. If the grid or block dimensions don't divide the tensor dimensions correctly, the kernel may read/write out of bounds, causing NaNs or incorrect results.
+- The MPK layers require `input_map` for each associated tensor to specify how dimensions are split across the grid. If grid/block dimensions don't divide tensor dimensions correctly, the kernel may read/write out of bounds, producing NaNs or wrong results.
 
 **Incomplete task attributes:**
-- Ensure all required attributes for each task are correctly specified in the compilation logic, in `runtime.cc`. Missing or incorrect attributes can lead to undefined behavior or compilation errors.
+- Ensure all required attributes for each task are correctly specified in the compilation logic in `runtime.cc`. Missing/incorrect attributes cause undefined behavior or compilation errors.
+
+**Kernel hangs / never terminates:**
+- Verify `total_num_requests` is set to match the number of in-flight test requests (typically 1, derived from `tokens.shape[0]`). If `next_request_id` never reaches `total_num_requests`, `prepare_next_batch` will keep returning true and iterations will not stop.
+- Verify the active `mode` is `"offline"` (the default). `MPK_TEST_MODE` is designed to layer on top of MODE_OFFLINE's `prepare_next_batch`; other modes are not supported.
+
+**Verifying that `prepare_next_batch` actually ran:**
+- After `pk()` returns, read back `pk.meta_tensors["step"][0]`. It should equal `prompt_lengths[0]` — `prepare_next_batch`'s Step 1.1 advances `step` by `num_tokens` on the second call. See `test_prepare_next_batch_testmode.py` for the canonical assertion.
 
 ## Example Test Files
 
 | File | What it tests |
 |---|---|
-| `tests/runtime_python/test_mode/test_rmsnorm_testmode.py` | Single layer (RMSNorm) |
-| `tests/runtime_python/test_mode/test_qwen3_mlp_testmode.py` | Multi-layer pipeline (Qwen3 MLP) |
+| `tests/runtime_python/test_mode/test_rmsnorm_testmode.py` | Single layer (RMSNorm), default meta tensors |
+| `tests/runtime_python/test_mode/test_prepare_next_batch_testmode.py` | Verifies `prepare_next_batch` runs and populates metadata (asserts `step` advanced) |
+| `tests/runtime_python/test_mode/test_diamond_fork_join_testmode.py` | Multi-task graph (synthetic fork+join) |
+| `tests/runtime_python/test_mode/test_multigpu_rmsnorm_testmode.py` | Multi-GPU smoke test under `mpirun -n 2` |

--- a/.claude/skills/test-mode/SKILL.md
+++ b/.claude/skills/test-mode/SKILL.md
@@ -283,6 +283,4 @@ The `LD_PRELOAD` is required so `dlopen()`-loaded launcher modules resolve `nvsh
 | File | What it tests |
 |---|---|
 | `tests/runtime_python/test_mode/test_rmsnorm_testmode.py` | Single layer (RMSNorm), default meta tensors |
-| `tests/runtime_python/test_mode/test_prepare_next_batch_testmode.py` | Verifies `prepare_next_batch` runs and populates metadata (asserts `step` advanced) |
 | `tests/runtime_python/test_mode/test_diamond_fork_join_testmode.py` | Multi-task graph (synthetic fork+join) |
-| `tests/runtime_python/test_mode/test_multigpu_rmsnorm_testmode.py` | Multi-GPU smoke test under `mpirun -n 2` |

--- a/.claude/skills/test-mode/SKILL.md
+++ b/.claude/skills/test-mode/SKILL.md
@@ -12,6 +12,23 @@ Test mode is selected by setting `params["test_mode"] = True` at construction ti
 2. Lets `init_request_resources()` and `prepare_next_batch` run normally — the same code paths production uses.
 3. Forces `prepare_next_batch`'s always-finalize shortcut on iter 1, which returns false and terminates the scheduler after exactly one task-graph pass.
 
+## Required: PyTorch Reference Comparison
+
+**Every test mode file must include a PyTorch reference implementation** that computes the same operation, and must compare the MPK output against it numerically. A test that only runs the kernel without checking correctness is not a valid test — it only proves the kernel doesn't crash.
+
+The reference should:
+- Use plain `torch` ops (or `torch.nn.functional`) to implement the same math the layer performs.
+- Run on the same input tensors as the MPK kernel (cast to a higher precision like `float32` if needed for a trustworthy reference).
+- Be compared with a tolerance appropriate to the dtype: bf16 typically `atol=1e-2, rtol=1e-2`; fp16 similar; fp32 much tighter.
+
+Use `torch.testing.assert_close(out, ref, atol=..., rtol=...)` and/or print `(out - ref).abs().max()` so failures surface immediately rather than silently producing wrong numbers.
+
+### Where the reference lives: `pytorch_reference.py`
+
+Per-layer test_mode files **must import their PyTorch reference from `pytorch_reference.py` in the same folder**, not redefine it inline. The folder layout is `tests/runtime_python/<arch>/sm100_<layer>/`, with one `pytorch_reference.py` per folder containing one function per in-scope layer. Both the new test_mode test (`test_<layer>_testmode.py`) and the existing kernel-wrapper test (`test_<layer>.py`) import from the same file, so they stay aligned on a single canonical reference.
+
+If `pytorch_reference.py` does not yet exist for the layer, create it. If a kernel-wrapper test already exists with an inline reference, extract that reference into `pytorch_reference.py` and refactor the kernel-wrapper test to import from it.
+
 ## Quick Start
 
 ```python
@@ -46,9 +63,15 @@ pk.compile(output_dir="./test_output")   # saves .cu and .json for debugging
 pk()
 torch.cuda.synchronize()
 
-# 5. Compare — `out` tensor is now modified in-place
+# 5. Compare against a PyTorch reference
+def torch_rmsnorm(x, w, eps=1e-6):
+    x_f32 = x.to(torch.float32)
+    rms = x_f32.pow(2).mean(dim=-1, keepdim=True).add(eps).rsqrt()
+    return (x_f32 * rms * w.to(torch.float32)).to(x.dtype)
+
 ref = torch_rmsnorm(x, w)
 print("Max diff:", (out - ref).abs().max().item())
+torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
 
 # 6. Cleanup
 pk.finalize()

--- a/.claude/skills/test-mode/SKILL.md
+++ b/.claude/skills/test-mode/SKILL.md
@@ -274,6 +274,7 @@ The `LD_PRELOAD` is required so `dlopen()`-loaded launcher modules resolve `nvsh
 **Kernel hangs / never terminates:**
 - Verify `total_num_requests` is set to match the number of in-flight test requests (typically 1, derived from `tokens.shape[0]`). If `next_request_id` never reaches `total_num_requests`, `prepare_next_batch` will keep returning true and iterations will not stop.
 - Verify the active `mode` is `"offline"` (the default). `MPK_TEST_MODE` is designed to layer on top of MODE_OFFLINE's `prepare_next_batch`; other modes are not supported.
+- The MPK runtime assumes occupying the entire GPU. If other processes are running, they can interfere with scheduling and cause hangs. Always check GPU availability before running. And if it hangs, kill and rerun on other idle GPUs.
 
 **Verifying that `prepare_next_batch` actually ran:**
 - After `pk()` returns, read back `pk.meta_tensors["step"][0]`. It should equal `prompt_lengths[0]` — `prepare_next_batch`'s Step 1.1 advances `step` by `num_tokens` on the second call. See `test_prepare_next_batch_testmode.py` for the canonical assertion.

--- a/include/mirage/persistent_kernel/persistent_kernel.cuh
+++ b/include/mirage/persistent_kernel/persistent_kernel.cuh
@@ -268,7 +268,7 @@ __device__ __forceinline__ bool
       config.step[request_id] = step + num_tokens;
       int step_advance = num_tokens;
 #endif
-#ifdef MPK_ENABLE_PROFILING
+#if defined(MPK_ENABLE_PROFILING) || defined(MPK_TEST_MODE)
       if (true)
 #else
       if ((step + step_advance + 1 >= config.max_seq_length) ||
@@ -1235,29 +1235,11 @@ __device__ __forceinline__ void execute_scheduler(RuntimeConfig config,
 #ifdef MPK_ENABLE_VERBOSE
         printf("[SCHD] END_OF_TASK_GRAPH\n");
 #endif
-#ifdef MPK_TEST_MODE
-        // Test mode: run task graph exactly once, then terminate.
-        // iteration_num stays at 1 throughout the single pass so that
-        // event counter thresholds (num_triggers * iteration_num) are
-        // consistent: each event fires exactly num_triggers times.
-        if (iteration_num > 0) {
-          printf("[SCHD] Single pass finished, terminating schedulers.\n");
-          terminate_schedulers(config);
-        } else {
-          size_t last_task_id =
-              worker_queue_next_free_task_pos[next_worker - my_first_worker]++;
-          st_relaxed_gpu_u64(
-              &config.worker_queues[next_worker]
-                                   [last_task_id % config.per_worker_queue_len],
-              compute_task_id(iteration_num + 1, 1 /*begin_task_graph*/));
-          atom_add_release_gpu_u64(
-              &config.worker_queue_last_ready_task_id[next_worker], 1);
-          next_worker = (next_worker == my_last_worker - 1) ? my_first_worker
-                                                            : next_worker + 1;
-        }
-#else // MPK_TEST_MODE
-
-        // Check if we want to continue
+        // Check if we want to continue. Test mode runs through the active
+        // mode's prepare_next_batch (typically MODE_OFFLINE) and terminates
+        // naturally on the second call: the always-finalize shortcut clears
+        // the in-flight request in Step 1, and Step 4 finds next_request_id
+        // already at total_num_requests, so num_tokens == 0 → returns false.
 #ifdef MPK_ENABLE_PROFILING
         PROFILER_EVENT_START(TASK_SCHD_PREPARE_BATCH, sched_profiling_cnt);
 #endif
@@ -1300,7 +1282,6 @@ __device__ __forceinline__ void execute_scheduler(RuntimeConfig config,
           next_worker = (next_worker == my_last_worker - 1) ? my_first_worker
                                                             : next_worker + 1;
         }
-#endif // MPK_TEST_MODE
       } else if (e.event_type == EVENT_LAUNCH_DEPENDENT_TASKS) {
         iteration_num = iteration_num + 1;
         // assign event in a round-robin fashion
@@ -1516,7 +1497,6 @@ extern "C" void
                            int total_num_requests,
                            long long eos_token_id,
                            int allocate_nvshmem_teams,
-                           int is_test_mode,
                            std::vector<std::string> model_tensor_names,
                            std::vector<void *> model_tensor_ptrs) {
   // Build global model tensors map from parallel vectors
@@ -1836,14 +1816,7 @@ extern "C" void
                            cudaEventDisableTiming);
 #endif
 
-  if (is_test_mode) {
-    printf(
-        "MPK is running in test mode. The persistent kernel will run exactly "
-        "one pass of the task graph, then terminate.\n");
-    printf("Skipping request resource initialization.\n");
-  } else {
-    init_request_resources();
-  }
+  init_request_resources();
 #ifdef USE_NVSHMEM
   // Add a global barrier for all init_kernel to complete
   nvshmem_barrier_all();

--- a/python/mirage/mpk/persistent_kernel.py
+++ b/python/mirage/mpk/persistent_kernel.py
@@ -49,10 +49,10 @@ static PyObject *init_func(PyObject *self, PyObject *args) {
   std::vector<void*> model_tensor_ptrs;
   int my_mpi_rank, num_workers, num_local_schedulers, num_remote_schedulers, max_seq_length, total_num_requests;
   long long eos_token_id;
-  int allocate_nvshmem_teams, is_test_mode;
+  int allocate_nvshmem_teams;
   void *profiler_buffer;
 
-  if (!PyArg_ParseTuple(args, "OOiiiiiiLiiOOO", &meta_list, &py_profiler_buffer, &my_mpi_rank, &num_workers, &num_local_schedulers, &num_remote_schedulers, &max_seq_length, &total_num_requests, &eos_token_id, &allocate_nvshmem_teams, &is_test_mode, &tensor_names_list, &tensor_ptrs_list, &py_json_path)) {
+  if (!PyArg_ParseTuple(args, "OOiiiiiiLiOOO", &meta_list, &py_profiler_buffer, &my_mpi_rank, &num_workers, &num_local_schedulers, &num_remote_schedulers, &max_seq_length, &total_num_requests, &eos_token_id, &allocate_nvshmem_teams, &tensor_names_list, &tensor_ptrs_list, &py_json_path)) {
     PyErr_SetString(PyExc_TypeError, "Invalid parameters");
     return NULL;
   }
@@ -74,7 +74,7 @@ static PyObject *init_func(PyObject *self, PyObject *args) {
   for(Py_ssize_t i = 0; i < meta_size; i++) {
     PyObject *item = PyList_GetItem(meta_list, i);
     void* tensor = PyLong_AsVoidPtr(item);
-    if(!tensor && !is_test_mode) {
+    if(!tensor) {
       PyErr_Format(PyExc_TypeError, "Failed to convert item %d (meta) to void pointer", i);
       return NULL;
     }
@@ -105,7 +105,7 @@ static PyObject *init_func(PyObject *self, PyObject *args) {
     }
   }
 
-  init_persistent_kernel(meta_tensors, profiler_buffer, my_mpi_rank, num_workers, num_local_schedulers, num_remote_schedulers, max_seq_length, total_num_requests, eos_token_id, allocate_nvshmem_teams, is_test_mode, model_tensor_names, model_tensor_ptrs);
+  init_persistent_kernel(meta_tensors, profiler_buffer, my_mpi_rank, num_workers, num_local_schedulers, num_remote_schedulers, max_seq_length, total_num_requests, eos_token_id, allocate_nvshmem_teams, model_tensor_names, model_tensor_ptrs);
 
   Py_RETURN_NONE;
 }
@@ -422,14 +422,18 @@ class PersistentKernel:
         self.target_cc = torch.cuda.get_device_properties(0).major * 10 + torch.cuda.get_device_properties(0).minor
 
         if test_mode:
-            # Skip all following checks
-            self.total_num_requests = 1
-            return
+            # Auto-allocate any meta tensors the test author didn't provide so
+            # the kernel sees valid GPU pointers. Shapes are derived from the
+            # kernel-level params already on `self`. Defaults model "single
+            # prefill of max_num_batched_tokens tokens, content all zero" — the
+            # test author overrides any subset by setting them in
+            # `params["meta_tensors"]` before constructing PersistentKernel.
+            self._apply_test_mode_meta_defaults()
 
-        self.total_num_requests = meta_tensors["tokens"].shape[0]
+        self.total_num_requests = self.meta_tensors["tokens"].shape[0]
 
         # Checks
-        assert self.max_seq_length == meta_tensors["tokens"].shape[1]
+        assert self.max_seq_length == self.meta_tensors["tokens"].shape[1]
         qo_indptr_buffer = self.meta_tensors["qo_indptr_buffer"]
         # Asserts "==" below is not guaranteed by vllm, because the shape is changed depending on real situation. But the mem space won't change.
         assert qo_indptr_buffer.shape[0] <= self.max_num_batched_requests+1, f"qo_indptr_buffer.shape: {qo_indptr_buffer.shape}, max_num_batched_requests: {self.max_num_batched_requests}"
@@ -452,7 +456,52 @@ class PersistentKernel:
         assert paged_kv_indptr_buffer.dtype == torch.int32, f"paged_kv_indptr_buffer.dtype: {paged_kv_indptr_buffer.dtype}"
         assert paged_kv_indices_buffer.dtype == torch.int32, f"paged_kv_indices_buffer.dtype: {paged_kv_indices_buffer.dtype}"
         assert paged_kv_last_page_len_buffer.dtype == torch.int32, f"paged_kv_last_page_len_buffer.dtype: {paged_kv_last_page_len_buffer.dtype}"
-    
+
+    def _apply_test_mode_meta_defaults(self):
+        # Allocate any missing meta tensors with shapes derived from the
+        # kernel-level params. Mirrors the production wiring in
+        # demo/qwen3/demo.py (qo/paged_kv buffers sized to max_num_*).
+        # `total_num_requests` is taken from `tokens.shape[0]` after this
+        # function runs, so default `tokens` to a single-request buffer.
+        device = "cuda"
+        if "tokens" not in self.meta_tensors:
+            self.meta_tensors["tokens"] = torch.zeros(
+                1, self.max_seq_length, dtype=torch.int64, device=device)
+        n_req = self.meta_tensors["tokens"].shape[0]
+        if "step" not in self.meta_tensors:
+            self.meta_tensors["step"] = torch.zeros(
+                n_req, dtype=torch.int32, device=device)
+        if "prompt_lengths" not in self.meta_tensors:
+            # Default to a single prefill that fills one iter's batched-token
+            # budget. Test authors override for decode/multi-request scenarios.
+            self.meta_tensors["prompt_lengths"] = torch.full(
+                (n_req,), self.max_num_batched_tokens,
+                dtype=torch.int32, device=device)
+        if "input_tokens" not in self.meta_tensors:
+            self.meta_tensors["input_tokens"] = torch.zeros(
+                self.max_num_batched_tokens, dtype=torch.int64, device=device)
+        if "output_tokens" not in self.meta_tensors:
+            self.meta_tensors["output_tokens"] = torch.zeros(
+                self.max_num_batched_tokens, dtype=torch.int64, device=device)
+        if "num_new_tokens" not in self.meta_tensors:
+            self.meta_tensors["num_new_tokens"] = torch.zeros(
+                1, dtype=torch.int32, device=device)
+        if "qo_indptr_buffer" not in self.meta_tensors:
+            self.meta_tensors["qo_indptr_buffer"] = torch.zeros(
+                self.max_num_batched_requests + 1,
+                dtype=torch.int32, device=device)
+        if "paged_kv_indptr_buffer" not in self.meta_tensors:
+            self.meta_tensors["paged_kv_indptr_buffer"] = torch.zeros(
+                self.max_num_batched_requests + 1,
+                dtype=torch.int32, device=device)
+        if "paged_kv_indices_buffer" not in self.meta_tensors:
+            self.meta_tensors["paged_kv_indices_buffer"] = torch.zeros(
+                self.max_num_pages, dtype=torch.int32, device=device)
+        if "paged_kv_last_page_len_buffer" not in self.meta_tensors:
+            self.meta_tensors["paged_kv_last_page_len_buffer"] = torch.zeros(
+                self.max_num_batched_requests,
+                dtype=torch.int32, device=device)
+
     @classmethod
     def get_default_init_parameters(cls):
         return {
@@ -2698,7 +2747,6 @@ class PersistentKernel:
             self.total_num_requests,
             self.eos_token_id,
             self.allocate_nvshmem_teams,
-            self.test_mode,
             model_tensor_names,
             model_tensor_ptrs,
             "",  # Empty JSON path = use __FILE__ based path during initial compile
@@ -2811,12 +2859,11 @@ class PersistentKernel:
             self.total_num_requests,
             self.eos_token_id,
             self.allocate_nvshmem_teams,
-            self.test_mode,
             model_tensor_names,
             model_tensor_ptrs,
             json_path,  # Pass the JSON path for kernel reuse
         )
-        
+
         self._is_compiled = True
 
     def __call__(self, **kwargs):
@@ -2849,32 +2896,6 @@ class PersistentKernel:
             export_to_perfetto_trace(
                 self.profiler_tensor, trace_name
             )
-
-    def run_test_mode(self):
-        """Test-mode execution: launch the task graph once.
-
-        Input/output tensors must be pre-attached via attach_input() before
-        compile(). After run_test_mode() returns, the output tensors contain the results.
-        """
-        assert self.test_mode, "run_test_mode() is only available in test mode"
-        assert self._is_compiled, "Must call compile() before run_test_mode()"
-
-        stream = torch.cuda.current_stream()
-        # Convert torch.cuda.Stream to raw pointer (integer) for the C launcher
-        stream_ptr = 0
-        if hasattr(stream, "cuda_stream"):
-            try:
-                stream_ptr = int(stream.cuda_stream)
-            except Exception:
-                try:
-                    stream_ptr = int(stream.cuda_stream.value)
-                except Exception as e:
-                    raise ValueError(f"Invalid stream object: {stream} is of type {type(stream)}: {e}")
-        elif isinstance(stream, int):
-            stream_ptr = stream
-        else:
-            raise ValueError("Invalid stream object")
-        self.launch_func(stream_ptr)
 
     def __del__(self):
         if not self.__finalized__:

--- a/python/mirage/mpk/persistent_kernel.py
+++ b/python/mirage/mpk/persistent_kernel.py
@@ -2886,16 +2886,17 @@ class PersistentKernel:
             raise ValueError("Invalid stream object")
         self.launch_func(stream_ptr)
         if self.profiler_tensor is not None:
-            from .profiler_persistent import export_to_perfetto_trace
-            
+            from .profiler_persistent import export_to_csv, export_to_perfetto_trace
+
             if self.trace_name:
-                trace_name = self.trace_name + ".perfetto-trace"
+                stem = self.trace_name
             else:
-                trace_name = f"mirage_{self.mpi_rank}.perfetto-trace"
+                stem = f"mirage_{self.mpi_rank}"
 
             export_to_perfetto_trace(
-                self.profiler_tensor, trace_name
+                self.profiler_tensor, stem + ".perfetto-trace"
             )
+            export_to_csv(self.profiler_tensor, stem + ".csv")
 
     def __del__(self):
         if not self.__finalized__:

--- a/python/mirage/mpk/profiler_persistent.py
+++ b/python/mirage/mpk/profiler_persistent.py
@@ -122,25 +122,19 @@ def decode_tag(tag, num_blocks, num_groups):
     )
 
 
-def export_to_perfetto_trace(
-    profiler_buffer: torch.Tensor,
-    file_name: str,
-) -> None:
+def _decode_events(profiler_buffer: torch.Tensor):
+    """Yield decoded events from an on-device profiler buffer.
 
+    First yield is a header tuple ("__header__", num_blocks, num_groups);
+    subsequent yields are (block_idx, group_idx, event_idx, event_no,
+    event_type, timestamp).
+    """
     profiler_buffer_host = profiler_buffer.cpu()
     num_blocks, num_groups = profiler_buffer_host[:1].view(dtype=torch.int32)
     num_blocks = int(num_blocks)
     num_groups = int(num_groups)
 
-    tgen = TraceGenerator(file_name)
-
-    tid_map = {}
-    track_map = {}
-    for block_idx in range(num_blocks):
-        pid = tgen.create_group(f"block_{block_idx}")
-        for group_idx in range(num_groups):
-            tid = pid.create_group(f"group_{group_idx}")
-            tid_map[(block_idx, group_idx)] = tid
+    yield ("__header__", num_blocks, num_groups)
 
     for i in range(1, len(profiler_buffer_host)):
         if profiler_buffer_host[i] == 0:
@@ -152,7 +146,27 @@ def export_to_perfetto_trace(
         event_no, block_idx, group_idx, event_idx, event_type = decode_tag(
             tag, num_blocks, num_groups
         )
+        yield (block_idx, group_idx, event_idx, event_no, event_type, timestamp)
 
+
+def export_to_perfetto_trace(
+    profiler_buffer: torch.Tensor,
+    file_name: str,
+) -> None:
+    events = _decode_events(profiler_buffer)
+    _, num_blocks, num_groups = next(events)
+
+    tgen = TraceGenerator(file_name)
+
+    tid_map = {}
+    track_map = {}
+    for block_idx in range(num_blocks):
+        pid = tgen.create_group(f"block_{block_idx}")
+        for group_idx in range(num_groups):
+            tid = pid.create_group(f"group_{group_idx}")
+            tid_map[(block_idx, group_idx)] = tid
+
+    for block_idx, group_idx, event_idx, event_no, event_type, timestamp in events:
         event = event_name_list[event_idx] + f"_{event_no}"
         tid = tid_map[(block_idx, group_idx)]
 
@@ -170,3 +184,73 @@ def export_to_perfetto_trace(
             track.instant(timestamp, event)
 
     tgen.flush()
+
+
+def export_to_csv(
+    profiler_buffer: torch.Tensor,
+    file_name: str,
+) -> None:
+    """Write one CSV row per fully-paired task event (and per kInstant event).
+
+    Columns: task_type_id, task_type_name, block_idx, group_idx, event_no,
+             begin_ts, end_ts, duration_ns.
+
+    Raises RuntimeError on a dangling BEGIN with no matching END (indicates
+    profiler buffer overflow or a code bug). Timestamps are raw 32-bit
+    %globaltimer_lo values; durations are computed modulo 2^32, so traces
+    longer than ~4.3s will be incorrect — same limitation as the perfetto
+    export.
+    """
+    events = _decode_events(profiler_buffer)
+    next(events)  # discard header
+
+    pending = {}  # (block, group, event_idx) -> (event_no, begin_ts)
+    rows = []
+
+    for block_idx, group_idx, event_idx, event_no, event_type, timestamp in events:
+        key = (block_idx, group_idx, event_idx)
+        name = event_name_list.get(event_idx, f"UNKNOWN_{event_idx}")
+
+        if event_type == EventType.kBegin.value:
+            if key in pending:
+                prev_no, prev_ts = pending[key]
+                raise RuntimeError(
+                    f"dangling BEGIN: block={block_idx} group={group_idx} "
+                    f"event={name} event_no={prev_no} ts={prev_ts} has no END "
+                    f"before next BEGIN at event_no={event_no}"
+                )
+            pending[key] = (event_no, timestamp)
+        elif event_type == EventType.kEnd.value:
+            if key not in pending:
+                raise RuntimeError(
+                    f"END without matching BEGIN: block={block_idx} "
+                    f"group={group_idx} event={name} event_no={event_no}"
+                )
+            begin_no, begin_ts = pending.pop(key)
+            duration = (timestamp - begin_ts) & 0xFFFFFFFF
+            rows.append(
+                (event_idx, name, block_idx, group_idx, begin_no,
+                 begin_ts, timestamp, duration)
+            )
+        elif event_type == EventType.kInstant.value:
+            rows.append(
+                (event_idx, name, block_idx, group_idx, event_no,
+                 timestamp, timestamp, 0)
+            )
+
+    if pending:
+        (b, g, e), (no, ts) = next(iter(pending.items()))
+        name = event_name_list.get(e, f"UNKNOWN_{e}")
+        raise RuntimeError(
+            f"{len(pending)} dangling BEGIN event(s) with no matching END "
+            f"(profiler buffer likely overflowed). Example: block={b} "
+            f"group={g} event={name} event_no={no} ts={ts}"
+        )
+
+    with open(file_name, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow([
+            "task_type_id", "task_type_name", "block_idx", "group_idx",
+            "event_no", "begin_ts", "end_ts", "duration_ns",
+        ])
+        writer.writerows(rows)

--- a/scripts/parse_profile.py
+++ b/scripts/parse_profile.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Query MPK profiler CSV traces produced alongside the Perfetto trace.
+
+The CSV is emitted automatically when MPK runs with profiling enabled — see
+python/mirage/mpk/profiler_persistent.py:export_to_csv. This script aggregates
+per-task-type stats (min/max/avg/median) over all recorded events.
+
+Usage:
+    # Enumerate task types observed in the run, with event counts
+    python scripts/parse_profile.py mirage_0.csv --list
+
+    # Average runtime of one task type
+    python scripts/parse_profile.py mirage_0.csv TASK_LINEAR_SM100 --stat avg
+
+    # All stats at once
+    python scripts/parse_profile.py mirage_0.csv TASK_LINEAR_SM100 --stat all
+
+    # Numeric task-type id also accepted
+    python scripts/parse_profile.py mirage_0.csv 253 --stat min
+
+Output is JSON. Errors print {"error": "..."} on stdout and exit 2.
+"""
+
+import argparse
+import csv
+import json
+import os
+import statistics
+import sys
+from collections import Counter
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(REPO_ROOT, "python"))
+
+from mirage.mpk.profiler_persistent import event_name_list  # noqa: E402
+
+NAME_TO_ID = {name: tid for tid, name in event_name_list.items()}
+
+
+def fail(msg, code=2):
+    print(json.dumps({"error": msg}))
+    sys.exit(code)
+
+
+def load_rows(csv_path):
+    if not os.path.isfile(csv_path):
+        fail(f"csv file not found: {csv_path}")
+    with open(csv_path, newline="") as f:
+        reader = csv.DictReader(f)
+        return list(reader)
+
+
+def resolve_task_type(token):
+    """Return (task_type_id, task_type_name). Token may be numeric or a name."""
+    if token.isdigit():
+        tid = int(token)
+        return tid, event_name_list.get(tid, f"UNKNOWN_{tid}")
+    if token in NAME_TO_ID:
+        return NAME_TO_ID[token], token
+    fail(f"unknown task type: {token!r} (not in event_name_list)")
+
+
+def cmd_list(rows):
+    counts = Counter(r["task_type_name"] for r in rows)
+    out = [{"task_type": n, "count": c}
+           for n, c in counts.most_common()]
+    print(json.dumps(out))
+
+
+def cmd_stat(rows, task_type_token, stat):
+    tid, name = resolve_task_type(task_type_token)
+    durations = [int(r["duration_ns"]) for r in rows
+                 if int(r["task_type_id"]) == tid]
+    if not durations:
+        fail(f"task type {name!r} not found in trace")
+
+    if stat == "all":
+        out = {
+            "task_type": name,
+            "count": len(durations),
+            "min_ns": min(durations),
+            "max_ns": max(durations),
+            "avg_ns": statistics.fmean(durations),
+            "median_ns": statistics.median(durations),
+        }
+    elif stat == "avg":
+        out = {"task_type": name, "stat": "avg",
+               "value_ns": statistics.fmean(durations),
+               "count": len(durations)}
+    elif stat == "min":
+        out = {"task_type": name, "stat": "min",
+               "value_ns": min(durations),
+               "count": len(durations)}
+    elif stat == "max":
+        out = {"task_type": name, "stat": "max",
+               "value_ns": max(durations),
+               "count": len(durations)}
+    else:
+        fail(f"unknown stat: {stat!r}")
+
+    print(json.dumps(out))
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("csv_path")
+    p.add_argument("task_type", nargs="?",
+                   help="Task type name (e.g. TASK_LINEAR_SM100) or numeric id")
+    p.add_argument("--stat", choices=["avg", "min", "max", "all"],
+                   default="avg")
+    p.add_argument("--list", action="store_true", dest="list_mode",
+                   help="List all task types observed, with event counts")
+    args = p.parse_args()
+
+    rows = load_rows(args.csv_path)
+
+    if args.list_mode:
+        if args.task_type is not None:
+            fail("--list is mutually exclusive with positional task_type")
+        cmd_list(rows)
+        return
+
+    if args.task_type is None:
+        fail("task_type is required unless --list is given")
+
+    cmd_stat(rows, args.task_type, args.stat)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/runtime_python/blackwell/sm100_moe_sigmoid/test_topk_sigmoid_testmode.py
+++ b/tests/runtime_python/blackwell/sm100_moe_sigmoid/test_topk_sigmoid_testmode.py
@@ -155,7 +155,7 @@ def test_topk_sigmoid_testmode():
 
     # Run
     print("Running test kernel...")
-    pk.run_test_mode()
+    pk()
     torch.cuda.synchronize()
 
     # Compute reference

--- a/tests/runtime_python/test_mode/test_diamond_fork_join_testmode.py
+++ b/tests/runtime_python/test_mode/test_diamond_fork_join_testmode.py
@@ -117,7 +117,7 @@ def test_diamond_fork_join_testmode():
     pk.compile(output_dir=folder_path)
 
     print("Running diamond fork+join test kernel...")
-    pk.run_test_mode()
+    pk()
     torch.cuda.synchronize()
 
     ref_a = torch_rmsnorm(x_input, w_a)

--- a/tests/runtime_python/test_mode/test_fork_point_testmode.py
+++ b/tests/runtime_python/test_mode/test_fork_point_testmode.py
@@ -76,7 +76,7 @@ def test_fork_point_testmode():
     pk.compile(output_dir=folder_path)
 
     print("Running fork-point test kernel...")
-    pk.run_test_mode()
+    pk()
     torch.cuda.synchronize()
 
     ref_a = torch_rmsnorm(x_input, w_a)

--- a/tests/runtime_python/test_mode/test_fp8_moe_pipeline_testmode.py
+++ b/tests/runtime_python/test_mode/test_fp8_moe_pipeline_testmode.py
@@ -165,7 +165,7 @@ def test_moe_w13_fp8():
     print("Compiling...")
     pk.compile(output_dir=os.path.dirname(__file__))
     print("Running...")
-    pk.run_test_mode()
+    pk()
     torch.cuda.synchronize()
 
     print(f"\nOutput[0, 0, :8]:    {output[0, 0, :8]}")
@@ -232,7 +232,7 @@ def test_moe_w2_fp8():
     print("Compiling...")
     pk.compile(output_dir=os.path.dirname(__file__))
     print("Running...")
-    pk.run_test_mode()
+    pk()
     torch.cuda.synchronize()
 
     print(f"\nOutput[0, 0, :8]:    {output[0, 0, :8]}")
@@ -310,7 +310,7 @@ def test_moe_w13_silu_mul():
     print("Compiling...")
     pk.compile(output_dir=os.path.dirname(__file__))
     print("Running...")
-    pk.run_test_mode()
+    pk()
     torch.cuda.synchronize()
 
     print(f"\nSiLU-Mul[0, 0, :8]:  {silu_out[0, 0, :8]}")
@@ -406,7 +406,7 @@ def test_moe_w13_silu_mul_w2():
     print("Compiling...")
     pk.compile(output_dir=os.path.dirname(__file__))
     print("Running...")
-    pk.run_test_mode()
+    pk()
     torch.cuda.synchronize()
 
     print(f"\nW2 output[0, 0, :8]:  {w2_out[0, 0, :8]}")

--- a/tests/runtime_python/test_mode/test_grid_dim_sweep_testmode.py
+++ b/tests/runtime_python/test_mode/test_grid_dim_sweep_testmode.py
@@ -78,7 +78,7 @@ def _run_one_config(batch_size, hidden, tag):
     pk.compile(output_dir=folder_path)
 
     print(f"[{tag}] Running...")
-    pk.run_test_mode()
+    pk()
     torch.cuda.synchronize()
 
     ref_a = torch_rmsnorm(x_input, w_a)

--- a/tests/runtime_python/test_mode/test_join_point_testmode.py
+++ b/tests/runtime_python/test_mode/test_join_point_testmode.py
@@ -90,7 +90,7 @@ def test_join_point_testmode():
     pk.compile(output_dir=folder_path)
 
     print("Running join-point test kernel...")
-    pk.run_test_mode()
+    pk()
     torch.cuda.synchronize()
 
     ref_a = torch_rmsnorm(x1_input, w_a)

--- a/tests/runtime_python/test_mode/test_moe_w13_linear_testmode.py
+++ b/tests/runtime_python/test_mode/test_moe_w13_linear_testmode.py
@@ -113,7 +113,7 @@ def test_moe_w13_linear():
     pk.compile(output_dir=folder_path)
 
     print("Running...")
-    pk.run_test_mode()
+    pk()
     torch.cuda.synchronize()
 
     # --- Compare ---

--- a/tests/runtime_python/test_mode/test_qwen3_mlp_testmode.py
+++ b/tests/runtime_python/test_mode/test_qwen3_mlp_testmode.py
@@ -93,7 +93,7 @@ def test_gateup_only():
     pk.compile(output_dir=folder_path)
 
     print("Running...")
-    pk.run()
+    pk()
     torch.cuda.synchronize()
 
     print(f"\nmlp_mid[0, :8]:   {mlp_mid[0, :8]}")
@@ -211,7 +211,7 @@ def test_gateup_silu_down():
     pk.compile(output_dir=folder_path)
 
     print("Running...")
-    pk.run()
+    pk()
     torch.cuda.synchronize()
 
     print(f"\nmlp_out[0, :8]:   {mlp_out[0, :8]}")
@@ -321,7 +321,7 @@ def test_gateup_silu():
     pk.compile(output_dir=folder_path)
 
     print("Running...")
-    pk.run()
+    pk()
     torch.cuda.synchronize()
 
     print(f"\nsilu_mul_out[0, :8]:   {silu_mul_out[0, :8]}")

--- a/tests/runtime_python/test_mode/test_residual_stripping_testmode.py
+++ b/tests/runtime_python/test_mode/test_residual_stripping_testmode.py
@@ -88,7 +88,7 @@ def test_residual_stripping_testmode():
     pk.compile(output_dir=folder_path)
 
     print("Running residual-stripping test kernel...")
-    pk.run_test_mode()
+    pk()
     torch.cuda.synchronize()
 
     ref_a = torch_rmsnorm(x_input, w_a)

--- a/tests/runtime_python/test_mode/test_rmsnorm_testmode.py
+++ b/tests/runtime_python/test_mode/test_rmsnorm_testmode.py
@@ -65,7 +65,7 @@ def test_rmsnorm_testmode():
 
     # Run
     print("Running test kernel...")
-    pk.run_test_mode()
+    pk()
     torch.cuda.synchronize()
 
     # Compare against reference


### PR DESCRIPTION
Split out from `feat/dpskv3` (#707-series breakup) — the **test-mode interface** portion, rebased onto `mpk`.

## Included (6 commits)
- **Refactor the test-mode runtime interface**: remove the special `#ifdef MPK_TEST_MODE` scheduler path and the `is_test_mode` launch parameter. Test mode now runs through the normal `prepare_next_batch` (MODE_OFFLINE) with an always-finalize shortcut, so it terminates naturally after one pass — no dedicated runtime branch. (`persistent_kernel.cuh`, `python/mirage/mpk/persistent_kernel.py`)
- Update the generic `tests/runtime_python/test_mode/*` tests to the new interface.
- Update the `test-mode` / `add-mpk-task` skill docs.

