### PR TITLE
SM100 Linear Layer in CUDA

### DIFF
--- a/include/mirage/persistent_kernel/tasks/blackwell/linear_sm100_mpk.cuh
+++ b/include/mirage/persistent_kernel/tasks/blackwell/linear_sm100_mpk.cuh
@@ -1,37 +1,55 @@
+/* Copyright 2025 CMU
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #pragma once
-#include <cstdio>
-#include <iostream>
 
-// Cutlass includes
-#include <cutlass/half.h> // F16 data type
-// #include <cutlass/util/print_error.hpp>
-#include <cutlass/arch/barrier.h>
-#include <cutlass/cluster_launch.hpp>
-#include <cutlass/cutlass.h>
-#include <cutlass/numeric_conversion.h>
-#include <cutlass/numeric_types.h>
+#include <cuda.h>
+#include <cuda_bf16.h>
+#include <stdint.h>
 
-// CuTe includes
-#include <cute/algorithm/cooperative_copy.hpp> // Auto vectorized copy operation
-#include <cute/arch/cluster_sm90.hpp> // CuTe functions for querying the details of cluster launched
-#include <cute/arch/tmem_allocator_sm100.hpp> // TMEM allocator for SM100
-#include <cute/numeric/integral_constant.hpp> // Compile time in constants such as _1, _256 etc.
-#include <cute/tensor.hpp>                    // CuTe tensor implementation
-// using namespace cute;
-
-#include "../common/dmem_layout.cuh"
-#include "../common/worker_config.h"
-#include "../hopper/barrier.cuh"
-#include "../hopper/smem_layout_tma.cuh"
 #include "../hopper/tma.cuh"
-#include "storage.cuh"
+
+#include "sm100_ptx.cuh"
 
 namespace kernel {
+
+template <typename T,
+          int MMA_M,
+          int MMA_N,
+          int BK,
+          int NUM_AB_STAGE,
+          int NUM_ACC_STAGE,
+          int NUM_C_STAGE>
+struct LinearMpkSharedStorage {
+  alignas(128) T A[NUM_AB_STAGE * MMA_M * BK];
+  alignas(128) T B[NUM_AB_STAGE * MMA_N * BK];
+  alignas(128) T C[NUM_C_STAGE * MMA_N * MMA_M];
+
+  alignas(16) uint64_t ab_full_mbar[NUM_AB_STAGE];
+  alignas(16) uint64_t ab_empty_mbar[NUM_AB_STAGE];
+  alignas(16) uint64_t acc_full_mbar[NUM_ACC_STAGE];
+  alignas(16) uint64_t acc_empty_mbar[NUM_ACC_STAGE];
+
+  alignas(16) uint32_t tmem_base;
+};
+
+static constexpr int LINEAR_MPK_GROUP_M = 8;
 
 template <typename T_,
           typename TMA_A,
           typename TMA_B,
-          class BiasTensor,
           typename TMA_OUT,
           int MMA_M,
           int MMA_N,
@@ -44,694 +62,210 @@ template <typename T_,
           int NUM_ACC_STAGE = 2,
           int NUM_C_STAGE = 4>
 __device__ __noinline__ void
-    linear_sm100_mpk_task_impl(const TMA_A &tma_a,
-                               const TMA_B &tma_b,
-                               BiasTensor mBias,
-                               const TMA_OUT &tma_out) {
-  int warp_idx = cutlass::canonical_warp_idx_sync();
+    linear_sm100_mpk_task_impl(TMA_A const &tma_a,
+                               TMA_B const &tma_b,
+                               T_ const *mBias,
+                               int output_stride,
+                               TMA_OUT const &tma_out) {
+  using namespace ::kernel::sm100_ptx;
 
-  // Construct the MMA grid coordinate from the CTA grid coordinate
-  auto mma_coord_vmnk = cute::make_coord(0,        // Peer CTA coordinate
-                                         cute::_,  //    MMA-M coordinate
-                                         cute::_,  //    MMA-N coordinate
-                                         cute::_); //    MMA-K coordinate
+  constexpr int BK = 64;
+  constexpr int MMA_K = 16;
+  constexpr int K_SUB = BK / MMA_K;
+  constexpr int K_TILES = REDUCTION_SIZE / BK;
+  constexpr int NUM_M_TILES = (OUTPUT_SIZE + MMA_M - 1) / MMA_M;
+  constexpr int NUM_N_TILES = (BATCH_SIZE + MMA_N - 1) / MMA_N;
+  constexpr int NUM_TILES = NUM_M_TILES * NUM_N_TILES;
 
-  constexpr int num_tmem_columns = MMA_N * NUM_ACC_STAGE;
+  constexpr int A_TILE_ELEMS = MMA_M * BK;
+  constexpr int B_TILE_ELEMS = MMA_N * BK;
+  constexpr int C_TILE_ELEMS = MMA_N * MMA_M;
 
-  cute::TiledMMA tiled_mma = cute::make_tiled_mma(
-      cute::SM100_MMA_F16BF16_SS<T_,
-                                 T_,
-                                 float, // Mma's A, B, and Accumulator types
-                                 MMA_M,
-                                 MMA_N, // Mma M and N dimensions
-                                 cute::UMMA::Major::K,
-                                 cute::UMMA::Major::K>{}); // A and B layouts
-  auto bM = cute::tile_size<0>(
-      tiled_mma); // MMA Tile M. We'll use 1 MMAs per MMA Tile M.
-  auto bN = cute::tile_size<1>(
-      tiled_mma); // MMA Tile N. We'll use 1 MMAs per MMA Tile N.
-  auto bK = cute::tile_size<2>(tiled_mma) *
-            cute::Int<4>{}; // MMA Tile K. We'll use 4 MMAs per MMA Tile K. For
-                            // 16b types, tcgen05.mma has K16.
+  constexpr uint32_t idesc = make_idesc_f16(MMA_M, MMA_N);
 
-  auto mma_tiler = cute::make_shape(bM, bN, bK); // (MMA_M, MMA_N, MMA_K)
-
-  // Partition the GMEM tensors with the mma_tiler and mma_coord to get the
-  // slices processed
-  //   by this mma tile.
-  // CuTe provides local_tile partitioning function. local_tile accepts 4
-  // parameters:
-  //   * Tensor to partition
-  //   * Tiler to use for partitioning
-  //   * Coordinate to use for slicing the partitioned tensor
-  //   * Projection to ignore unwanted modes of the Tiler and Coordinate
-  auto mma_coord = cute::select<1, 2, 3>(mma_coord_vmnk);
-  auto cd_tiler =
-      cute::make_shape(bN, bM, bK); // (MmaTile_N, MmaTile_M, MmaTile_K)
-
-  cute::Tensor mA = cute::make_coord_tensor(cute::make_layout(
-      cute::make_shape(OUTPUT_SIZE, REDUCTION_SIZE),
-      cute::make_stride(
-          cute::E<1>{},
-          cute::E<0>{}))); // ArithTuple(_0,_0) o
-                           // (output_size,reduction_size):(_1@1,_1@0)
-  cute::Tensor mB = cute::make_coord_tensor(cute::make_layout(
-      cute::make_shape(BATCH_SIZE, REDUCTION_SIZE),
-      cute::make_stride(
-          cute::E<1>{},
-          cute::E<0>{}))); // ArithTuple(_0,_0) o
-                           // (batch_size,reduction_size):(_1@1,_1@0)
-  cute::Tensor mC = cute::make_coord_tensor(cute::make_layout(
-      cute::make_shape(BATCH_SIZE, OUTPUT_SIZE),
-      cute::make_stride(cute::E<1>{},
-                        cute::E<0>{}))); // ArithTuple(_0,_0) o
-                                         // (batch_size,output_size):(_1@1,_1@0)
-  cute::Tensor mBiasCoord = cute::make_identity_tensor(
-      cute::make_shape(cute::Int<BATCH_SIZE>{}, cute::Int<OUTPUT_SIZE>{}));
-
-  cute::Tensor gA = cute::local_tile(
-      mA,
-      mma_tiler,
-      mma_coord,
-      cute::Step<cute::_1,
-                 cute::X,
-                 cute::_1>{}); // ArithTuple(_0,_0) o
-                               // (_128,_64,8,64):(_1@1,_1@0,_128@1,_64@0)
-  cute::Tensor gB = cute::local_tile(
-      mB,
-      mma_tiler,
-      mma_coord,
-      cute::Step<cute::X,
-                 cute::_1,
-                 cute::_1>{}); // ArithTuple(_0,_0) o
-                               // (_32,_64,1,64):(_1@1,_1@0,_32@1,_64@0)
-  cute::Tensor gBias = cute::local_tile(
-      mBias,
-      cd_tiler,
-      mma_coord,
-      cute::Step<cute::_1,
-                 cute::_1,
-                 cute::X>{}); // gmem_ptr[16b](0x7704bd040000) o
-                              // (_32,_128,1,8):(1024,_1,32768,_128)
-  cute::Tensor gBiasCoord =
-      cute::local_tile(mBiasCoord,
-                       cd_tiler,
-                       mma_coord,
-                       cute::Step<cute::_1, cute::_1, cute::X>{});
-  cute::Tensor gC = cute::local_tile(
-      mC,
-      cd_tiler,
-      mma_coord,
-      cute::Step<cute::_1,
-                 cute::_1,
-                 cute::X>{}); // ArithTuple(_0,_0) o
-                              // (_32,_128,1,8):(_1@1,_1@0,_32@1,_128@0)
-
-  // if (cute::thread0()) {
-  //   cute::print("mA:\t"); cute::print(mA); cute::print("\n");       // mA:
-  //   ArithTuple(_0,_0) o (output_size,reduction_size):(_1@1,_1@0)
-  //   cute::print("mB:\t"); cute::print(mB); cute::print("\n");       // mB:
-  //   ArithTuple(_0,_0) o (batch_size,reduction_size):(_1@1,_1@0)
-  //   cute::print("mBias:\t"); cute::print(mBias); cute::print("\n");   //
-  //   mBias:   gmem_ptr[32b](GMEM_ADDR_C) o (batch_size,output_size):(1024,_1)
-  //   cute::print("mC:\t"); cute::print(mC); cute::print("\n");       // mC:
-  //   ArithTuple(_0,_0) o (batch_size,output_size):(_1@1,_1@0)
-  //   cute::print("gA:\t"); cute::print(gA); cute::print("\n");
-  //   cute::print("gB:\t"); cute::print(gB); cute::print("\n");
-  //   cute::print("gBias:\t"); cute::print(gBias); cute::print("\n");
-  //   cute::print("gC:\t"); cute::print(gC); cute::print("\n");
-  //   printf("num_ab_stage, num_acc_stage, num_c_stage, : %d, %d, %d\n",
-  //   NUM_AB_STAGE, NUM_ACC_STAGE, NUM_C_STAGE); printf("NOBIAS: %d\n",
-  //   NOBIAS);
-  // } __syncthreads();
-
-  // Pre-partitioned Tile Shape (MmaTile_M, MmaTile_K) to post-partitioned
-  // (MmaA, NumMma_M, NumMma_K)
-  auto mma_shape_A =
-      cute::partition_shape_A(tiled_mma,
-                              cute::make_shape(cute::Int<MMA_M>{},
-                                               cute::size<2>(mma_tiler),
-                                               cute::Int<NUM_AB_STAGE>{}));
-  // Pre-partitioned Tile Shape (MmaTile_N, MmaTile_K) to post-partitioned
-  // (MmaB, NumMma_N, NumMma_K)
-  auto mma_shape_B =
-      cute::partition_shape_B(tiled_mma,
-                              cute::make_shape(cute::Int<MMA_N>{},
-                                               cute::size<2>(mma_tiler),
-                                               cute::Int<NUM_AB_STAGE>{}));
-  // Pre-partitioned Tile Shape (MmaTile_N, MmaTile_M) to post-partitioned
-  // (MmaC, NumMma_N, NumMma_K)
-  auto mma_shape_C =
-      cute::make_shape(cute::make_shape(cute::Int<MMA_N>{}, cute::Int<MMA_M>{}),
-                       cute::Int<1>{},
-                       cute::Int<1>{},
-                       cute::Int<NUM_C_STAGE>{});
-
-  // Print and inspect mma_shape_A, and mma_shape_B for this example.
-  // if (cute::thread0()) {
-  //     cute::print("mma_shape_A:\t"); cute::print(mma_shape_A);
-  //     cute::print("\n");  // mma_shape_A:  ((_128,_16),_1,_4,_8)
-  //     cute::print("mma_shape_B:\t"); cute::print(mma_shape_B);
-  //     cute::print("\n");  // mma_shape_B:  ((_32,_16),_1,_4,_8)
-  //     cute::print("mma_shape_C:\t"); cute::print(mma_shape_C);
-  //     cute::print("\n");  // mma_shape_C:  ((_32,_128),_1,_1,_4)
-  // } __syncthreads();
-
-  auto sA_layout = cute::UMMA::tile_to_mma_shape(
-      cute::UMMA::Layout_K_SW128_Atom<T_>{}, mma_shape_A);
-  auto sB_layout = cute::UMMA::tile_to_mma_shape(
-      cute::UMMA::Layout_K_SW128_Atom<T_>{}, mma_shape_B);
-  // constuct unswizzled layout for C
-  auto sC_layout_fake = cute::UMMA::tile_to_mma_shape(
-      cute::UMMA::Layout_K_INTER_Atom<T_>{}, mma_shape_C);
-  auto sC_shape = cute::make_shape(
-      cute::make_shape(cute::Int<MMA_N>{}, cute::Int<MMA_M>{}),
-      cute::Int<1>{},
-      cute::Int<1>{},
-      cute::make_shape(cute::Int<1>{}, cute::Int<NUM_C_STAGE>{}));
-  auto sC_stride = cute::make_stride(
-      cute::make_stride(cute::Int<MMA_M>{}, cute::Int<1>{}),
-      cute::Int<0>{},
-      cute::Int<0>{},
-      cute::make_stride(cute::Int<0>{}, cute::Int<MMA_M * MMA_N>{}));
-  auto sC_layout = cute::composition(sC_layout_fake.layout_a(),
-                                     sC_layout_fake.offset(),
-                                     cute::make_layout(sC_shape, sC_stride));
-
-  // if (cute::thread0()){
-  //     cute::print("sA_layout:\t"); cute::print(sA_layout); cute::print("\n");
-  //     // sA_layout:   ArithTuple(_0,0) o
-  //     ((_128,_16),_1,_4,8):((_1@1,_1@0),_0,_16@0,_8@0)
-  //     cute::print("sB_layout:\t"); cute::print(sB_layout); cute::print("\n");
-  //     // sB_layout:   ArithTuple(_0,0) o
-  //     ((_32,_16),_1,_4,8):((_1@1,_1@0),_0,_16@0,_8@0)
-  //     cute::print("sC_layout:\t"); cute::print(sC_layout); cute::print("\n");
-  //     // sC_layout:   ArithTuple(_0,0) o
-  //     ((_32,_128),_1,_1,4):((_1@1,_1@0),_0,_128@0,_4@0)
-  // } __syncthreads();
-
-  using SharedStorage = PipedSharedStorage<T_,
-                                           T_,
-                                           T_,
-                                           decltype(sA_layout),
-                                           decltype(sB_layout),
-                                           decltype(sC_layout),
-                                           NUM_AB_STAGE,
-                                           NUM_ACC_STAGE>;
-
-  extern __shared__ char shared_memory[];
-  uintptr_t aligned_smem =
-      (reinterpret_cast<uintptr_t>(shared_memory) + 127) / 128 * 128;
-  SharedStorage &shared_storage =
-      *reinterpret_cast<SharedStorage *>(aligned_smem);
-
-  // Initialize the barriers in shared memory
-  if (warp_idx == 0) {
-    cutlass::arch::detail::initialize_barrier_array_aligned<
-        cutlass::arch::ClusterTransactionBarrier,
-        NUM_AB_STAGE>(shared_storage.ab_full_mbar_ptr, /* arrival count */ 1);
-    cutlass::arch::detail::initialize_barrier_array_aligned<
-        cutlass::arch::ClusterBarrier,
-        NUM_AB_STAGE>(shared_storage.ab_empty_mbar_ptr, /* arrival count */ 1);
-    cutlass::arch::detail::initialize_barrier_array_aligned<
-        cutlass::arch::ClusterBarrier,
-        NUM_ACC_STAGE>(shared_storage.acc_full_mbar_ptr, /* arrival count */ 1);
-    cutlass::arch::detail::initialize_barrier_array_aligned<
-        cutlass::arch::ClusterBarrier,
-        NUM_ACC_STAGE>(shared_storage.acc_empty_mbar_ptr,
-                       /* arrival count */ 4);
-  }
-
-  // Sync tmem allocation status between MMA and epilogue warps within CTA
-  // 32 threads (mma) + 128 threads (epilog) to sync
-  cutlass::arch::NamedBarrier tmem_allocation_result_barrier(
-      32 + 128, cutlass::arch::ReservedNamedBarriers::TmemAllocBarrier);
-  cutlass::arch::NamedBarrier epilogue_wg_barrier(
-      128, /*bar-id*/ cutlass::arch::ReservedNamedBarriers::EpilogueBarrier);
-
-  // Represent the SMEM buffers for A and B
-  cute::Tensor tCsA =
-      shared_storage.tensor_sA(); // (MmaA, NumMma_M, NumMma_K, Tiles_K)
-  cute::Tensor tCsB =
-      shared_storage.tensor_sB(); // (MmaB, NumMma_M, NumMma_K, Tiles_K)
-  cute::Tensor sC_epi = shared_storage.tensor_sC(); // (EpiTile)
-
-  //
-  // Mma partitioning for A and B
-  //
-
-  auto mma_v = cute::get<0>(mma_coord_vmnk);
-  cute::ThrMMA cta_mma = tiled_mma.get_slice(mma_v); // Use Peer CTA coordinate
-  cute::Tensor tCgA =
-      cta_mma.partition_A(gA); // (MmaA, NumMma_M, NumMma_K, Tiles_K)
-  cute::Tensor tCgB =
-      cta_mma.partition_B(gB); // (MmaB, NumMma_N, NumMma_K, Tiles_K)
-
-  // if (cute::thread0()) {
-  //   cute::print("tCgA:\t"); cute::print(tCgA); cute::print("\n");  // tCgA:
-  //   ArithTuple(_0,0) o ((_128,_16),_1,_4,64):((_1@1,_1@0),_0,_16@0,_64@0)
-  //   cute::print("tCgB:\t"); cute::print(tCgB); cute::print("\n");  // tCgB:
-  //   ArithTuple(_0,0) o ((_32,_16),_1,_4,64):((_1@1,_1@0),_0,_16@0,_64@0)
-  //   cute::print("tCgC_epi:\t"); cute::print(tCgC_epi); cute::print("\n");  //
-  //   tCgC:   ArithTuple(_0,_0) o
-  //   ((_32,_128),_1,_1,1,8):((_1@1,_1@0),_0,_0,_32@1,_128@0)
-  //   cute::print("tCsA:\t"); cute::print(tCsA); cute::print("\n");
-  //   cute::print("tCsB:\t"); cute::print(tCsB); cute::print("\n");
-  //   cute::print("sC_epi:\t"); cute::print(sC_epi); cute::print("\n");
-  // } __syncthreads();
-
-  // TMA bytes must match actual clamped box dims.
-  // When BATCH_SIZE < MMA_N, TMA input box is clamped to min(MMA_N,
-  // BATCH_SIZE). size<1>(mma_tiler)=bN corresponds to the input (B) TMA
-  // dimension. size<0>(mma_tiler)=bM corresponds to the weight (A) TMA
-  // dimension.
   constexpr int kClampedBN = (BATCH_SIZE < MMA_N) ? BATCH_SIZE : MMA_N;
