### PR TITLE
Fix double-counted MoE residual under tensor parallelism

### DIFF
--- a/include/mirage/persistent_kernel/tasks/blackwell/mul_sum_add_sm100.cuh
+++ b/include/mirage/persistent_kernel/tasks/blackwell/mul_sum_add_sm100.cuh
@@ -33,8 +33,9 @@ __device__ __forceinline__ void
 
   for (int row_idx = 0; row_idx < BATCH_SIZE; ++row_idx) {
     for (int i = threadIdx.x; i < OUTPUT_SIZE; i += blockDim.x) {
-      T res_val = d_residual[row_idx * OUTPUT_STRIDE + i];
-      float sum_val = float(res_val);
+      float sum_val =
+          (d_residual != nullptr) ? float(d_residual[row_idx * OUTPUT_STRIDE + i])
+                                  : 0.0f;
 #pragma unroll
       for (int topk_idx = 0; topk_idx < NUM_TOPK; ++topk_idx) {
         T val = d_input[row_idx * OUTPUT_STRIDE * NUM_TOPK +

--- a/python/mirage/mpk/persistent_kernel.py
+++ b/python/mirage/mpk/persistent_kernel.py
@@ -1353,7 +1353,17 @@ class PersistentKernel:
         tb_graph.new_input(output, (0, 1, -1), -1, True)
         self.kn_graph.customized([input, weight, residual, output], tb_graph)
 
-        self.kn_graph.register_task(tb_graph, "moe_mul_sum_add_sm100")
+        # Under tensor parallelism the MoE output is row-parallel and followed by
+        # an allreduce. The residual must be added on exactly one rank, otherwise
+        # the allreduce sums it world_size times (double-counted residual). Mirror
+        # the rank-0-only guard used by linear_with_residual_layer; the SM100
+        # kernel skips the residual add when its pointer is null (params[0]==0).
+        params = []
+        enable_residual = 1
+        if self.world_size > 1 and self.mpi_rank != 0:
+            enable_residual = 0
+        params.append(enable_residual)
+        self.kn_graph.register_task(tb_graph, "moe_mul_sum_add_sm100", params)
 
     def splitk_linear_layer(
         self,

--- a/src/kernel/task_register.cc
+++ b/src/kernel/task_register.cc
@@ -2895,7 +2895,11 @@ int TaskRegister::register_moe_silu_mul_task(threadblock::Graph const &bgraph,
 
 int TaskRegister::register_moe_mul_sum_add_sm100_task(
     threadblock::Graph const &bgraph, std::vector<int> const &params) {
-  assert(params.size() == 0);
+  bool rank_with_residual = true;
+  if (!params.empty()) {
+    assert(params.size() == 1);
+    rank_with_residual = (params[0] == 1);
+  }
   int batch_size = 0, num_experts_per_tok = 0, output_size = 0, input_stride,
       output_stride;
   std::vector<tb::TBInputOp *> input_ops;
@@ -2941,7 +2945,8 @@ int TaskRegister::register_moe_mul_sum_add_sm100_task(
          /*OUTPUT_STRIDE=*/output_stride);
   code.e("    task_desc->input_ptrs[0],");
   code.e("    task_desc->input_ptrs[1],");
-  code.e("    task_desc->input_ptrs[2],");
+  code.e("    $,",
+         rank_with_residual ? "task_desc->input_ptrs[2]" : "nullptr");
   code.e("    task_desc->output_ptrs[0]);");
   return register_task_variant(TASK_MOE_MUL_SUM_ADD_SM100, code.to_string());
 }


### PR DESCRIPTION
Under tensor parallelism the MoE block output is row-parallel and is followed by an allreduce that sums the partial outputs across ranks. The residual was added inside moe_mul_sum_add on every rank before that allreduce, so the allreduce summed the residual world_size times, meaning that it was doubled on 2 GPUs. After the next RMSNorm, this shows up as a uniform numerical divergence from the 1-GPU baseline and corrupts all downstream layers.

The attention o_proj path (linear_with_residual_layer) already guards this by adding the residual on rank 0 only. This applies the same rank-0-only guard to moe_mul_sum_add:

- persistent_kernel.py: pass enable_residual (0 on non-zero ranks under TP) to the moe_mul_sum_add_sm100 task.
- task_register.cc: accept the optional param and emit a null residual pointer for ranks that must skip the add.
- mul_sum_add_sm100.cuh: treat a null residual pointer as 0.

Verified with a single-GPU simulation: doubling the MoE residual reproduces the observed 2-GPU divergence, and the guarded version matches the 1-GPU baseline.