### PR TITLE
test: add MoE residual double-count regression test

### DIFF
--- a/tests/runtime_python/blackwell/sm100_moe/runtime_kernel_wrapper_sm100.cu
+++ b/tests/runtime_python/blackwell/sm100_moe/runtime_kernel_wrapper_sm100.cu
@@ -592,14 +592,18 @@ __global__ __launch_bounds__(256) void mul_sum_add_sm100_wrapper(
 }
 
 void mul_sum_add_sm100_kernel(torch::Tensor input,
-                              torch::Tensor residual,
+                              c10::optional<at::Tensor> residual,
                               torch::Tensor weight,
                               torch::Tensor output) {
 
   using T = bfloat16;
 
+  // A null residual (residual=None) exercises the rank-0-only residual guard
+  // used under tensor parallelism: non-zero ranks pass a null residual so the
+  // skip connection is added on exactly one rank before the allreduce.
+  bool has_residual = residual.has_value();
   void *input_ptr = input.data_ptr();
-  void *residual_ptr = residual.data_ptr();
+  void *residual_ptr = has_residual ? residual->data_ptr() : nullptr;
   void *weight_ptr = weight.data_ptr();
   void *output_ptr = output.data_ptr();
 
@@ -610,7 +614,9 @@ void mul_sum_add_sm100_kernel(torch::Tensor input,
 
   assert(input.size(0) == BATCH_SIZE && input.size(1) == NUM_TOPK &&
          input.size(2) == OUTPUT_SIZE);
-  assert(residual.size(0) == BATCH_SIZE && residual.size(1) == OUTPUT_SIZE);
+  if (has_residual) {
+    assert(residual->size(0) == BATCH_SIZE && residual->size(1) == OUTPUT_SIZE);
+  }
   assert(weight.size(0) == BATCH_SIZE && weight.size(1) == NUM_TOPK);
   assert(output.size(0) == BATCH_SIZE && output.size(1) == OUTPUT_SIZE);
 

--- a/tests/runtime_python/blackwell/sm100_moe/test_weighted_sum.py
+++ b/tests/runtime_python/blackwell/sm100_moe/test_weighted_sum.py
@@ -25,7 +25,7 @@ for output_size in output_sizes:
     torch_topk_weights = F.softmax(topk_expert_score, dim=1, dtype=torch.float)
     output = torch.zeros(batch_size, output_size, device="cuda", dtype=torch.bfloat16)
         
-    # mpk impl
+    # mpk impl (with residual)
     runtime_kernel_blackwell.mul_sum_add_sm100(x, residual, torch_topk_weights, output)
     # reference impl
     torch_out = x.to(torch.float) * torch_topk_weights.unsqueeze(-1)
@@ -38,7 +38,34 @@ for output_size in output_sizes:
         rtol=1e-2,
         atol=1e-2,
     )
-    print("Test passed!")
+    print("Test passed (with residual)!")
+
+    # Regression test for the double-counted MoE residual fix (PR #722):
+    # under tensor parallelism the MoE output is row-parallel and followed by an
+    # allreduce, so the residual must be added on exactly one rank. Non-zero
+    # ranks pass a null residual (residual=None) and the kernel must add 0
+    # instead of the skip connection. Passing None here drives the same null
+    # d_residual pointer path and must yield the weighted sum WITHOUT residual.
+    output_no_res = torch.zeros(batch_size, output_size, device="cuda", dtype=torch.bfloat16)
+    runtime_kernel_blackwell.mul_sum_add_sm100(x, None, torch_topk_weights, output_no_res)
+    torch_out_no_res = x.to(torch.float) * torch_topk_weights.unsqueeze(-1)
+    torch_out_no_res = torch_out_no_res.sum(dim=1).to(torch.bfloat16)
+
+    torch.testing.assert_close(
+        output_no_res,
+        torch_out_no_res,
+        rtol=1e-2,
+        atol=1e-2,
+    )
+    # The two outputs must differ by exactly the residual; this guards against a
+    # regression where every rank adds the residual (double-counting it).
+    torch.testing.assert_close(
+        (output.to(torch.float) - output_no_res.to(torch.float)),
+        residual.to(torch.float),
+        rtol=1e-2,
+        atol=1e-2,
+    )
+    print("Test passed (null residual / TP rank-0 guard)!")
 
     # Warm-up
     for _ in range(16):


### PR DESCRIPTION
Make mul_sum_add_sm100 test wrapper accept an optional residual (None -> null pointer), mirroring the w13/w2 wrappers, and extend test_weighted_sum to assert the null-residual path adds 0 and that the with/without-residual outputs differ by exactly the residual.