-  int tma_transaction_bytes =
-      sizeof(T_) * kClampedBN * cute::size<2>(mma_tiler) +
-      sizeof(T_) * cute::size<0>(mma_tiler) * cute::size<2>(mma_tiler);
+  constexpr int TMA_BYTES = (int)sizeof(T_) * (MMA_M * BK + kClampedBN * BK);
 
-  constexpr int TILE_SIZE = 64;
-  constexpr int INPUT_TMA_TILE_SIZE = 64;
-  constexpr int WEIGHT_TMA_TILE_SIZE = 64;
-  constexpr int OUTPUT_ATOM_SIZE = 128;
-  constexpr int B = 3;
-  constexpr int M = 3;
-  constexpr int S = 3;
+  constexpr int tmem_used_columns = MMA_N * NUM_ACC_STAGE;
+  constexpr int num_tmem_columns = (tmem_used_columns <= 128)   ? 128
+                                   : (tmem_used_columns <= 256) ? 256
+                                                                : 512;
+  static_assert(num_tmem_columns <= 512, "TMEM oversubscribed");
 
-  T_ *shared_weight = shared_storage.A.begin();
-  T_ *shared_input = shared_storage.B.begin();
-  T_ *mm_output = shared_storage.C.begin();
+  int const tid = threadIdx.x;
+  if (tid >= 256) {
+    return;
+  }
+  int const wid = tid / 32;
 
-  Barrier *ab_full_mbar_ptr =
-      reinterpret_cast<Barrier *>(shared_storage.ab_full_mbar_ptr);
+  int const k_begin = 0;
+  int const k_end = K_TILES;
+  bool const use_reduce_add = SplitK;
 
-  using InputSmem = smem_tma<T_,
-                             B,
-                             M,
-                             S,
-                             MMA_N,
-                             INPUT_TMA_TILE_SIZE,
-                             1>; // 64/64 = 1
-  InputSmem input_smem(shared_input);
+  using SharedStorage = LinearMpkSharedStorage<T_,
+                                               MMA_M,
+                                               MMA_N,
+                                               BK,
+                                               NUM_AB_STAGE,
+                                               NUM_ACC_STAGE,
+                                               NUM_C_STAGE>;
+  extern __shared__ __align__(1024) char linear_mpk_smem_raw[];
+  uintptr_t aligned =
+      (reinterpret_cast<uintptr_t>(linear_mpk_smem_raw) + 1023) / 1024 * 1024;
+  SharedStorage &ss = *reinterpret_cast<SharedStorage *>(aligned);
 
-  using WeightSmem = smem_tma<T_,
-                              B,
-                              M,
-                              S,
-                              OUTPUT_ATOM_SIZE,
-                              WEIGHT_TMA_TILE_SIZE,
-                              1>; // 64/64 = 1
-  WeightSmem input_weight_smem(shared_weight);
+  int const A_smem = __cvta_generic_to_shared(&ss.A[0]);
+  int const B_smem = __cvta_generic_to_shared(&ss.B[0]);
+  int const ab_full = __cvta_generic_to_shared(&ss.ab_full_mbar[0]);
+  int const ab_empty = __cvta_generic_to_shared(&ss.ab_empty_mbar[0]);
+  int const acc_full = __cvta_generic_to_shared(&ss.acc_full_mbar[0]);
+  int const acc_empty = __cvta_generic_to_shared(&ss.acc_empty_mbar[0]);
 
-  using OutputSmem = smem_tma<T_, 0, M, S, MMA_N, OUTPUT_ATOM_SIZE, 1>;
-  OutputSmem mm_output_smem(mm_output);
-
-  // // check tma descriptor:
-  // if(threadIdx.x == 0){
-  //     printf("smem start addr: %u\n",
-  //     cute::cast_smem_ptr_to_uint(shared_memory)); printf("shared_weight:
-  //     %u\n", cute::cast_smem_ptr_to_uint(shared_weight));
-  //     printf("shared_input: %u\n",
-  //     cute::cast_smem_ptr_to_uint(shared_input)); printf("mm_output: %u\n",
-  //     cute::cast_smem_ptr_to_uint(mm_output));
-  // } __syncthreads();
-
-  // // Fence acquire tensor map:
-  // ptx::n32_t<128> size_bytes;
-  // // Since the tensor map was modified from the host using cudaMemcpy,
-  // // the scope should be .sys.
-  // ptx::fence_proxy_tensormap_generic(
-  //   ptx::sem_acquire, ptx::scope_sys, tma_a.desc_ptr, size_bytes
-  // );
-  // ptx::fence_proxy_tensormap_generic(
-  //   ptx::sem_acquire, ptx::scope_sys, tma_b.desc_ptr, size_bytes
-  // );
-  // ptx::fence_proxy_tensormap_generic(
-  //   ptx::sem_acquire, ptx::scope_sys, tma_out.desc_ptr, size_bytes
-  // );
-
-  // MMA Fragment Allocation
-  // We allocate "fragments" which are SMEM descriptors that serve as inputs to
-  // cute::gemm operations. For tcgen05.mma operations:
-  // - Matrices A and B are sourced from SMEM
-  // - tCrA and tCrB provide descriptor views of tCsA and tCsB respectively
-  // - The first mode of each descriptor represents the SMEM for a single MMA
-  // operation
-  cute::Tensor tCrA =
-      cta_mma.make_fragment_A(tCsA); // (MmaA, NumMma_M, NumMma_K, Tiles_K)
-  cute::Tensor tCrB =
-      cta_mma.make_fragment_B(tCsB); // (MmaB, NumMma_M, NumMma_K, Tiles_K)
-  auto acc_shape = cute::partition_shape_C(
-      tiled_mma,
-      cute::make_shape(cute::size<0>(mma_tiler),
-                       cute::size<1>(mma_tiler),
-                       cute::Int<NUM_ACC_STAGE>{})); // (MmaC, NumMma_M,
-                                                     // NumMma_N, NumAcc_Stage)
-  // (MMA, MMA_M, MMA_N, STAGE)
-  auto tCtAcc = tiled_mma.make_fragment_C(acc_shape);
-
-  cutlass::arch::fence_barrier_init();
+  if (wid == 0 && elect_sync()) {
+    for (int i = 0; i < NUM_AB_STAGE; i++) {
+      mbar_init(ab_full + i * 8, 1);
+      mbar_init(ab_empty + i * 8, 1);
+    }
+    for (int i = 0; i < NUM_ACC_STAGE; i++) {
+      mbar_init(acc_full + i * 8, 1);
+      mbar_init(acc_empty + i * 8, 1);
+    }
+    asm volatile("fence.mbarrier_init.release.cluster;");
+  } else if (wid == 1) {
+    int addr = __cvta_generic_to_shared(&ss.tmem_base);
+    tcgen05_alloc(addr, num_tmem_columns);
+  }
   __syncthreads();
+  int const taddr = 0;
 
-  // if (cute::thread0()) {
-  //   printf("tma_trans_bytes_A: %d\n", tma_trans_bytes_A);
-  //   printf("tma_trans_bytes_B: %d\n", tma_trans_bytes_B);
-  //   cute::print("tCrA:\t"); cute::print(tCrA); cute::print("\n");     //
-  //   tCrA:   UMMA::DescriptorIterator o (_1,_1,_4):(_0,_0,_2)
-  //   cute::print("tCrB:\t"); cute::print(tCrB); cute::print("\n");     //
-  //   tCrB:   UMMA::DescriptorIterator o (_1,_1,_4):(_0,_0,_2)
-  //   cute::print("tCtAcc:\t"); cute::print(tCtAcc); cute::print("\n"); //
-  //   tCtAcc: tmem_[32b](TMEM_ADDR) o ((_128,_256),_1,_1):((_65536,_1),_0,_0)
-  // } __syncthreads();
+  if (wid == 5) {
+    if (elect_sync()) {
+      int stage_seq = 0;
+      for (int t = 0; t < NUM_TILES; t++) {
+        int m_tile, n_tile;
+        supergroup_tile_coord(
+            t, NUM_M_TILES, NUM_N_TILES, LINEAR_MPK_GROUP_M, m_tile, n_tile);
 
-  int k_tile_count = cute::size<4>(tCgA);
-
-  using TmemAllocator = cute::TMEM::Allocator1Sm;
-  TmemAllocator tmem_allocator{};
-
-  __syncthreads(); // Wait for all threads until warp0 allocates TMEM
-
-  if (warp_idx == 5) {
-    // TMA warp (1)
-    int total_k_tile_count = 0;
-    for (int m_tile = 0; m_tile < cute::size<3>(tCgA); ++m_tile) {
-      for (int n_tile = 0; n_tile < cute::size<3>(tCgB); ++n_tile) {
-
-        int num_prev_k_blk = total_k_tile_count;
-        total_k_tile_count += k_tile_count;
-
-        int tma_wr_k_tile = 0;
-        int smem_wr_buffer = (num_prev_k_blk + tma_wr_k_tile) % NUM_AB_STAGE;
-        int tma_wr_ab_empty_phase =
-            (num_prev_k_blk + tma_wr_k_tile) / NUM_AB_STAGE % 2 ^ 1;
-
-        bool peek_ab_empty_status =
-            try_wait_barrier(shared_storage.ab_empty_mbar_ptr[smem_wr_buffer],
-                             tma_wr_ab_empty_phase);
-
-        // CUTE_UNROLL
-        for (int k_tile = 0; k_tile < k_tile_count; ++k_tile) {
-
-          int tma_wr_k_tile_next = tma_wr_k_tile + 1;
-          int smem_wr_buffer_next =
-              (num_prev_k_blk + tma_wr_k_tile_next) % NUM_AB_STAGE;
-          int tma_wr_ab_empty_phase_next = smem_wr_buffer_next == 0
-                                               ? tma_wr_ab_empty_phase ^ 1
-                                               : tma_wr_ab_empty_phase;
-
-          // Wait for an empty buffer
-          if (!peek_ab_empty_status) {
-            cute::wait_barrier(shared_storage.ab_empty_mbar_ptr[smem_wr_buffer],
-                               tma_wr_ab_empty_phase);
+        for (int k = k_begin; k < k_end; k++, stage_seq++) {
+          int stage = stage_seq % NUM_AB_STAGE;
+          if (stage_seq >= NUM_AB_STAGE) {
+            int phase = (stage_seq / NUM_AB_STAGE - 1) % 2;
+            mbar_wait(ab_empty + stage * 8, phase);
           }
 
-          if (cute::elect_one_sync()) {
-            int tma_coords_A[2] = {k_tile * TILE_SIZE,
-                                   m_tile * OUTPUT_ATOM_SIZE};
-            int tma_coords_B[2] = {k_tile * TILE_SIZE, n_tile * MMA_N};
-            input_weight_smem.set_ptr(
-                shared_weight + smem_wr_buffer * OUTPUT_ATOM_SIZE * TILE_SIZE);
-            input_smem.set_ptr(shared_input +
-                               smem_wr_buffer * MMA_N * TILE_SIZE);
-            cute::set_barrier_transaction_bytes(
-                shared_storage.ab_full_mbar_ptr[smem_wr_buffer],
-                tma_transaction_bytes);
-            // set_barrier_transaction_bytes(ab_full_mbar_ptr[smem_wr_buffer],
-            // tma_transaction_bytes);
-            tma_a.tma_cp_async(ab_full_mbar_ptr[smem_wr_buffer],
-                               input_weight_smem.base_ptr,
-                               tma_coords_A);
-            tma_b.tma_cp_async(ab_full_mbar_ptr[smem_wr_buffer],
-                               input_smem.base_ptr,
-                               tma_coords_B);
-          }
-
-          if (tma_wr_k_tile_next < k_tile_count) {
-            peek_ab_empty_status = try_wait_barrier(
-                shared_storage.ab_empty_mbar_ptr[smem_wr_buffer_next],
-                tma_wr_ab_empty_phase_next);
-          }
-
-          tma_wr_k_tile = tma_wr_k_tile_next;
-          smem_wr_buffer = smem_wr_buffer_next;
-          tma_wr_ab_empty_phase = tma_wr_ab_empty_phase_next;
-
-        } // end for k_tile
-
-      } // end for n_tile
-    }
-  } else if (warp_idx == 4) {
-    // MMA warp (1)
-
-    // Wait for TMEM allocation to complete
-    tmem_allocation_result_barrier.arrive_and_wait();
-    tCtAcc.data() = shared_storage.tmem_base_ptr;
-
-    int total_k_tile_count = 0;
-    int num_tiles_executed = 0;
-    for (int m_tile = 0; m_tile < cute::size<3>(tCgA); ++m_tile) {
-      for (int n_tile = 0; n_tile < cute::size<3>(tCgB); ++n_tile) {
-
-        int acc_buf_idx = num_tiles_executed % NUM_ACC_STAGE;
-        auto tCtAcc_Slice = tCtAcc(cute::_, cute::_, cute::_, acc_buf_idx);
-
-        int num_prev_k_blk = total_k_tile_count;
-        total_k_tile_count += k_tile_count;
-
-        int mma_rd_k_tile = 0;
-        int smem_rd_buffer = (num_prev_k_blk + mma_rd_k_tile) % NUM_AB_STAGE;
-        int mma_rd_ab_full_phase =
-            (num_prev_k_blk + mma_rd_k_tile) / NUM_AB_STAGE % 2;
-
-        // Peek full phase
-        bool peek_ab_full_status =
-            try_wait_barrier(shared_storage.ab_full_mbar_ptr[smem_rd_buffer],
-                             mma_rd_ab_full_phase);
-
-        int acc_empty_phase = num_tiles_executed / NUM_ACC_STAGE % 2 ^ 1;
-        cute::wait_barrier(shared_storage.acc_empty_mbar_ptr[acc_buf_idx],
-                           acc_empty_phase);
-
-        // Initialize the accumulator to zero
-        tiled_mma.accumulate_ = cute::UMMA::ScaleOut::Zero;
-
-        for (int k_tile = 0; k_tile < k_tile_count; ++k_tile) {
-          int mma_rd_k_tile_next = mma_rd_k_tile + 1;
-          int smem_rd_buffer_next =
-              (num_prev_k_blk + mma_rd_k_tile_next) % NUM_AB_STAGE;
-          int mma_rd_ab_full_phase_next = smem_rd_buffer_next == 0
-                                              ? mma_rd_ab_full_phase ^ 1
-                                              : mma_rd_ab_full_phase;
-
-          if (!peek_ab_full_status) {
-            cute::wait_barrier(shared_storage.ab_full_mbar_ptr[smem_rd_buffer],
-                               mma_rd_ab_full_phase);
-          }
-
-          // if (!peek_ab_full_status){
-          //   wait(ab_full_mbar_ptr[smem_rd_buffer], mma_rd_ab_full_phase);
-          // }
-
-          // Perform MMA operation
-          for (int k_block = 0; k_block < cute::size<2>(tCrA); ++k_block) {
-            cute::gemm(tiled_mma,
-                       tCrA(cute::_, cute::_, k_block, smem_rd_buffer),
-                       tCrB(cute::_, cute::_, k_block, smem_rd_buffer),
-                       tCtAcc_Slice);
-            tiled_mma.accumulate_ = cute::UMMA::ScaleOut::One;
-          }
-
-          cutlass::arch::umma_arrive(
-              &shared_storage.ab_empty_mbar_ptr[smem_rd_buffer]);
-
-          if (mma_rd_k_tile_next < k_tile_count) {
-            peek_ab_full_status = try_wait_barrier(
-                shared_storage.ab_full_mbar_ptr[smem_rd_buffer_next],
-                mma_rd_ab_full_phase_next);
-          }
-
-          mma_rd_k_tile = mma_rd_k_tile_next;
-          smem_rd_buffer = smem_rd_buffer_next;
-          mma_rd_ab_full_phase = mma_rd_ab_full_phase_next;
-
-        } // end for k_tile
-
-        cutlass::arch::umma_arrive(
-            &shared_storage.acc_full_mbar_ptr[acc_buf_idx]);
-        num_tiles_executed++;
-
-      } // end for n_tile
-    }
-  } else if (warp_idx < 4) {
-    // Epilogue warps (4)
-
-    // Allocate TMEM for accumulators
-    if (warp_idx == 0) {
-      tmem_allocator.allocate(num_tmem_columns, &shared_storage.tmem_base_ptr);
-    }
-    tmem_allocation_result_barrier.arrive_and_wait();
-    tCtAcc.data() = shared_storage.tmem_base_ptr;
-
-    using AccType = typename decltype(tCtAcc)::value_type;
-    using TypeBias = T_;
-    using TypeC = T_;
-
-    cutlass::NumericConverter<AccType, TypeBias> converterBias;
-    cutlass::NumericConverter<TypeC, AccType> converter;
-
-    cute::TiledCopy tiled_copy_t2r =
-        cute::make_tmem_copy(cute::SM100_TMEM_LOAD_32dp32b1x{},
-                             tCtAcc(cute::_, cute::_, cute::_, 0)); // (128,32)
-    cute::ThrCopy thr_copy_t2r = tiled_copy_t2r.get_slice(threadIdx.x);
-    cute::Tensor tTR_tAcc = thr_copy_t2r.partition_S(
-        tCtAcc); // tmem_[32b](0x0000.0000) o
-                 // ((_32,_1),_32,_1,_1,_2):((_65536,_0),_1,_0,_0,_32)
-
-    cute::Tensor tCgC_fake = cute::make_tensor<TypeC>(cute::shape(
-        tCtAcc(cute::_, cute::_, cute::_, 0))); // (T2R, T2R_M, T2R_N)
-    cute::Tensor tTR_rAcc_fake = thr_copy_t2r.partition_D(tCgC_fake);
-    cute::Tensor tTR_rAcc = cute::make_tensor<AccType>(
-        cute::shape(tTR_rAcc_fake)); // ptr[32b](some_ptr) o
-                                     // ((_1,_1),_32,_1,_1):((_0,_0),_1,_0,_0)
-
-    // if(threadIdx.x == 0) {
-    //   cute::print("tiled_copy_t2r:\t"); cute::print(tiled_copy_t2r);
-    //   cute::print("\n"); // cute::print("thr_copy_t2r:\t");
-    //   cute::print(thr_copy_t2r); cute::print("\n"); //
-    //   cute::print("tTR_tAcc:\t"); cute::print(tTR_tAcc); cute::print("\n");
-    //   // cute::print("tTR_rAcc:\t"); cute::print(tTR_rAcc);
-    //   cute::print("\n"); // cute::print("tCtAcc:\t"); cute::print(tCtAcc);
-    //   cute::print("\n"); // printf("tmem_base_ptr: %u\n",
-    //   shared_storage.tmem_base_ptr);
-    // } epilogue_wg_barrier.arrive_and_wait();
-
-    int num_tiles_executed = 0;
-    for (int m_tile = 0; m_tile < cute::size<3>(tCgA); ++m_tile) {
-      for (int n_tile = 0; n_tile < cute::size<3>(tCgB); ++n_tile) {
-        int acc_buf_idx = num_tiles_executed % NUM_ACC_STAGE;
-        int acc_full_phase = num_tiles_executed / NUM_ACC_STAGE % 2;
-        int c_smem_wr_buffer_idx = num_tiles_executed % NUM_C_STAGE;
-
-        cute::Tensor tCgBias =
-            gBias(cute::_, cute::_, n_tile, m_tile); // (Mma_M, Mma_N)
-        cute::Tensor tCrBiasTypeBias = cute::make_tensor<TypeBias>(
-            cute::shape(tTR_rAcc(0, cute::_, 0, 0))); // (T2R_M, T2R_N)
-        cute::Tensor tCrBiasTypeAcc =
-            cute::make_tensor<AccType>(cute::shape(tCrBiasTypeBias));
-        cute::Tensor tCrC =
-            cute::make_tensor<TypeC>(cute::shape(tCrBiasTypeBias));
-
-        // if(threadIdx.x == 0 and m_tile == 0 and n_tile == 0) {
-        //   cute::print("tCgBias:\t"); cute::print(tCgBias); cute::print("\n");
-        //   // cute::print("tCrBiasTypeBias:\t"); cute::print(tCrBiasTypeBias);
-        //   cute::print("\n"); // cute::print("tCrBiasTypeAcc:\t");
-        //   cute::print(tCrBiasTypeAcc); cute::print("\n"); //
-        //   cute::print("tCrC:\t"); cute::print(tCrC); cute::print("\n"); //
-        // } epilogue_wg_barrier.arrive_and_wait();
-
-        // T2R and register operations
-        if constexpr (!NOBIAS) {
-          cute::Tensor tCgBiasCoord =
-              gBiasCoord(cute::_, cute::_, n_tile, m_tile);
-          cute::Tensor tCgBiasPred =
-              cute::lazy::transform(tCgBiasCoord, [&](auto const &coord) {
-                return cute::elem_less(
-                    coord,
-                    cute::make_shape(cute::Int<BATCH_SIZE>{},
-                                     cute::Int<OUTPUT_SIZE>{}));
-              });
-          CUTE_UNROLL
-          for (int i = 0; i < tCrBiasTypeBias.size(); i++) {
-            tCrBiasTypeBias[i] = TypeBias(0);
-          }
-          // Epilogue has 128 threads but bias may have fewer than 128 columns
-          // (OUTPUT_SIZE), and the MMA_N tile may have more rows than the
-          // runtime batch capacity. Guard both dimensions before reading the
-          // residual tensor.
-          if (threadIdx.x < OUTPUT_SIZE) {
-            cute::copy_if(tCgBiasPred(cute::_, threadIdx.x),
-                          tCgBias(cute::_, threadIdx.x),
-                          tCrBiasTypeBias);
-          }
-          // optimize with vectorized type conversion
-
-          CUTE_UNROLL
-          for (int i = 0; i < tCrBiasTypeBias.size(); i++) {
-            tCrBiasTypeAcc[i] = converterBias(tCrBiasTypeBias[i]);
-          }
+          int ab_mbar = ab_full + stage * 8;
+          mbar_tx(ab_mbar, TMA_BYTES);
+          int a_dst = A_smem + stage * A_TILE_ELEMS * (int)sizeof(T_);
+          int b_dst = B_smem + stage * B_TILE_ELEMS * (int)sizeof(T_);
+          tma_load_2d_cta(
+              a_dst, tma_a.desc_ptr, k * BK, m_tile * MMA_M, ab_mbar);
+          tma_load_2d_cta(
+              b_dst, tma_b.desc_ptr, k * BK, n_tile * MMA_N, ab_mbar);
         }
-
-        mm_output_smem.set_ptr(mm_output +
-                               c_smem_wr_buffer_idx * MMA_N * OUTPUT_ATOM_SIZE);
-
-        cute::wait_barrier(shared_storage.acc_full_mbar_ptr[acc_buf_idx],
-                           acc_full_phase);
-        // T2R copy
-        cute::copy(tiled_copy_t2r,
-                   tTR_tAcc(cute::_, cute::_, cute::_, cute::_, acc_buf_idx),
-                   tTR_rAcc);
-
-        // arrive acc empty buffer
-        epilogue_wg_barrier.arrive_and_wait();
-        if (cute::elect_one_sync()) {
-          cute::arrive_barrier(shared_storage.acc_empty_mbar_ptr[acc_buf_idx]);
-        }
-
-        if constexpr (!NOBIAS) {
-          CUTE_UNROLL
-          for (int i = 0; i < tTR_rAcc.size(); i++) {
-            tTR_rAcc[i] += tCrBiasTypeAcc[i];
-          }
-        }
-
-        CUTE_UNROLL
-        for (int i = 0; i < tCrC.size(); i++) {
-          tCrC[i] = converter(tTR_rAcc[i]);
-        }
-
-        // R2S copy
-        cute::Tensor sC_epi_slice =
-            cute::flatten(sC_epi(cute::_, 0, 0, c_smem_wr_buffer_idx));
-        cute::copy(tCrC, sC_epi_slice(cute::_, threadIdx.x));
-
-        // S2G TMA
-        cute::tma_store_fence(); // Ensure C smem stores are visible to TMA
-        epilogue_wg_barrier
-            .arrive_and_wait(); // Ensure all threads have issued fence
-
-        if (warp_idx == 0 && cute::elect_one_sync()) {
-          if constexpr (SplitK) {
-            tma_out.tma_reduce_add_async(
-                mm_output_smem.base_ptr,
-                {m_tile * OUTPUT_ATOM_SIZE, n_tile * MMA_N});
-          } else {
-            tma_out.tma_store_async(
-                mm_output_smem.base_ptr,
-                {m_tile * OUTPUT_ATOM_SIZE, n_tile * MMA_N});
-          }
-
-          cute::tma_store_arrive();
-          cute::tma_store_wait<NUM_C_STAGE - 1>();
-        }
-
-        num_tiles_executed++;
       }
     }
-    // wait all TMA stores to complete
-    if (warp_idx == 0 && cute::elect_one_sync()) {
-      cute::tma_store_wait<0>();
+  } else if (wid == 4) {
+    if (elect_sync()) {
+      int stage_seq = 0;
+      int local_iter = 0;
+      for (int t = 0; t < NUM_TILES; t++, local_iter++) {
+        int acc_idx = local_iter % NUM_ACC_STAGE;
+        int acc_taddr = taddr + acc_idx * MMA_N;
+        if (local_iter >= NUM_ACC_STAGE) {
+          int acc_empty_phase = (local_iter / NUM_ACC_STAGE - 1) % 2;
+          mbar_wait(acc_empty + acc_idx * 8, acc_empty_phase);
+        }
+        for (int k = k_begin; k < k_end; k++, stage_seq++) {
+          int stage = stage_seq % NUM_AB_STAGE;
+          int phase = (stage_seq / NUM_AB_STAGE) % 2;
+          mbar_wait(ab_full + stage * 8, phase);
+          tcgen05_fence_after();
+
+          int a_base = A_smem + stage * A_TILE_ELEMS * (int)sizeof(T_);
+          int b_base = B_smem + stage * B_TILE_ELEMS * (int)sizeof(T_);
+          for (int ks = 0; ks < K_SUB; ks++) {
+            uint64_t a_desc = make_desc(a_base + ks * 32);
+            uint64_t b_desc = make_desc(b_base + ks * 32);
+            int acc = (k == k_begin && ks == 0) ? 0 : 1;
+            tcgen05_mma(acc_taddr, a_desc, b_desc, idesc, acc);
+          }
+          tcgen05_commit(ab_empty + stage * 8);
+        }
+        tcgen05_commit(acc_full + acc_idx * 8);
+      }
+    }
+  } else if (wid < 4) {
+    int local_iter = 0;
+    for (int t = 0; t < NUM_TILES; t++, local_iter++) {
+      int m_tile, n_tile;
+      supergroup_tile_coord(
+          t, NUM_M_TILES, NUM_N_TILES, LINEAR_MPK_GROUP_M, m_tile, n_tile);
+
+      int acc_idx = local_iter % NUM_ACC_STAGE;
+      int acc_full_phase = (local_iter / NUM_ACC_STAGE) % 2;
+      int c_stage = local_iter % NUM_C_STAGE;
+      int acc_taddr = taddr + acc_idx * MMA_N;
+      mbar_wait(acc_full + acc_idx * 8, acc_full_phase);
+      tcgen05_fence_after();
+
+      float acc[MMA_N];
+      int ld_addr = acc_taddr + (tid << 16);
+      tcgen05_ld_cols<MMA_N>(ld_addr, acc);
+      tcgen05_ld_wait();
+
+      named_barrier_sync(1, 128);
+      if (wid == 0 && elect_sync()) {
+        mbar_arrive(acc_empty + acc_idx * 8);
+      }
+
+      int out_col = m_tile * MMA_M + tid;
+      if constexpr (!NOBIAS) {
+        if (out_col < OUTPUT_SIZE) {
+#pragma unroll
+          for (int j = 0; j < MMA_N; j++) {
+            int batch_row = n_tile * MMA_N + j;
+            if (batch_row < BATCH_SIZE) {
+              uint16_t bits = *reinterpret_cast<uint16_t const *>(
+                  &mBias[batch_row * output_stride + out_col]);
+              acc[j] += __bfloat162float(
+                  *reinterpret_cast<__nv_bfloat16 const *>(&bits));
+            }
+          }
+        }
+      }
+
+      int c_base = __cvta_generic_to_shared(&ss.C[c_stage * C_TILE_ELEMS]);
+#pragma unroll
+      for (int j = 0; j < MMA_N; j++) {
+        nv_bfloat16 v = __float2bfloat16(acc[j]);
+        int off = (j * MMA_M + tid) * (int)sizeof(T_);
+        asm volatile("st.shared.b16 [%0], %1;" ::"r"(c_base + off),
+                     "h"(*reinterpret_cast<uint16_t *>(&v)));
+      }
+
+      kernel::tma::async_proxy_fence();
+      named_barrier_sync(1, 128);
+
+      if (wid == 0 && elect_sync()) {
+        int coords[2] = {m_tile * MMA_M, n_tile * MMA_N};
+        if (use_reduce_add) {
+          tma_out.tma_reduce_add_async(&ss.C[c_stage * C_TILE_ELEMS], coords);
+        } else {
+          tma_out.tma_store_async(&ss.C[c_stage * C_TILE_ELEMS], coords);
+        }
+        kernel::tma::store_commit_group();
+        kernel::tma::store_async_wait<NUM_C_STAGE - 1>();
+      }
+    }
+    if (wid == 0 && elect_sync()) {
+      kernel::tma::store_async_wait<0>();
     }
   }
+
   __syncthreads();
-
-  // Release the right to allocate before deallocations so that the next CTA can
-  // rasterize Then deallocate TMEM
-  if (warp_idx == 0) {
-    // don't do relinquish for megakernel
-    // tmem_allocator.release_allocation_lock();
-    tmem_allocator.free(shared_storage.tmem_base_ptr, num_tmem_columns);
+  if (wid == 1) {
+    tcgen05_dealloc(0, num_tmem_columns);
   }
-
-} // end linear_sm100_mpk_task_impl
+}
 
 } // namespace kernel

--- a/include/mirage/persistent_kernel/tasks/blackwell/linear_sm100_mpk_cutlass.cuh
+++ b/include/mirage/persistent_kernel/tasks/blackwell/linear_sm100_mpk_cutlass.cuh
@@ -1,0 +1,752 @@
+/* Copyright 2025 CMU
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <cstdio>
+#include <iostream>
+
+// Cutlass includes
+#include <cutlass/half.h> // F16 data type
+// #include <cutlass/util/print_error.hpp>
+#include <cutlass/arch/barrier.h>
+#include <cutlass/cluster_launch.hpp>
+#include <cutlass/cutlass.h>
+#include <cutlass/numeric_conversion.h>
+#include <cutlass/numeric_types.h>
+
+// CuTe includes
+#include <cute/algorithm/cooperative_copy.hpp> // Auto vectorized copy operation
+#include <cute/arch/cluster_sm90.hpp> // CuTe functions for querying the details of cluster launched
+#include <cute/arch/tmem_allocator_sm100.hpp> // TMEM allocator for SM100
+#include <cute/numeric/integral_constant.hpp> // Compile time in constants such as _1, _256 etc.
+#include <cute/tensor.hpp>                    // CuTe tensor implementation
+// using namespace cute;
+
+#include "../common/dmem_layout.cuh"
+#include "../common/worker_config.h"
+#include "../hopper/barrier.cuh"
+#include "../hopper/smem_layout_tma.cuh"
+#include "../hopper/tma.cuh"
+#include "storage.cuh"
+
+namespace kernel {
+
+template <typename T_,
+          typename TMA_A,
+          typename TMA_B,
+          class BiasTensor,
+          typename TMA_OUT,
+          int MMA_M,
+          int MMA_N,
+          int BATCH_SIZE,
+          int OUTPUT_SIZE,
+          int REDUCTION_SIZE,
+          bool NOBIAS,
+          bool SplitK,
+          int NUM_AB_STAGE = 8,
+          int NUM_ACC_STAGE = 2,
+          int NUM_C_STAGE = 4>
+__device__ __noinline__ void
+    linear_sm100_mpk_task_impl(const TMA_A &tma_a,
+                               const TMA_B &tma_b,
+                               BiasTensor mBias,
+                               const TMA_OUT &tma_out) {
+  int warp_idx = cutlass::canonical_warp_idx_sync();
+
+  // Construct the MMA grid coordinate from the CTA grid coordinate
+  auto mma_coord_vmnk = cute::make_coord(0,        // Peer CTA coordinate
+                                         cute::_,  //    MMA-M coordinate
+                                         cute::_,  //    MMA-N coordinate
+                                         cute::_); //    MMA-K coordinate
+
+  constexpr int num_tmem_columns = MMA_N * NUM_ACC_STAGE;
+
+  cute::TiledMMA tiled_mma = cute::make_tiled_mma(
+      cute::SM100_MMA_F16BF16_SS<T_,
+                                 T_,
+                                 float, // Mma's A, B, and Accumulator types
+                                 MMA_M,
+                                 MMA_N, // Mma M and N dimensions
+                                 cute::UMMA::Major::K,
+                                 cute::UMMA::Major::K>{}); // A and B layouts
+  auto bM = cute::tile_size<0>(
+      tiled_mma); // MMA Tile M. We'll use 1 MMAs per MMA Tile M.
+  auto bN = cute::tile_size<1>(
+      tiled_mma); // MMA Tile N. We'll use 1 MMAs per MMA Tile N.
+  auto bK = cute::tile_size<2>(tiled_mma) *
+            cute::Int<4>{}; // MMA Tile K. We'll use 4 MMAs per MMA Tile K. For
+                            // 16b types, tcgen05.mma has K16.
+
+  auto mma_tiler = cute::make_shape(bM, bN, bK); // (MMA_M, MMA_N, MMA_K)
+
+  // Partition the GMEM tensors with the mma_tiler and mma_coord to get the
+  // slices processed
+  //   by this mma tile.
+  // CuTe provides local_tile partitioning function. local_tile accepts 4
+  // parameters:
+  //   * Tensor to partition
+  //   * Tiler to use for partitioning
+  //   * Coordinate to use for slicing the partitioned tensor
+  //   * Projection to ignore unwanted modes of the Tiler and Coordinate
+  auto mma_coord = cute::select<1, 2, 3>(mma_coord_vmnk);
+  auto cd_tiler =
+      cute::make_shape(bN, bM, bK); // (MmaTile_N, MmaTile_M, MmaTile_K)
+
+  cute::Tensor mA = cute::make_coord_tensor(cute::make_layout(
+      cute::make_shape(OUTPUT_SIZE, REDUCTION_SIZE),
+      cute::make_stride(
+          cute::E<1>{},
+          cute::E<0>{}))); // ArithTuple(_0,_0) o
+                           // (output_size,reduction_size):(_1@1,_1@0)
+  cute::Tensor mB = cute::make_coord_tensor(cute::make_layout(
+      cute::make_shape(BATCH_SIZE, REDUCTION_SIZE),
+      cute::make_stride(
+          cute::E<1>{},
+          cute::E<0>{}))); // ArithTuple(_0,_0) o
+                           // (batch_size,reduction_size):(_1@1,_1@0)
+  cute::Tensor mC = cute::make_coord_tensor(cute::make_layout(
+      cute::make_shape(BATCH_SIZE, OUTPUT_SIZE),
+      cute::make_stride(cute::E<1>{},
+                        cute::E<0>{}))); // ArithTuple(_0,_0) o
+                                         // (batch_size,output_size):(_1@1,_1@0)
+  cute::Tensor mBiasCoord = cute::make_identity_tensor(
+      cute::make_shape(cute::Int<BATCH_SIZE>{}, cute::Int<OUTPUT_SIZE>{}));
+
+  cute::Tensor gA = cute::local_tile(
+      mA,
+      mma_tiler,
+      mma_coord,
+      cute::Step<cute::_1,
+                 cute::X,
+                 cute::_1>{}); // ArithTuple(_0,_0) o
+                               // (_128,_64,8,64):(_1@1,_1@0,_128@1,_64@0)
+  cute::Tensor gB = cute::local_tile(
+      mB,
+      mma_tiler,
+      mma_coord,
+      cute::Step<cute::X,
+                 cute::_1,
+                 cute::_1>{}); // ArithTuple(_0,_0) o
+                               // (_32,_64,1,64):(_1@1,_1@0,_32@1,_64@0)
+  cute::Tensor gBias = cute::local_tile(
+      mBias,
+      cd_tiler,
+      mma_coord,
+      cute::Step<cute::_1,
+                 cute::_1,
+                 cute::X>{}); // gmem_ptr[16b](0x7704bd040000) o
+                              // (_32,_128,1,8):(1024,_1,32768,_128)
+  cute::Tensor gBiasCoord =
+      cute::local_tile(mBiasCoord,
+                       cd_tiler,
+                       mma_coord,
+                       cute::Step<cute::_1, cute::_1, cute::X>{});
+  cute::Tensor gC = cute::local_tile(
+      mC,
+      cd_tiler,
+      mma_coord,
+      cute::Step<cute::_1,
+                 cute::_1,
+                 cute::X>{}); // ArithTuple(_0,_0) o
+                              // (_32,_128,1,8):(_1@1,_1@0,_32@1,_128@0)
+
+  // if (cute::thread0()) {
+  //   cute::print("mA:\t"); cute::print(mA); cute::print("\n");       // mA:
+  //   ArithTuple(_0,_0) o (output_size,reduction_size):(_1@1,_1@0)
+  //   cute::print("mB:\t"); cute::print(mB); cute::print("\n");       // mB:
+  //   ArithTuple(_0,_0) o (batch_size,reduction_size):(_1@1,_1@0)
+  //   cute::print("mBias:\t"); cute::print(mBias); cute::print("\n");   //
+  //   mBias:   gmem_ptr[32b](GMEM_ADDR_C) o (batch_size,output_size):(1024,_1)
+  //   cute::print("mC:\t"); cute::print(mC); cute::print("\n");       // mC:
+  //   ArithTuple(_0,_0) o (batch_size,output_size):(_1@1,_1@0)
+  //   cute::print("gA:\t"); cute::print(gA); cute::print("\n");
+  //   cute::print("gB:\t"); cute::print(gB); cute::print("\n");
+  //   cute::print("gBias:\t"); cute::print(gBias); cute::print("\n");
+  //   cute::print("gC:\t"); cute::print(gC); cute::print("\n");
+  //   printf("num_ab_stage, num_acc_stage, num_c_stage, : %d, %d, %d\n",
+  //   NUM_AB_STAGE, NUM_ACC_STAGE, NUM_C_STAGE); printf("NOBIAS: %d\n",
+  //   NOBIAS);
+  // } __syncthreads();
+
+  // Pre-partitioned Tile Shape (MmaTile_M, MmaTile_K) to post-partitioned
+  // (MmaA, NumMma_M, NumMma_K)
+  auto mma_shape_A =
+      cute::partition_shape_A(tiled_mma,
+                              cute::make_shape(cute::Int<MMA_M>{},
+                                               cute::size<2>(mma_tiler),
+                                               cute::Int<NUM_AB_STAGE>{}));
+  // Pre-partitioned Tile Shape (MmaTile_N, MmaTile_K) to post-partitioned
+  // (MmaB, NumMma_N, NumMma_K)
+  auto mma_shape_B =
+      cute::partition_shape_B(tiled_mma,
+                              cute::make_shape(cute::Int<MMA_N>{},
+                                               cute::size<2>(mma_tiler),
+                                               cute::Int<NUM_AB_STAGE>{}));
+  // Pre-partitioned Tile Shape (MmaTile_N, MmaTile_M) to post-partitioned
+  // (MmaC, NumMma_N, NumMma_K)
+  auto mma_shape_C =
+      cute::make_shape(cute::make_shape(cute::Int<MMA_N>{}, cute::Int<MMA_M>{}),
+                       cute::Int<1>{},
+                       cute::Int<1>{},
+                       cute::Int<NUM_C_STAGE>{});
+
+  // Print and inspect mma_shape_A, and mma_shape_B for this example.
+  // if (cute::thread0()) {
+  //     cute::print("mma_shape_A:\t"); cute::print(mma_shape_A);
+  //     cute::print("\n");  // mma_shape_A:  ((_128,_16),_1,_4,_8)
+  //     cute::print("mma_shape_B:\t"); cute::print(mma_shape_B);
+  //     cute::print("\n");  // mma_shape_B:  ((_32,_16),_1,_4,_8)
+  //     cute::print("mma_shape_C:\t"); cute::print(mma_shape_C);
+  //     cute::print("\n");  // mma_shape_C:  ((_32,_128),_1,_1,_4)
+  // } __syncthreads();
+
+  auto sA_layout = cute::UMMA::tile_to_mma_shape(
+      cute::UMMA::Layout_K_SW128_Atom<T_>{}, mma_shape_A);
+  auto sB_layout = cute::UMMA::tile_to_mma_shape(
+      cute::UMMA::Layout_K_SW128_Atom<T_>{}, mma_shape_B);
+  // constuct unswizzled layout for C
+  auto sC_layout_fake = cute::UMMA::tile_to_mma_shape(
+      cute::UMMA::Layout_K_INTER_Atom<T_>{}, mma_shape_C);
+  auto sC_shape = cute::make_shape(
+      cute::make_shape(cute::Int<MMA_N>{}, cute::Int<MMA_M>{}),
+      cute::Int<1>{},
+      cute::Int<1>{},
+      cute::make_shape(cute::Int<1>{}, cute::Int<NUM_C_STAGE>{}));
+  auto sC_stride = cute::make_stride(
+      cute::make_stride(cute::Int<MMA_M>{}, cute::Int<1>{}),
+      cute::Int<0>{},
+      cute::Int<0>{},
+      cute::make_stride(cute::Int<0>{}, cute::Int<MMA_M * MMA_N>{}));
+  auto sC_layout = cute::composition(sC_layout_fake.layout_a(),
+                                     sC_layout_fake.offset(),
+                                     cute::make_layout(sC_shape, sC_stride));
+
+  // if (cute::thread0()){
+  //     cute::print("sA_layout:\t"); cute::print(sA_layout); cute::print("\n");
+  //     // sA_layout:   ArithTuple(_0,0) o
+  //     ((_128,_16),_1,_4,8):((_1@1,_1@0),_0,_16@0,_8@0)
+  //     cute::print("sB_layout:\t"); cute::print(sB_layout); cute::print("\n");
+  //     // sB_layout:   ArithTuple(_0,0) o
+  //     ((_32,_16),_1,_4,8):((_1@1,_1@0),_0,_16@0,_8@0)
+  //     cute::print("sC_layout:\t"); cute::print(sC_layout); cute::print("\n");
+  //     // sC_layout:   ArithTuple(_0,0) o
+  //     ((_32,_128),_1,_1,4):((_1@1,_1@0),_0,_128@0,_4@0)
+  // } __syncthreads();
+
+  using SharedStorage = PipedSharedStorage<T_,
+                                           T_,
+                                           T_,
+                                           decltype(sA_layout),
+                                           decltype(sB_layout),
+                                           decltype(sC_layout),
+                                           NUM_AB_STAGE,
+                                           NUM_ACC_STAGE>;
+
+  extern __shared__ char shared_memory[];
+  uintptr_t aligned_smem =
+      (reinterpret_cast<uintptr_t>(shared_memory) + 127) / 128 * 128;
+  SharedStorage &shared_storage =
+      *reinterpret_cast<SharedStorage *>(aligned_smem);
+
+  // Initialize the barriers in shared memory
+  if (warp_idx == 0) {
+    cutlass::arch::detail::initialize_barrier_array_aligned<
+        cutlass::arch::ClusterTransactionBarrier,
+        NUM_AB_STAGE>(shared_storage.ab_full_mbar_ptr, /* arrival count */ 1);
+    cutlass::arch::detail::initialize_barrier_array_aligned<
+        cutlass::arch::ClusterBarrier,
+        NUM_AB_STAGE>(shared_storage.ab_empty_mbar_ptr, /* arrival count */ 1);
+    cutlass::arch::detail::initialize_barrier_array_aligned<
+        cutlass::arch::ClusterBarrier,
+        NUM_ACC_STAGE>(shared_storage.acc_full_mbar_ptr, /* arrival count */ 1);
+    cutlass::arch::detail::initialize_barrier_array_aligned<
+        cutlass::arch::ClusterBarrier,
+        NUM_ACC_STAGE>(shared_storage.acc_empty_mbar_ptr,
+                       /* arrival count */ 4);
+  }
+
+  // Sync tmem allocation status between MMA and epilogue warps within CTA
+  // 32 threads (mma) + 128 threads (epilog) to sync
+  cutlass::arch::NamedBarrier tmem_allocation_result_barrier(
+      32 + 128, cutlass::arch::ReservedNamedBarriers::TmemAllocBarrier);
+  cutlass::arch::NamedBarrier epilogue_wg_barrier(
+      128, /*bar-id*/ cutlass::arch::ReservedNamedBarriers::EpilogueBarrier);
+
+  // Represent the SMEM buffers for A and B
+  cute::Tensor tCsA =
+      shared_storage.tensor_sA(); // (MmaA, NumMma_M, NumMma_K, Tiles_K)
+  cute::Tensor tCsB =
+      shared_storage.tensor_sB(); // (MmaB, NumMma_M, NumMma_K, Tiles_K)
+  cute::Tensor sC_epi = shared_storage.tensor_sC(); // (EpiTile)
+
+  //
+  // Mma partitioning for A and B
+  //
+
+  auto mma_v = cute::get<0>(mma_coord_vmnk);
+  cute::ThrMMA cta_mma = tiled_mma.get_slice(mma_v); // Use Peer CTA coordinate
+  cute::Tensor tCgA =
+      cta_mma.partition_A(gA); // (MmaA, NumMma_M, NumMma_K, Tiles_K)
+  cute::Tensor tCgB =
+      cta_mma.partition_B(gB); // (MmaB, NumMma_N, NumMma_K, Tiles_K)
+
+  // if (cute::thread0()) {
+  //   cute::print("tCgA:\t"); cute::print(tCgA); cute::print("\n");  // tCgA:
+  //   ArithTuple(_0,0) o ((_128,_16),_1,_4,64):((_1@1,_1@0),_0,_16@0,_64@0)
+  //   cute::print("tCgB:\t"); cute::print(tCgB); cute::print("\n");  // tCgB:
+  //   ArithTuple(_0,0) o ((_32,_16),_1,_4,64):((_1@1,_1@0),_0,_16@0,_64@0)
+  //   cute::print("tCgC_epi:\t"); cute::print(tCgC_epi); cute::print("\n");  //
+  //   tCgC:   ArithTuple(_0,_0) o
+  //   ((_32,_128),_1,_1,1,8):((_1@1,_1@0),_0,_0,_32@1,_128@0)
+  //   cute::print("tCsA:\t"); cute::print(tCsA); cute::print("\n");
+  //   cute::print("tCsB:\t"); cute::print(tCsB); cute::print("\n");
+  //   cute::print("sC_epi:\t"); cute::print(sC_epi); cute::print("\n");
+  // } __syncthreads();
+
+  // TMA bytes must match actual clamped box dims.
+  // When BATCH_SIZE < MMA_N, TMA input box is clamped to min(MMA_N,
+  // BATCH_SIZE). size<1>(mma_tiler)=bN corresponds to the input (B) TMA
+  // dimension. size<0>(mma_tiler)=bM corresponds to the weight (A) TMA
+  // dimension.
+  constexpr int kClampedBN = (BATCH_SIZE < MMA_N) ? BATCH_SIZE : MMA_N;
+  int tma_transaction_bytes =
+      sizeof(T_) * kClampedBN * cute::size<2>(mma_tiler) +
+      sizeof(T_) * cute::size<0>(mma_tiler) * cute::size<2>(mma_tiler);
+
+  constexpr int TILE_SIZE = 64;
+  constexpr int INPUT_TMA_TILE_SIZE = 64;
+  constexpr int WEIGHT_TMA_TILE_SIZE = 64;
+  constexpr int OUTPUT_ATOM_SIZE = 128;
+  constexpr int B = 3;
+  constexpr int M = 3;
+  constexpr int S = 3;
+
+  T_ *shared_weight = shared_storage.A.begin();
+  T_ *shared_input = shared_storage.B.begin();
+  T_ *mm_output = shared_storage.C.begin();
+
+  Barrier *ab_full_mbar_ptr =
+      reinterpret_cast<Barrier *>(shared_storage.ab_full_mbar_ptr);
+
+  using InputSmem = smem_tma<T_,
+                             B,
+                             M,
+                             S,
+                             MMA_N,
+                             INPUT_TMA_TILE_SIZE,
+                             1>; // 64/64 = 1
+  InputSmem input_smem(shared_input);
+
+  using WeightSmem = smem_tma<T_,
+                              B,
+                              M,
+                              S,
+                              OUTPUT_ATOM_SIZE,
+                              WEIGHT_TMA_TILE_SIZE,
+                              1>; // 64/64 = 1
+  WeightSmem input_weight_smem(shared_weight);
+
+  using OutputSmem = smem_tma<T_, 0, M, S, MMA_N, OUTPUT_ATOM_SIZE, 1>;
+  OutputSmem mm_output_smem(mm_output);
+
+  // // check tma descriptor:
+  // if(threadIdx.x == 0){
+  //     printf("smem start addr: %u\n",
+  //     cute::cast_smem_ptr_to_uint(shared_memory)); printf("shared_weight:
+  //     %u\n", cute::cast_smem_ptr_to_uint(shared_weight));
+  //     printf("shared_input: %u\n",
+  //     cute::cast_smem_ptr_to_uint(shared_input)); printf("mm_output: %u\n",
+  //     cute::cast_smem_ptr_to_uint(mm_output));
+  // } __syncthreads();
+
+  // // Fence acquire tensor map:
+  // ptx::n32_t<128> size_bytes;
+  // // Since the tensor map was modified from the host using cudaMemcpy,
+  // // the scope should be .sys.
+  // ptx::fence_proxy_tensormap_generic(
+  //   ptx::sem_acquire, ptx::scope_sys, tma_a.desc_ptr, size_bytes
+  // );
+  // ptx::fence_proxy_tensormap_generic(
+  //   ptx::sem_acquire, ptx::scope_sys, tma_b.desc_ptr, size_bytes
+  // );
+  // ptx::fence_proxy_tensormap_generic(
+  //   ptx::sem_acquire, ptx::scope_sys, tma_out.desc_ptr, size_bytes
+  // );
+
+  // MMA Fragment Allocation
+  // We allocate "fragments" which are SMEM descriptors that serve as inputs to
+  // cute::gemm operations. For tcgen05.mma operations:
+  // - Matrices A and B are sourced from SMEM
+  // - tCrA and tCrB provide descriptor views of tCsA and tCsB respectively
+  // - The first mode of each descriptor represents the SMEM for a single MMA
+  // operation
+  cute::Tensor tCrA =
+      cta_mma.make_fragment_A(tCsA); // (MmaA, NumMma_M, NumMma_K, Tiles_K)
+  cute::Tensor tCrB =
+      cta_mma.make_fragment_B(tCsB); // (MmaB, NumMma_M, NumMma_K, Tiles_K)
+  auto acc_shape = cute::partition_shape_C(
+      tiled_mma,
+      cute::make_shape(cute::size<0>(mma_tiler),
+                       cute::size<1>(mma_tiler),
+                       cute::Int<NUM_ACC_STAGE>{})); // (MmaC, NumMma_M,
+                                                     // NumMma_N, NumAcc_Stage)
+  // (MMA, MMA_M, MMA_N, STAGE)
+  auto tCtAcc = tiled_mma.make_fragment_C(acc_shape);
+
+  cutlass::arch::fence_barrier_init();
+  __syncthreads();
+
+  // if (cute::thread0()) {
+  //   printf("tma_trans_bytes_A: %d\n", tma_trans_bytes_A);
+  //   printf("tma_trans_bytes_B: %d\n", tma_trans_bytes_B);
+  //   cute::print("tCrA:\t"); cute::print(tCrA); cute::print("\n");     //
+  //   tCrA:   UMMA::DescriptorIterator o (_1,_1,_4):(_0,_0,_2)
+  //   cute::print("tCrB:\t"); cute::print(tCrB); cute::print("\n");     //
+  //   tCrB:   UMMA::DescriptorIterator o (_1,_1,_4):(_0,_0,_2)
+  //   cute::print("tCtAcc:\t"); cute::print(tCtAcc); cute::print("\n"); //
+  //   tCtAcc: tmem_[32b](TMEM_ADDR) o ((_128,_256),_1,_1):((_65536,_1),_0,_0)
+  // } __syncthreads();
+
+  int k_tile_count = cute::size<4>(tCgA);
+
+  using TmemAllocator = cute::TMEM::Allocator1Sm;
+  TmemAllocator tmem_allocator{};
+
+  __syncthreads(); // Wait for all threads until warp0 allocates TMEM
+
+  if (warp_idx == 5) {
+    // TMA warp (1)
+    int total_k_tile_count = 0;
+    for (int m_tile = 0; m_tile < cute::size<3>(tCgA); ++m_tile) {
+      for (int n_tile = 0; n_tile < cute::size<3>(tCgB); ++n_tile) {
+
+        int num_prev_k_blk = total_k_tile_count;
+        total_k_tile_count += k_tile_count;
+
+        int tma_wr_k_tile = 0;
+        int smem_wr_buffer = (num_prev_k_blk + tma_wr_k_tile) % NUM_AB_STAGE;
+        int tma_wr_ab_empty_phase =
+            (num_prev_k_blk + tma_wr_k_tile) / NUM_AB_STAGE % 2 ^ 1;
+
+        bool peek_ab_empty_status =
+            try_wait_barrier(shared_storage.ab_empty_mbar_ptr[smem_wr_buffer],
+                             tma_wr_ab_empty_phase);
+
+        // CUTE_UNROLL
+        for (int k_tile = 0; k_tile < k_tile_count; ++k_tile) {
+
+          int tma_wr_k_tile_next = tma_wr_k_tile + 1;
+          int smem_wr_buffer_next =
+              (num_prev_k_blk + tma_wr_k_tile_next) % NUM_AB_STAGE;
+          int tma_wr_ab_empty_phase_next = smem_wr_buffer_next == 0
+                                               ? tma_wr_ab_empty_phase ^ 1
+                                               : tma_wr_ab_empty_phase;
+
+          // Wait for an empty buffer
+          if (!peek_ab_empty_status) {
+            cute::wait_barrier(shared_storage.ab_empty_mbar_ptr[smem_wr_buffer],
+                               tma_wr_ab_empty_phase);
+          }
+
+          if (cute::elect_one_sync()) {
+            int tma_coords_A[2] = {k_tile * TILE_SIZE,
+                                   m_tile * OUTPUT_ATOM_SIZE};
+            int tma_coords_B[2] = {k_tile * TILE_SIZE, n_tile * MMA_N};
+            input_weight_smem.set_ptr(
+                shared_weight + smem_wr_buffer * OUTPUT_ATOM_SIZE * TILE_SIZE);
+            input_smem.set_ptr(shared_input +
+                               smem_wr_buffer * MMA_N * TILE_SIZE);
+            cute::set_barrier_transaction_bytes(
+                shared_storage.ab_full_mbar_ptr[smem_wr_buffer],
+                tma_transaction_bytes);
+            // set_barrier_transaction_bytes(ab_full_mbar_ptr[smem_wr_buffer],
+            // tma_transaction_bytes);
+            tma_a.tma_cp_async(ab_full_mbar_ptr[smem_wr_buffer],
+                               input_weight_smem.base_ptr,
+                               tma_coords_A);
+            tma_b.tma_cp_async(ab_full_mbar_ptr[smem_wr_buffer],
+                               input_smem.base_ptr,
+                               tma_coords_B);
+          }
+
+          if (tma_wr_k_tile_next < k_tile_count) {
+            peek_ab_empty_status = try_wait_barrier(
+                shared_storage.ab_empty_mbar_ptr[smem_wr_buffer_next],
+                tma_wr_ab_empty_phase_next);
+          }
+
+          tma_wr_k_tile = tma_wr_k_tile_next;
+          smem_wr_buffer = smem_wr_buffer_next;
+          tma_wr_ab_empty_phase = tma_wr_ab_empty_phase_next;
+
+        } // end for k_tile
+
+      } // end for n_tile
+    }
+  } else if (warp_idx == 4) {
+    // MMA warp (1)
+
+    // Wait for TMEM allocation to complete
+    tmem_allocation_result_barrier.arrive_and_wait();
+    tCtAcc.data() = shared_storage.tmem_base_ptr;
+
+    int total_k_tile_count = 0;
+    int num_tiles_executed = 0;
+    for (int m_tile = 0; m_tile < cute::size<3>(tCgA); ++m_tile) {
+      for (int n_tile = 0; n_tile < cute::size<3>(tCgB); ++n_tile) {
+
+        int acc_buf_idx = num_tiles_executed % NUM_ACC_STAGE;
+        auto tCtAcc_Slice = tCtAcc(cute::_, cute::_, cute::_, acc_buf_idx);
+
+        int num_prev_k_blk = total_k_tile_count;
+        total_k_tile_count += k_tile_count;
+
+        int mma_rd_k_tile = 0;
+        int smem_rd_buffer = (num_prev_k_blk + mma_rd_k_tile) % NUM_AB_STAGE;
+        int mma_rd_ab_full_phase =
+            (num_prev_k_blk + mma_rd_k_tile) / NUM_AB_STAGE % 2;
+
+        // Peek full phase
+        bool peek_ab_full_status =
+            try_wait_barrier(shared_storage.ab_full_mbar_ptr[smem_rd_buffer],
+                             mma_rd_ab_full_phase);
+
+        int acc_empty_phase = num_tiles_executed / NUM_ACC_STAGE % 2 ^ 1;
+        cute::wait_barrier(shared_storage.acc_empty_mbar_ptr[acc_buf_idx],
+                           acc_empty_phase);
+
+        // Initialize the accumulator to zero
+        tiled_mma.accumulate_ = cute::UMMA::ScaleOut::Zero;
+
+        for (int k_tile = 0; k_tile < k_tile_count; ++k_tile) {
+          int mma_rd_k_tile_next = mma_rd_k_tile + 1;
+          int smem_rd_buffer_next =
+              (num_prev_k_blk + mma_rd_k_tile_next) % NUM_AB_STAGE;
+          int mma_rd_ab_full_phase_next = smem_rd_buffer_next == 0
+                                              ? mma_rd_ab_full_phase ^ 1
+                                              : mma_rd_ab_full_phase;
+
+          if (!peek_ab_full_status) {
+            cute::wait_barrier(shared_storage.ab_full_mbar_ptr[smem_rd_buffer],
+                               mma_rd_ab_full_phase);
+          }
+
+          // if (!peek_ab_full_status){
+          //   wait(ab_full_mbar_ptr[smem_rd_buffer], mma_rd_ab_full_phase);
+          // }
+
+          // Perform MMA operation
+          for (int k_block = 0; k_block < cute::size<2>(tCrA); ++k_block) {
+            cute::gemm(tiled_mma,
+                       tCrA(cute::_, cute::_, k_block, smem_rd_buffer),
+                       tCrB(cute::_, cute::_, k_block, smem_rd_buffer),
+                       tCtAcc_Slice);
+            tiled_mma.accumulate_ = cute::UMMA::ScaleOut::One;
+          }
+
+          cutlass::arch::umma_arrive(
+              &shared_storage.ab_empty_mbar_ptr[smem_rd_buffer]);
+
+          if (mma_rd_k_tile_next < k_tile_count) {
+            peek_ab_full_status = try_wait_barrier(
+                shared_storage.ab_full_mbar_ptr[smem_rd_buffer_next],
+                mma_rd_ab_full_phase_next);
+          }
+
+          mma_rd_k_tile = mma_rd_k_tile_next;
+          smem_rd_buffer = smem_rd_buffer_next;
+          mma_rd_ab_full_phase = mma_rd_ab_full_phase_next;
+
+        } // end for k_tile
+
+        cutlass::arch::umma_arrive(
+            &shared_storage.acc_full_mbar_ptr[acc_buf_idx]);
+        num_tiles_executed++;
+
+      } // end for n_tile
+    }
+  } else if (warp_idx < 4) {
+    // Epilogue warps (4)
+
+    // Allocate TMEM for accumulators
+    if (warp_idx == 0) {
+      tmem_allocator.allocate(num_tmem_columns, &shared_storage.tmem_base_ptr);
+    }
+    tmem_allocation_result_barrier.arrive_and_wait();
+    tCtAcc.data() = shared_storage.tmem_base_ptr;
+
+    using AccType = typename decltype(tCtAcc)::value_type;
+    using TypeBias = T_;
+    using TypeC = T_;
+
+    cutlass::NumericConverter<AccType, TypeBias> converterBias;
+    cutlass::NumericConverter<TypeC, AccType> converter;
+
+    cute::TiledCopy tiled_copy_t2r =
+        cute::make_tmem_copy(cute::SM100_TMEM_LOAD_32dp32b1x{},
+                             tCtAcc(cute::_, cute::_, cute::_, 0)); // (128,32)
+    cute::ThrCopy thr_copy_t2r = tiled_copy_t2r.get_slice(threadIdx.x);
+    cute::Tensor tTR_tAcc = thr_copy_t2r.partition_S(
+        tCtAcc); // tmem_[32b](0x0000.0000) o
+                 // ((_32,_1),_32,_1,_1,_2):((_65536,_0),_1,_0,_0,_32)
+
+    cute::Tensor tCgC_fake = cute::make_tensor<TypeC>(cute::shape(
+        tCtAcc(cute::_, cute::_, cute::_, 0))); // (T2R, T2R_M, T2R_N)
+    cute::Tensor tTR_rAcc_fake = thr_copy_t2r.partition_D(tCgC_fake);
+    cute::Tensor tTR_rAcc = cute::make_tensor<AccType>(
+        cute::shape(tTR_rAcc_fake)); // ptr[32b](some_ptr) o
+                                     // ((_1,_1),_32,_1,_1):((_0,_0),_1,_0,_0)
+
+    // if(threadIdx.x == 0) {
+    //   cute::print("tiled_copy_t2r:\t"); cute::print(tiled_copy_t2r);
+    //   cute::print("\n"); // cute::print("thr_copy_t2r:\t");
+    //   cute::print(thr_copy_t2r); cute::print("\n"); //
+    //   cute::print("tTR_tAcc:\t"); cute::print(tTR_tAcc); cute::print("\n");
+    //   // cute::print("tTR_rAcc:\t"); cute::print(tTR_rAcc);
+    //   cute::print("\n"); // cute::print("tCtAcc:\t"); cute::print(tCtAcc);
+    //   cute::print("\n"); // printf("tmem_base_ptr: %u\n",
+    //   shared_storage.tmem_base_ptr);
+    // } epilogue_wg_barrier.arrive_and_wait();
+
+    int num_tiles_executed = 0;
+    for (int m_tile = 0; m_tile < cute::size<3>(tCgA); ++m_tile) {
+      for (int n_tile = 0; n_tile < cute::size<3>(tCgB); ++n_tile) {
+        int acc_buf_idx = num_tiles_executed % NUM_ACC_STAGE;
+        int acc_full_phase = num_tiles_executed / NUM_ACC_STAGE % 2;
+        int c_smem_wr_buffer_idx = num_tiles_executed % NUM_C_STAGE;
+
+        cute::Tensor tCgBias =
+            gBias(cute::_, cute::_, n_tile, m_tile); // (Mma_M, Mma_N)
+        cute::Tensor tCrBiasTypeBias = cute::make_tensor<TypeBias>(
+            cute::shape(tTR_rAcc(0, cute::_, 0, 0))); // (T2R_M, T2R_N)
+        cute::Tensor tCrBiasTypeAcc =
+            cute::make_tensor<AccType>(cute::shape(tCrBiasTypeBias));
+        cute::Tensor tCrC =
+            cute::make_tensor<TypeC>(cute::shape(tCrBiasTypeBias));
+
+        // if(threadIdx.x == 0 and m_tile == 0 and n_tile == 0) {
+        //   cute::print("tCgBias:\t"); cute::print(tCgBias); cute::print("\n");
+        //   // cute::print("tCrBiasTypeBias:\t"); cute::print(tCrBiasTypeBias);
+        //   cute::print("\n"); // cute::print("tCrBiasTypeAcc:\t");
+        //   cute::print(tCrBiasTypeAcc); cute::print("\n"); //
+        //   cute::print("tCrC:\t"); cute::print(tCrC); cute::print("\n"); //
+        // } epilogue_wg_barrier.arrive_and_wait();
+
+        // T2R and register operations
+        if constexpr (!NOBIAS) {
+          cute::Tensor tCgBiasCoord =
+              gBiasCoord(cute::_, cute::_, n_tile, m_tile);
+          cute::Tensor tCgBiasPred =
+              cute::lazy::transform(tCgBiasCoord, [&](auto const &coord) {
+                return cute::elem_less(
+                    coord,
+                    cute::make_shape(cute::Int<BATCH_SIZE>{},
+                                     cute::Int<OUTPUT_SIZE>{}));
+              });
+          CUTE_UNROLL
+          for (int i = 0; i < tCrBiasTypeBias.size(); i++) {
+            tCrBiasTypeBias[i] = TypeBias(0);
+          }
+          // Epilogue has 128 threads but bias may have fewer than 128 columns
+          // (OUTPUT_SIZE), and the MMA_N tile may have more rows than the
+          // runtime batch capacity. Guard both dimensions before reading the
+          // residual tensor.
+          if (threadIdx.x < OUTPUT_SIZE) {
+            cute::copy_if(tCgBiasPred(cute::_, threadIdx.x),
+                          tCgBias(cute::_, threadIdx.x),
+                          tCrBiasTypeBias);
+          }
+          // optimize with vectorized type conversion
+
+          CUTE_UNROLL
+          for (int i = 0; i < tCrBiasTypeBias.size(); i++) {
+            tCrBiasTypeAcc[i] = converterBias(tCrBiasTypeBias[i]);
+          }
+        }
+
+        mm_output_smem.set_ptr(mm_output +
+                               c_smem_wr_buffer_idx * MMA_N * OUTPUT_ATOM_SIZE);
+
+        cute::wait_barrier(shared_storage.acc_full_mbar_ptr[acc_buf_idx],
+                           acc_full_phase);
+        // T2R copy
+        cute::copy(tiled_copy_t2r,
+                   tTR_tAcc(cute::_, cute::_, cute::_, cute::_, acc_buf_idx),
+                   tTR_rAcc);
+
+        // arrive acc empty buffer
+        epilogue_wg_barrier.arrive_and_wait();
+        if (cute::elect_one_sync()) {
+          cute::arrive_barrier(shared_storage.acc_empty_mbar_ptr[acc_buf_idx]);
+        }
+
+        if constexpr (!NOBIAS) {
+          CUTE_UNROLL
+          for (int i = 0; i < tTR_rAcc.size(); i++) {
+            tTR_rAcc[i] += tCrBiasTypeAcc[i];
+          }
+        }
+
+        CUTE_UNROLL
+        for (int i = 0; i < tCrC.size(); i++) {
+          tCrC[i] = converter(tTR_rAcc[i]);
+        }
+
+        // R2S copy
+        cute::Tensor sC_epi_slice =
+            cute::flatten(sC_epi(cute::_, 0, 0, c_smem_wr_buffer_idx));
+        cute::copy(tCrC, sC_epi_slice(cute::_, threadIdx.x));
+
+        // S2G TMA
+        cute::tma_store_fence(); // Ensure C smem stores are visible to TMA
+        epilogue_wg_barrier
+            .arrive_and_wait(); // Ensure all threads have issued fence
+
+        if (warp_idx == 0 && cute::elect_one_sync()) {
+          if constexpr (SplitK) {
+            tma_out.tma_reduce_add_async(
+                mm_output_smem.base_ptr,
+                {m_tile * OUTPUT_ATOM_SIZE, n_tile * MMA_N});
+          } else {
+            tma_out.tma_store_async(
+                mm_output_smem.base_ptr,
+                {m_tile * OUTPUT_ATOM_SIZE, n_tile * MMA_N});
+          }
+
+          cute::tma_store_arrive();
+          cute::tma_store_wait<NUM_C_STAGE - 1>();
+        }
+
+        num_tiles_executed++;
+      }
+    }
+    // wait all TMA stores to complete
+    if (warp_idx == 0 && cute::elect_one_sync()) {
+      cute::tma_store_wait<0>();
+    }
+  }
+  __syncthreads();
+
+  // Release the right to allocate before deallocations so that the next CTA can
+  // rasterize Then deallocate TMEM
+  if (warp_idx == 0) {
+    // don't do relinquish for megakernel
+    // tmem_allocator.release_allocation_lock();
+    tmem_allocator.free(shared_storage.tmem_base_ptr, num_tmem_columns);
+  }
+
+} // end linear_sm100_mpk_task_impl
+
+} // namespace kernel

--- a/include/mirage/persistent_kernel/tasks/blackwell/sm100_ptx.cuh
+++ b/include/mirage/persistent_kernel/tasks/blackwell/sm100_ptx.cuh
@@ -48,6 +48,32 @@ __device__ __forceinline__ void mbar_wait(int addr, int phase) {
                "r"(phase));
 }
 
+__device__ __forceinline__ void mbar_arrive(int addr) {
+  asm volatile(
+      "mbarrier.arrive.release.cta.shared::cta.b64 _, [%0];" ::"r"(addr)
+      : "memory");
+}
+
+__device__ __forceinline__ void named_barrier_sync(int bar, int count) {
+  asm volatile("bar.sync %0, %1;" ::"r"(bar), "r"(count) : "memory");
+}
+
+__device__ __forceinline__ void tma_load_2d_cta(
+    int smem_addr, void const *desc, int c0, int c1, int mbar_addr) {
+  uint64_t desc_i = reinterpret_cast<uint64_t>(desc);
+  asm volatile(
+      "cp.async.bulk.tensor.5d.shared::cta.global.tile.mbarrier::complete_tx::"
+      "bytes [%0], [%1, {%3, %4, %5, %6, %7}], [%2];" ::"r"(smem_addr),
+      "l"(desc_i),
+      "r"(mbar_addr),
+      "r"(c0),
+      "r"(c1),
+      "r"(0),
+      "r"(0),
+      "r"(0)
+      : "memory");
+}
+
 __device__ __forceinline__ void mbar_tx(int addr, int bytes) {
   asm volatile(
       "mbarrier.arrive.expect_tx.release.cta.shared::cta.b64 _, [%0], %1;" ::
@@ -83,6 +109,96 @@ __device__ __forceinline__ void tcgen05_commit(int mbar_addr) {
   asm volatile("tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::"
                "cluster.b64 [%0];" ::"r"(mbar_addr)
                : "memory");
+}
+
+__device__ __forceinline__ void tcgen05_alloc(int addr_smem, int num_cols) {
+  asm volatile(
+      "tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [%0], %1;" ::"r"(
+          addr_smem),
+      "r"(num_cols));
+}
+
+__device__ __forceinline__ void tcgen05_dealloc(int taddr, int num_cols) {
+  asm volatile(
+      "tcgen05.dealloc.cta_group::1.sync.aligned.b32 %0, %1;" ::"r"(taddr),
+      "r"(num_cols));
+}
+
+__device__ __forceinline__ void tcgen05_relinquish_alloc_permit() {
+  asm volatile("tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned;" ::
+                   : "memory");
+}
+
+__device__ __forceinline__ void tcgen05_fence_before() {
+  asm volatile("tcgen05.fence::before_thread_sync;");
+}
+
+__device__ __forceinline__ void tcgen05_fence_after() {
+  asm volatile("tcgen05.fence::after_thread_sync;");
+}
+
+__device__ __forceinline__ void tcgen05_ld_x16(int taddr, float (&out)[16]) {
+  asm volatile("tcgen05.ld.sync.aligned.32x32b.x16.b32 "
+               "{%0,%1,%2,%3,%4,%5,%6,%7,%8,%9,%10,%11,%12,%13,%14,%15}, [%16];"
+               : "=f"(out[0]),
+                 "=f"(out[1]),
+                 "=f"(out[2]),
+                 "=f"(out[3]),
+                 "=f"(out[4]),
+                 "=f"(out[5]),
+                 "=f"(out[6]),
+                 "=f"(out[7]),
+                 "=f"(out[8]),
+                 "=f"(out[9]),
+                 "=f"(out[10]),
+                 "=f"(out[11]),
+                 "=f"(out[12]),
+                 "=f"(out[13]),
+                 "=f"(out[14]),
+                 "=f"(out[15])
+               : "r"(taddr));
+}
+
+template <int N>
+__device__ __forceinline__ void tcgen05_ld_cols(int taddr, float (&out)[N]) {
+  static_assert(N % 16 == 0, "tcgen05_ld_cols supports multiples of 16");
+#pragma unroll
+  for (int c = 0; c < N / 16; c++) {
+    float chunk[16];
+    tcgen05_ld_x16(taddr + c * 16, chunk);
+#pragma unroll
+    for (int i = 0; i < 16; i++) {
+      out[c * 16 + i] = chunk[i];
+    }
+  }
+}
+
+__device__ __forceinline__ void tcgen05_ld_wait() {
+  asm volatile("tcgen05.wait::ld.sync.aligned;");
+}
+
+__device__ __forceinline__ constexpr uint32_t make_idesc_f16(int mma_m,
+                                                             int mma_n) {
+  return (1U << 4) | (1U << 7) | (1U << 10) | ((uint32_t)(mma_n >> 3) << 17) |
+         ((uint32_t)(mma_m >> 4) << 24);
+}
+
+__device__ __forceinline__ void supergroup_tile_coord(int linear_idx,
+                                                      int num_m_tiles,
+                                                      int num_n_tiles,
+                                                      int group_m,
+                                                      int &m_tile,
+                                                      int &n_tile) {
+  int tiles_per_group = group_m * num_n_tiles;
+  int group_id = linear_idx / tiles_per_group;
+  int idx_in_group = linear_idx - group_id * tiles_per_group;
+  int first_m = group_id * group_m;
+  int rows_in_group = num_m_tiles - first_m;
+  if (rows_in_group > group_m) {
+    rows_in_group = group_m;
+  }
+  m_tile = first_m + (idx_in_group % rows_in_group);
+  n_tile = idx_in_group / rows_in_group;
 }
 
 } // namespace sm100_ptx

--- a/include/mirage/persistent_kernel/tasks/blackwell/task_header.cuh
+++ b/include/mirage/persistent_kernel/tasks/blackwell/task_header.cuh
@@ -32,6 +32,7 @@
 #include "linear_fp8_1d2d_sm100.cuh"
 #include "linear_fp8_sm100.cuh"
 #include "linear_sm100_mpk.cuh"
+// #include "linear_sm100_mpk_cutlass.cuh" // CUTLASS
 #include "mla_dispatch_sm100.cuh"
 #include "mla_kv_cache_gather_sm100.cuh"
 #include "mla_kv_cache_gather_split_sm100.cuh"

--- a/src/kernel/task_register.cc
+++ b/src/kernel/task_register.cc
@@ -1837,19 +1837,12 @@ int TaskRegister::register_linear_sm100_task(threadblock::Graph const &bgraph,
   code.e("TMA_OUT "
          "tma_out(static_cast<CUtensorMap*>(task_desc->output_tma_desc_ptrs[0]["
          "0]));");
-  // Bias Tensor setup
-  code.e("cute::Layout layout_Bias = cute::make_layout(cute::make_shape($, $), "
-         "cute::make_stride($, cute::Int<1>{}));",
-         batch_size,
-         output_size,
-         output_stride);
-  code.e("cute::Tensor mBias = "
-         "cute::make_tensor(cute::make_gmem_ptr(static_cast<cute::bfloat16_t*>("
-         "$)), layout_Bias);",
+  code.e("cute::bfloat16_t const *mBias = "
+         "static_cast<cute::bfloat16_t const *>($);",
          (with_residual && rank_with_residual) ? "task_desc->input_ptrs[2]"
                                                : "nullptr");
   code.e("kernel::linear_sm100_mpk_task_impl<cute::bfloat16_t, TMA_A, TMA_B, "
-         "decltype(mBias), TMA_OUT, "
+         "TMA_OUT, "
          "$, $, $, $, $, $, $, "
          "$, $, $>(",
          MMA_M,
@@ -1865,6 +1858,7 @@ int TaskRegister::register_linear_sm100_task(threadblock::Graph const &bgraph,
   code.e("    tma_a,");
   code.e("    tma_b,");
   code.e("    mBias,");
+  code.e("    $,", output_stride);
   code.e("    tma_out); ");
 
   if (with_residual) {
@@ -1991,18 +1985,11 @@ int TaskRegister::register_splitk_linear_sm100_task(
   code.e("TMA_OUT "
          "tma_out(static_cast<CUtensorMap*>(task_desc->output_tma_desc_ptrs[0]["
          "0]));");
-  // Bias Tensor setup
-  code.e("cute::Layout layout_Bias = cute::make_layout(cute::make_shape($, $), "
-         "cute::make_stride($, cute::Int<1>{}));",
-         batch_size,
-         output_size,
-         output_stride);
-  code.e("cute::Tensor mBias = "
-         "cute::make_tensor(cute::make_gmem_ptr(static_cast<cute::bfloat16_t*>("
-         "$)), layout_Bias);",
+  code.e("cute::bfloat16_t const *mBias = "
+         "static_cast<cute::bfloat16_t const *>($);",
          with_residual ? "task_desc->input_ptrs[2]" : "nullptr");
   code.e("kernel::linear_sm100_mpk_task_impl<cute::bfloat16_t, TMA_A, TMA_B, "
-         "decltype(mBias), TMA_OUT, "
+         "TMA_OUT, "
          "$, $, $, $, $, $, $, "
          "$, $, $>(",
          MMA_M,
@@ -2018,6 +2005,7 @@ int TaskRegister::register_splitk_linear_sm100_task(
   code.e("    tma_a,");
   code.e("    tma_b,");
   code.e("    mBias,");
+  code.e("    $,", output_stride);
   code.e("    tma_out); ");
 
   return register_task_variant(TASK_SPLITK_LINEAR_SM100, code.to_string());

--- a/tests/runtime_python/blackwell/sm100_linear/runtime_kernel_wrapper_sm100.cu
+++ b/tests/runtime_python/blackwell/sm100_linear/runtime_kernel_wrapper_sm100.cu
@@ -75,6 +75,8 @@ __global__
   constexpr int OUTPUT_TMA_CP_SIZE = 128;
   constexpr int OUTPUT_ATOM_REPEAT_COL = 1;
 
+  constexpr int CLAMPED_BN = (BATCH_SIZE < MMA_N) ? BATCH_SIZE : MMA_N;
+
   using TMA_B =
       kernel::tma::tma_2d<bfloat16,
                           B,
@@ -82,7 +84,7 @@ __global__
                           S,
                           BATCH_SIZE,                /*GMEM_ROW_*/
                           REDUCTION_SIZE,            /*GMEM_COL_*/
-                          MMA_N,                     /*SMEM_ROW_*/
+                          CLAMPED_BN,                /*SMEM_ROW_*/
                           TMA_CP_ASYNC_SIZE,         /*SMEM_COL_*/
                           REDUCTION_SIZE,            /*GMEM_STRIDE_ROW_*/
                           1,                         /*GMEM_STRIDE_COL_*/
@@ -113,7 +115,7 @@ __global__
                           S,
                           BATCH_SIZE,             /*GMEM_ROW_*/
                           OUTPUT_SIZE,            /*GMEM_COL_*/
-                          MMA_N,                  /*SMEM_ROW_*/
+                          CLAMPED_BN,             /*SMEM_ROW_*/
                           MMA_M,                  /*SMEM_COL_*/
                           OUTPUT_SIZE,            /*GMEM_STRIDE_ROW_*/
                           1,                      /*GMEM_STRIDE_COL_*/
@@ -157,6 +159,7 @@ void launch_linear_sm100_mpk(void *input_ptr,
 
   constexpr int MMA_M = 128;
   constexpr int MMA_N = 16;
+  constexpr int CLAMPED_BN = (BATCH_SIZE < MMA_N) ? BATCH_SIZE : MMA_N;
 
   constexpr int TMA_CP_ASYNC_SIZE =
       64; // note that if swizzle 128 is used, 64 is maximal cp size
@@ -184,7 +187,7 @@ void launch_linear_sm100_mpk(void *input_ptr,
   uint64_t i_gmem_shape[2] = {static_cast<uint64_t>(BATCH_SIZE),
                               static_cast<uint64_t>(REDUCTION_SIZE)};
   uint64_t i_gmem_stride[2] = {1, static_cast<uint64_t>(REDUCTION_SIZE)};
-  uint32_t i_smem_shape[2] = {static_cast<uint32_t>(MMA_N),
+  uint32_t i_smem_shape[2] = {static_cast<uint32_t>(CLAMPED_BN),
                               static_cast<uint32_t>(TMA_CP_ASYNC_SIZE)};
 
   size_t i_smem_repeat_col =
@@ -220,7 +223,7 @@ void launch_linear_sm100_mpk(void *input_ptr,
   uint64_t o_gmem_shape[2] = {static_cast<uint64_t>(BATCH_SIZE),
                               static_cast<uint64_t>(OUTPUT_SIZE)};
   uint64_t o_gmem_stride[2] = {1, static_cast<uint64_t>(output_stride)};
-  uint32_t o_smem_shape[2] = {static_cast<uint32_t>(MMA_N),
+  uint32_t o_smem_shape[2] = {static_cast<uint32_t>(CLAMPED_BN),
                               static_cast<uint32_t>(MMA_M)};
   size_t o_smem_repeat_col = 1;
   mirage::runtime::fill_tma_desc<bfloat16, 0, M, S, 2>(
@@ -384,6 +387,8 @@ __global__ __launch_bounds__(256, 1) void linear_splitk_sm100_wrapper(
   constexpr int OUTPUT_TMA_CP_SIZE = 128;
   constexpr int OUTPUT_ATOM_REPEAT_COL = 1;
 
+  constexpr int CLAMPED_BN = (BATCH_SIZE < MMA_N) ? BATCH_SIZE : MMA_N;
+
   using TMA_B =
       kernel::tma::tma_2d<bfloat16,
                           B,
@@ -391,7 +396,7 @@ __global__ __launch_bounds__(256, 1) void linear_splitk_sm100_wrapper(
                           S,
                           BATCH_SIZE,                /*GMEM_ROW_*/
                           REDUCTION_SIZE,            /*GMEM_COL_*/
-                          MMA_N,                     /*SMEM_ROW_*/
+                          CLAMPED_BN,                /*SMEM_ROW_*/
                           TMA_CP_ASYNC_SIZE,         /*SMEM_COL_*/
                           REDUCTION_SIZE,            /*GMEM_STRIDE_ROW_*/
                           1,                         /*GMEM_STRIDE_COL_*/
@@ -422,7 +427,7 @@ __global__ __launch_bounds__(256, 1) void linear_splitk_sm100_wrapper(
                           S,
                           BATCH_SIZE,             /*GMEM_ROW_*/
                           OUTPUT_SIZE,            /*GMEM_COL_*/
-                          MMA_N,                  /*SMEM_ROW_*/
+                          CLAMPED_BN,             /*SMEM_ROW_*/
                           MMA_M,                  /*SMEM_COL_*/
                           OUTPUT_SIZE,            /*GMEM_STRIDE_ROW_*/
                           1,                      /*GMEM_STRIDE_COL_*/
@@ -466,6 +471,7 @@ void launch_linear_splitk_sm100(void *input_ptr,
 
   constexpr int MMA_M = 128;
   constexpr int MMA_N = 16;
+  constexpr int CLAMPED_BN = (BATCH_SIZE < MMA_N) ? BATCH_SIZE : MMA_N;
 
   constexpr int TMA_CP_ASYNC_SIZE =
       64; // note that if swizzle 128 is used, 64 is maximal cp size
@@ -493,7 +499,7 @@ void launch_linear_splitk_sm100(void *input_ptr,
   uint64_t i_gmem_shape[2] = {static_cast<uint64_t>(BATCH_SIZE),
                               static_cast<uint64_t>(REDUCTION_SIZE)};
   uint64_t i_gmem_stride[2] = {1, static_cast<uint64_t>(REDUCTION_SIZE)};
-  uint32_t i_smem_shape[2] = {static_cast<uint32_t>(MMA_N),
+  uint32_t i_smem_shape[2] = {static_cast<uint32_t>(CLAMPED_BN),
                               static_cast<uint32_t>(TMA_CP_ASYNC_SIZE)};
 
   size_t i_smem_repeat_col =
@@ -529,7 +535,7 @@ void launch_linear_splitk_sm100(void *input_ptr,
   uint64_t o_gmem_shape[2] = {static_cast<uint64_t>(BATCH_SIZE),
                               static_cast<uint64_t>(OUTPUT_SIZE)};
   uint64_t o_gmem_stride[2] = {1, static_cast<uint64_t>(output_stride)};
-  uint32_t o_smem_shape[2] = {static_cast<uint32_t>(MMA_N),
+  uint32_t o_smem_shape[2] = {static_cast<uint32_t>(CLAMPED_BN),
                               static_cast<uint32_t>(MMA_M)};
   size_t o_smem_repeat_col = 1;
   mirage::runtime::fill_tma_desc<bfloat16, 0, M, S, 2>(

--- a/tests/runtime_python/blackwell/sm100_linear/runtime_kernel_wrapper_sm100.cu
+++ b/tests/runtime_python/blackwell/sm100_linear/runtime_kernel_wrapper_sm100.cu
@@ -129,7 +129,6 @@ __global__
   kernel::linear_sm100_mpk_task_impl<T,
                                      TMA_A,
                                      TMA_B,
-                                     BiasTensor,
                                      TMA_OUT,
                                      MMA_M,
                                      MMA_N,
@@ -140,7 +139,8 @@ __global__
                                      /*SplitK=*/false,
                                      NUM_AB_STAGE,
                                      NUM_ACC_STAGE,
-                                     NUM_C_STAGE>(tma_a, tma_b, mBias, tma_out);
+                                     NUM_C_STAGE>(
+      tma_a, tma_b, mBias.data().get(), OUTPUT_SIZE, tma_out);
 }
 
 template <typename T, int BATCH_SIZE, int OUTPUT_SIZE, int REDUCTION_SIZE>
@@ -438,7 +438,6 @@ __global__ __launch_bounds__(256, 1) void linear_splitk_sm100_wrapper(
   kernel::linear_sm100_mpk_task_impl<T,
                                      TMA_A,
                                      TMA_B,
-                                     BiasTensor,
                                      TMA_OUT,
                                      MMA_M,
                                      MMA_N,
@@ -449,7 +448,8 @@ __global__ __launch_bounds__(256, 1) void linear_splitk_sm100_wrapper(
                                      /*SplitK=*/true,
                                      NUM_AB_STAGE,
                                      NUM_ACC_STAGE,
-                                     NUM_C_STAGE>(tma_a, tma_b, mBias, tma_out);
+                                     NUM_C_STAGE>(
+      tma_a, tma_b, mBias.data().get(), OUTPUT_SIZE, tma_out);
 }
 
 template <typename T, int BATCH_SIZE, int OUTPUT_SIZE, int REDUCTION_SIZE>


### PR DESCRIPTION
Rewrites the SM100 (Blackwell) BF16 linear MPK task (`linear_sm100_mpk.cuh`) from CUTLASS/CuTe to CUDA for runtime v2.

Verified with:
```
cd ~/mirage/tests/runtime_python/blackwell/sm100_linear
python setup.py build_ext --inplace

python test_matmul_mpk.py
python test_matmul_splitk.py
```

Tested with:
```
cmake --build build --target mirage_runtime -j
touch python/mirage/_cython/core.pyx
python setup.py build_ext --inplace
cd ./demo/qwen3
CUDA_VISIBLE_DEVICES=0 python demo.py --use-mirage
```

```
MPK branch: 
    per-token latency: 5.907 ms
    per-token latency: 5.111 ms
    per-token latency: 5.204 ms

linear cuda branch: 
    per-token latency: 5.857 ms
    per-token latency: 5.315 ms
    per-token latency: 5.561 ms
```