### PR TITLE
Adding Structured Decoding with XGrammar

### DIFF
--- a/demo/coding_agent/reset.sh
+++ b/demo/coding_agent/reset.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Reset the coding-agent demo workspace back to its seed files (main.py, notes.txt).
+# Reuses tool_runtime.reset_workspace() so the seed content has a single source.
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+python -c "import sys; sys.path.insert(0, '$HERE'); import tool_runtime as R; \
+R.reset_workspace(); print('workspace reset:', sorted(p.name for p in R.WORKSPACE.iterdir()))"

--- a/demo/coding_agent/run_demo.py
+++ b/demo/coding_agent/run_demo.py
@@ -1,0 +1,187 @@
+"""
+Constrained coding-agent demo — XGrammar structural tags + a sandboxed runtime.
+
+The model is constrained to emit ONLY the five tool calls
+(list/read/write/edit/bash), tool-only, newline-separated. Each turn the calls
+are executed inside a locked-down workspace and the results are fed back,
+looping until the model runs ``python main.py``. The grammar constrains the
+*shape* of every call; tool_runtime.py independently enforces all filesystem
+and execution safety.
+
+The demo folder is ``demo/coding_agent/`` and the sandbox is
+``demo/coding_agent/workspace/`` (resolved relative to this file).
+
+Run it two ways:
+
+    # Live: constrained decoding through the MPK megakernel + Qwen3-8B
+    CUDA_VISIBLE_DEVICES=1 python demo/coding_agent/run_demo.py
+
+    # Scripted: no GPU/model — drives the SAME sandbox runtime through a fixed
+    # happy path plus adversarial calls, to show the safety enforcement:
+    python demo/coding_agent/run_demo.py --scripted
+"""
+
+import argparse
+import json
+import pathlib
+import sys
+import textwrap
+
+HERE = pathlib.Path(__file__).parent
+sys.path.insert(0, str(HERE))
+
+import tool_runtime as R                         # noqa: E402
+from structural_tags import build_structural_tag  # noqa: E402
+
+MAX_TURNS = 6
+
+TASK = ('Update main.py so it prints "new message" instead of "old message", '
+        "then run it with `python main.py` to confirm the change.")
+
+SYSTEM = textwrap.dedent("""\
+    You are a coding agent working inside a locked sandbox folder. Respond with
+    exactly ONE tool call per message — no prose — as
+    <function=NAME>{json args}</function>. You will be shown its result before
+    your next step. The available tools are:
+
+      <function=list>{}</function>
+      <function=read>{"filename":"main.py"}</function>
+      <function=write>{"filename":"main.py","content":"..."}</function>
+      <function=edit>{"filename":"main.py","old":"...","new":"..."}</function>
+      <function=bash>{"command":"python main.py"}</function>
+
+    Filenames are bare names ending in .txt or .py inside the workspace; bash may
+    only run `python <file>.py`. List the files, read what you need, make the
+    change, then run `python main.py`.""")
+
+
+# ── formatting helpers ──────────────────────────────────────────────────────
+
+def _indent(text: str, n: int = 3) -> str:
+    pad = " " * n
+    return "\n".join(pad + line for line in text.splitlines()) or (pad + "(empty)")
+
+
+def _compact(args: dict, width: int = 88) -> str:
+    s = json.dumps(args, ensure_ascii=False)
+    return s if len(s) <= width else s[:width - 1] + "…"
+
+
+def _run_tool_call(text: str):
+    """Execute the single tool call in ``text`` (the grammar allows exactly one).
+    Print it, and return (result_str, ran_main)."""
+    try:
+        calls = R.parse_tool_calls(text)
+    except R.ToolError as e:
+        print(_indent(f"(unparseable) ERROR: {e}"))
+        return f"ERROR: {e}", False
+    if not calls:
+        print(_indent("(no tool call emitted)"))
+        return "(no tool call emitted)", False
+
+    name, args = calls[0]
+    result = R.dispatch(name, args)
+    print(f"   $ {name}({_compact(args)})")
+    print(_indent(result, 5))
+    ran_main = (name == "bash" and isinstance(args, dict)
+                and args.get("command") == "python main.py"
+                and not result.startswith("ERROR"))
+    return f"[{name}] {result}", ran_main
+
+
+# ── live model driver ───────────────────────────────────────────────────────
+
+def run_live() -> None:
+    import threading
+    import time
+
+    from mirage.engine import ModelRunner, RunnerConfig
+
+    R.reset_workspace()
+    stag = build_structural_tag()
+
+    cfg = RunnerConfig(
+        model="Qwen/Qwen3-8B", vocab_size=153600,
+        enable_constrained_decoding=True, do_sample=True,
+        max_num_batched_requests=1, max_num_batched_tokens=8,
+        max_seq_length=1024, max_num_pages=64, page_size=4096)
+    runner = ModelRunner(cfg)              # xgrammar auto-initialized from the flag
+    rt, tok = runner.runtime, runner.tokenizer
+    threading.Thread(target=runner, daemon=True).start()
+    time.sleep(2)
+
+    conversation = [{"role": "system", "content": SYSTEM},
+                    {"role": "user", "content": TASK}]
+    print("TASK:", TASK, "\n")
+
+    for turn in range(MAX_TURNS):
+        prompt = tok.apply_chat_template(
+            conversation, tokenize=True, add_generation_prompt=True,
+            enable_thinking=False, return_tensors="pt")[0]
+        rid = turn
+        rt.set_request_grammar(rid, structural_tag=stag)
+        rt.submit(rid, prompt)
+        row, final = rt.wait_for_request(rid, timeout=180)
+        text = tok.decode(rt.read_tokens_at_row(row, final)[prompt.shape[0]:],
+                          skip_special_tokens=True).strip()
+        # grammar for this rid is auto-released when the turn completes
+
+        print(f"── turn {turn} ── model:")
+        print(_indent(text))
+        conversation.append({"role": "assistant", "content": text})
+
+        result, ran_main = _run_tool_call(text)
+        conversation.append({"role": "user", "content": "Tool result:\n" + result})
+        if ran_main:
+            print("\n✓ model ran `python main.py` — task complete.")
+            break
+    else:
+        print("\n(reached MAX_TURNS without running `python main.py`)")
+
+    print("\nfinal main.py:\n" + _indent((R.WORKSPACE / "main.py").read_text()))
+    rt.shutdown()
+
+
+# ── scripted driver (no GPU/model) ──────────────────────────────────────────
+
+def run_scripted() -> None:
+    R.reset_workspace()
+    print("TASK:", TASK)
+    print("(scripted: driving the real sandbox runtime directly, no model)\n")
+
+    print("=== happy path: what a well-behaved agent emits ===")
+    for call in [
+        '<function=list>{}</function>',
+        '<function=read>{"filename":"main.py"}</function>',
+        '<function=read>{"filename":"notes.txt"}</function>',
+        '<function=edit>{"filename":"main.py","old":"old message","new":"new message"}</function>',
+        '<function=bash>{"command":"python main.py"}</function>',
+    ]:
+        _run_tool_call(call)
+
+    print("\n=== safety: the runtime rejects these even though the grammar is bypassed ===")
+    for label, call in [
+        ("absolute path",   '<function=read>{"filename":"/etc/passwd"}</function>'),
+        ("path traversal",  '<function=read>{"filename":"../../secret.txt"}</function>'),
+        ("unsupported ext", '<function=read>{"filename":"main.sh"}</function>'),
+        ("shell chaining",  '<function=bash>{"command":"python main.py && rm -rf /"}</function>'),
+        ("non-python bash", '<function=bash>{"command":"ls"}</function>'),
+        ("cat via bash",    '<function=bash>{"command":"cat main.py"}</function>'),
+        ("bad python write",'<function=write>{"filename":"broken.py","content":"def ("}</function>'),
+    ]:
+        print(f"\n[{label}]")
+        _run_tool_call(call)
+
+    print("\nfinal main.py:\n" + _indent((R.WORKSPACE / "main.py").read_text()))
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--scripted", action="store_true",
+                   help="run without a model; drive the sandbox runtime directly")
+    args = p.parse_args()
+    (run_scripted if args.scripted else run_live)()
+
+
+if __name__ == "__main__":
+    main()

--- a/demo/coding_agent/structural_tags.py
+++ b/demo/coding_agent/structural_tags.py
@@ -1,0 +1,88 @@
+"""
+XGrammar structural tag for the constrained coding-agent demo.
+
+Constrains the model to emit exactly ONE of the five allowed tool calls
+(list/read/write/edit/bash) per turn, tool-only (no prose), using the composable
+``tags_with_separator`` format with ``stop_after_first=True``. Each turn ends
+after one call so the runtime can execute it and feed the result back before the
+model's next step. Built with the modern ``xgrammar.StructuralTag.from_json(...)``
+API — NOT ``StructuralTagItem`` and NOT ``from_legacy_structural_tag``.
+
+The grammar only constrains the *shape* of each call: which tools exist, that a
+filename looks like ``NAME.txt`` / ``NAME.py``, and that ``bash`` is exactly
+``python NAME.py``. All filesystem/execution *safety* is enforced independently
+by tool_runtime.py, so the sandbox never depends on the grammar.
+
+The ``.py`` write/edit content is a plain JSON string here (validated at runtime
+with ``ast.parse``). The tag structure is kept modular so a real Python grammar
+can later replace the ``content`` schema of the write/edit tags.
+"""
+
+import xgrammar as xgr
+
+# Shared with tool_runtime.py on purpose: the grammar rejects malformed calls
+# early, and the runtime re-validates against the same contract (defense in
+# depth). A bare filename ending in .txt/.py — no separators, no traversal.
+FILENAME_PATTERN = r"^[A-Za-z0-9_\-]+\.(txt|py)$"
+BASH_PATTERN = r"^python [A-Za-z0-9_\-]+\.py$"
+
+TOOL_NAMES = ("list", "read", "write", "edit", "bash")
+
+_FILENAME_SCHEMA = {"type": "string", "pattern": FILENAME_PATTERN}
+
+
+def _tag(begin: str, properties: dict, required: list) -> dict:
+    """One ``<function=NAME> {json-schema args} </function>`` tag definition."""
+    return {
+        "type": "tag",
+        "begin": begin,
+        "content": {
+            "type": "json_schema",
+            "json_schema": {
+                "type": "object",
+                "properties": properties,
+                "required": required,
+                "additionalProperties": False,
+            },
+        },
+        "end": "</function>",
+    }
+
+
+def build_structural_tag() -> "xgr.StructuralTag":
+    """Return the StructuralTag constraining output to exactly one of the five
+    sandbox tool calls per turn."""
+    return xgr.StructuralTag.from_json({
+        "format": {
+            "type": "tags_with_separator",
+            "separator": "\n",
+            "at_least_one": True,
+            "stop_after_first": True,
+            "tags": [
+                _tag("<function=list>", {}, []),
+                _tag("<function=read>",
+                     {"filename": _FILENAME_SCHEMA}, ["filename"]),
+                _tag("<function=write>",
+                     {"filename": _FILENAME_SCHEMA, "content": {"type": "string"}},
+                     ["filename", "content"]),
+                _tag("<function=edit>",
+                     {"filename": _FILENAME_SCHEMA,
+                      "old": {"type": "string"}, "new": {"type": "string"}},
+                     ["filename", "old", "new"]),
+                _tag("<function=bash>",
+                     {"command": {"type": "string", "pattern": BASH_PATTERN}},
+                     ["command"]),
+            ],
+        }
+    })
+
+
+if __name__ == "__main__":
+    # Smoke test: build + compile the tag against a small char vocab.
+    tag = build_structural_tag()
+    vocab = list(dict.fromkeys(
+        ' \t\n{}[]":,._/0123456789'
+        'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ<>=()|-'))
+    ti = xgr.TokenizerInfo(vocab, vocab_type=xgr.VocabType.RAW, vocab_size=len(vocab))
+    xgr.GrammarCompiler(ti).compile_structural_tag(tag)
+    print("structural tag compiled OK; tools:", ", ".join(TOOL_NAMES))

--- a/demo/coding_agent/tool_runtime.py
+++ b/demo/coding_agent/tool_runtime.py
@@ -1,0 +1,197 @@
+r"""
+Sandboxed tool runtime for the constrained coding-agent demo.
+
+Executes the five tool calls (list/read/write/edit/bash) INSIDE one workspace
+folder and enforces every safety rule independently of the grammar — so the
+sandbox holds even if the structural tag is bypassed entirely:
+
+  * filenames must match ^[A-Za-z0-9_\-]+\.(txt|py)$ — no absolute paths, no
+    ``..``, no path separators, no traversal;
+  * the resolved path must stay inside the workspace;
+  * only .txt / .py extensions are supported;
+  * .py writes/edits must pass ``ast.parse`` before touching disk;
+  * bash only runs ``python <filename.py>`` for a file in the workspace, via a
+    ``subprocess`` with no shell, a fixed cwd, captured output and a timeout.
+
+The workspace is resolved relative to this file (``demo/coding_agent/workspace``),
+so the enforcement does not depend on the process's current directory.
+"""
+
+import ast
+import json
+import re
+import subprocess
+from pathlib import Path
+
+WORKSPACE = (Path(__file__).parent / "workspace").resolve()
+FILENAME_RE = re.compile(r"^[A-Za-z0-9_\-]+\.(txt|py)$")
+BASH_RE = re.compile(r"^python ([A-Za-z0-9_\-]+\.py)$")
+SUPPORTED_EXTS = (".txt", ".py")
+BASH_TIMEOUT_S = 10
+
+# Initial demo files; also used to (re)seed the workspace for a clean run.
+SEED_FILES = {
+    "main.py": 'def main():\n    print("old message")\n\n'
+               'if __name__ == "__main__":\n    main()\n',
+    "notes.txt": "This file contains the message that main.py should print.\n",
+}
+
+
+class ToolError(Exception):
+    """A call violated a sandbox rule; the message is surfaced to the model."""
+
+
+# ── Path safety ─────────────────────────────────────────────────────────────
+
+def resolve_workspace_path(filename: str) -> Path:
+    """Validate ``filename`` and return an absolute path guaranteed to live
+    inside the workspace. Rejects anything that is not a bare ``NAME.txt`` /
+    ``NAME.py`` (which already excludes absolute paths, ``..`` and separators),
+    then re-checks containment after resolving as defense in depth."""
+    if not isinstance(filename, str) or not FILENAME_RE.match(filename):
+        raise ToolError(
+            f"illegal filename {filename!r}: must match {FILENAME_RE.pattern}")
+    path = (WORKSPACE / filename).resolve()
+    if not path.is_relative_to(WORKSPACE):
+        raise ToolError(f"path escapes workspace: {filename!r}")
+    return path
+
+
+def _check_ext(path: Path) -> None:
+    if path.suffix not in SUPPORTED_EXTS:
+        raise ToolError(
+            f"unsupported extension {path.suffix!r}; only {SUPPORTED_EXTS}")
+
+
+def _validate_python(source: str, name: str) -> None:
+    try:
+        ast.parse(source)
+    except SyntaxError as e:
+        raise ToolError(f"{name}: python syntax error: {e}") from e
+
+
+# ── Tools ───────────────────────────────────────────────────────────────────
+
+def tool_list(args: dict) -> str:
+    """`ls` the workspace. The only valid payload is ``{}``."""
+    if args != {}:
+        raise ToolError("list takes no arguments; payload must be {}")
+    names = sorted(p.name for p in WORKSPACE.iterdir())
+    return "\n".join(names) if names else "(empty)"
+
+
+def tool_read(args: dict) -> str:
+    """Read a .txt/.py file from the workspace."""
+    path = resolve_workspace_path(args["filename"])
+    _check_ext(path)
+    if not path.is_file():
+        raise ToolError(f"no such file: {path.name}")
+    return path.read_text()
+
+
+def tool_write(args: dict) -> str:
+    """Create or overwrite a .txt/.py file. .py content must parse."""
+    path = resolve_workspace_path(args["filename"])
+    _check_ext(path)
+    content = args["content"]
+    if not isinstance(content, str):
+        raise ToolError("content must be a string")
+    if path.suffix == ".py":
+        _validate_python(content, path.name)
+    path.write_text(content)
+    return f"wrote {path.name} ({len(content)} bytes)"
+
+
+def tool_edit(args: dict) -> str:
+    """Replace the exact ``old`` text with ``new`` (must occur exactly once).
+    For .py files the result must still parse."""
+    path = resolve_workspace_path(args["filename"])
+    _check_ext(path)
+    if not path.is_file():
+        raise ToolError(f"no such file: {path.name}")
+    old, new = args["old"], args["new"]
+    if not isinstance(old, str) or not isinstance(new, str):
+        raise ToolError("old and new must be strings")
+    text = path.read_text()
+    count = text.count(old)
+    if count == 0:
+        raise ToolError(f"`old` text not found in {path.name}")
+    if count > 1:
+        raise ToolError(f"`old` text is ambiguous: found {count}x in {path.name}")
+    updated = text.replace(old, new, 1)
+    if path.suffix == ".py":
+        _validate_python(updated, path.name)
+    path.write_text(updated)
+    return f"edited {path.name}"
+
+
+def tool_bash(args: dict) -> str:
+    """Run exactly ``python <filename.py>`` in the workspace (no shell)."""
+    command = args["command"]
+    m = BASH_RE.match(command) if isinstance(command, str) else None
+    if not m:
+        raise ToolError("bash only allows `python <filename.py>`")
+    path = resolve_workspace_path(m.group(1))  # re-validate inside workspace
+    if path.suffix != ".py":
+        raise ToolError("bash can only run .py files")
+    if not path.is_file():
+        raise ToolError(f"no such file: {path.name}")
+    proc = subprocess.run(
+        ["python", path.name], cwd=str(WORKSPACE),
+        capture_output=True, text=True, timeout=BASH_TIMEOUT_S)
+    body = proc.stdout + (f"\n[stderr]\n{proc.stderr}" if proc.stderr else "")
+    return f"exit={proc.returncode}\n{body}".rstrip()
+
+
+_TOOLS = {"list": tool_list, "read": tool_read, "write": tool_write,
+          "edit": tool_edit, "bash": tool_bash}
+
+
+# ── Parse + dispatch ────────────────────────────────────────────────────────
+
+_CALL_RE = re.compile(r"<function=(\w+)>(.*?)</function>", re.S)
+
+
+def parse_tool_calls(text: str):
+    """Extract ``(name, args_dict)`` pairs from model output. Malformed JSON or
+    an unknown tool raises ToolError so the caller can report it."""
+    calls = []
+    for name, raw in _CALL_RE.findall(text):
+        raw = raw.strip() or "{}"
+        try:
+            args = json.loads(raw)
+        except json.JSONDecodeError as e:
+            raise ToolError(f"{name}: bad JSON args {raw!r}: {e}") from e
+        if name not in _TOOLS:
+            raise ToolError(f"unknown tool {name!r}")
+        calls.append((name, args))
+    return calls
+
+
+def dispatch(name: str, args: dict) -> str:
+    """Execute one tool call, converting any ToolError into an ``ERROR: ...``
+    string so the agent loop can feed it back to the model instead of crashing."""
+    if name not in _TOOLS:
+        return f"ERROR: unknown tool {name!r}"
+    try:
+        return _TOOLS[name](args)
+    except ToolError as e:
+        return f"ERROR: {e}"
+    except KeyError as e:
+        return f"ERROR: missing argument {e}"
+    except subprocess.TimeoutExpired:
+        return f"ERROR: `{name}` timed out after {BASH_TIMEOUT_S}s"
+    except Exception as e:  # pragma: no cover - unexpected
+        return f"ERROR: {type(e).__name__}: {e}"
+
+
+# ── Workspace maintenance ───────────────────────────────────────────────────
+
+def reset_workspace() -> None:
+    """Restore the workspace to exactly the seed files, for a reproducible run."""
+    WORKSPACE.mkdir(parents=True, exist_ok=True)
+    for p in WORKSPACE.iterdir():
+        if p.is_file():
+            p.unlink()
+    for name, content in SEED_FILES.items():
+        (WORKSPACE / name).write_text(content)

--- a/demo/coding_agent/workspace/main.py
+++ b/demo/coding_agent/workspace/main.py
@@ -1,0 +1,5 @@
+def main():
+    print("old message")
+
+if __name__ == "__main__":
+    main()

--- a/demo/coding_agent/workspace/notes.txt
+++ b/demo/coding_agent/workspace/notes.txt
@@ -1,0 +1,1 @@
+This file contains the message that main.py should print.

--- a/demo/coding_agent_large/.gitignore
+++ b/demo/coding_agent_large/.gitignore
@@ -1,0 +1,2 @@
+workspace/
+__pycache__/

--- a/demo/coding_agent_large/agent_runtime.py
+++ b/demo/coding_agent_large/agent_runtime.py
@@ -1,0 +1,314 @@
+r"""Sandboxed tool runtime for the large coding-agent demo.
+
+Executes the registry tools INSIDE one workspace folder and enforces every
+safety rule independently of the grammar — so the sandbox holds even if the
+structural tag were bypassed:
+
+  * paths must resolve inside the workspace (no absolute paths, no ``..``);
+  * only a whitelist of source/text extensions may be read/written;
+  * ``.py`` writes/edits must pass ``ast.parse`` before touching disk;
+  * ``run_python`` / ``run_pytest`` use ``subprocess`` with **no shell**, a fixed
+    cwd, captured output and a timeout;
+  * ``git_status`` / ``git_diff`` are read-only.
+
+``reset_workspace()`` restores the seed project and (re)inits a git repo with an
+initial commit, so ``git_status`` / ``git_diff`` show the agent's own changes.
+The grammar constrains the *shape* of each call; this module owns *safety*.
+"""
+
+import ast
+import json
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+HERE = Path(__file__).parent
+WORKSPACE = (HERE / "workspace").resolve()
+SEED = HERE / "project_seed"
+
+TEXT_EXTS = (".py", ".txt", ".md", ".json", ".toml", ".cfg", ".ini")
+CMD_TIMEOUT_S = 30
+MAX_OUTPUT = 4000          # truncate tool output fed back to the model
+# Tests are the reward signal — the agent may READ them but never modify them,
+# so it can't "pass" by weakening the suite (enforced, not just prompt-asked).
+TEST_RE = re.compile(r"^(test_.*|.*_test|conftest)\.py$")
+
+
+class ToolError(Exception):
+    """A call violated a sandbox rule; the message is surfaced to the model."""
+
+
+# ── Path safety ─────────────────────────────────────────────────────────────
+
+def _resolve(path: str) -> Path:
+    """Validate a workspace-relative path and return an absolute path guaranteed
+    to live inside the workspace."""
+    if not isinstance(path, str) or not path.strip():
+        raise ToolError("path must be a non-empty string")
+    p = Path(path)
+    if p.is_absolute() or ".." in p.parts:
+        raise ToolError(f"illegal path {path!r}: must be workspace-relative, no '..'")
+    resolved = (WORKSPACE / p).resolve()
+    if not (resolved == WORKSPACE or resolved.is_relative_to(WORKSPACE)):
+        raise ToolError(f"path escapes workspace: {path!r}")
+    return resolved
+
+
+def _check_ext(p: Path) -> None:
+    if p.suffix not in TEXT_EXTS:
+        raise ToolError(f"unsupported extension {p.suffix!r}; allowed: {TEXT_EXTS}")
+
+
+def _guard_not_test(p: Path) -> None:
+    """Refuse writes/edits to test files — the agent must fix the code, not the
+    tests, so it can't pass by weakening the suite."""
+    if TEST_RE.match(p.name):
+        raise ToolError(f"editing test files is not allowed: {_rel(p)}")
+
+
+def _validate_python(source: str, name: str) -> None:
+    try:
+        ast.parse(source)
+    except SyntaxError as e:
+        raise ToolError(f"{name}: python syntax error: {e}") from e
+
+
+def _rel(p: Path) -> str:
+    return str(p.relative_to(WORKSPACE))
+
+
+def _visible(p: Path) -> bool:
+    """Hide the .git bookkeeping dir from the file-listing/search tools."""
+    return ".git" not in p.relative_to(WORKSPACE).parts
+
+
+def _clip(s: str) -> str:
+    return s if len(s) <= MAX_OUTPUT else s[:MAX_OUTPUT] + "\n... (truncated)"
+
+
+# ── Tools ───────────────────────────────────────────────────────────────────
+
+def tool_list_dir(args: dict) -> str:
+    root = _resolve(args["path"])
+    if not root.is_dir():
+        raise ToolError(f"not a directory: {args['path']!r}")
+    names = sorted(_rel(p) for p in root.rglob("*") if p.is_file() and _visible(p))
+    return "\n".join(names) if names else "(empty)"
+
+
+def tool_read_file(args: dict) -> str:
+    p = _resolve(args["path"])
+    _check_ext(p)
+    if not p.is_file():
+        raise ToolError(f"no such file: {args['path']!r}")
+    return _clip(p.read_text())
+
+
+def tool_write_file(args: dict) -> str:
+    p = _resolve(args["path"])
+    _check_ext(p)
+    _guard_not_test(p)
+    content = args["content"]
+    if not isinstance(content, str):
+        raise ToolError("content must be a string")
+    if p.suffix == ".py":
+        _validate_python(content, p.name)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content)
+    return f"wrote {_rel(p)} ({len(content)} bytes)"
+
+
+def _tolerant_replace(text: str, old: str, new: str):
+    """Replace `old` with `new`. Exact-unique first; then a per-line match that
+    ignores trailing whitespace and surrounding blank lines (models rarely
+    reproduce a big block byte-for-byte). Returns (updated, note) or (None, why)."""
+    n = text.count(old)
+    if n == 1:
+        return text.replace(old, new, 1), None
+    if n > 1:
+        return None, f"is ambiguous: {n} exact occurrences"
+    fl = text.split("\n")
+    on = [ln.rstrip() for ln in old.strip("\n").split("\n")]
+    fn = [ln.rstrip() for ln in fl]
+    hits = ([i for i in range(len(fn) - len(on) + 1) if fn[i:i + len(on)] == on]
+            if on else [])
+    if len(hits) == 1:
+        i = hits[0]
+        return "\n".join(fl[:i] + new.split("\n") + fl[i + len(on):]), \
+            "matched ignoring trailing whitespace"
+    if len(hits) > 1:
+        return None, f"is ambiguous: {len(hits)} whitespace-insensitive matches"
+    return None, "not found"
+
+
+def tool_edit_file(args: dict) -> str:
+    p = _resolve(args["path"])
+    _check_ext(p)
+    _guard_not_test(p)
+    if not p.is_file():
+        raise ToolError(f"no such file: {args['path']!r}")
+    old, new = args["old"], args["new"]
+    if not isinstance(old, str) or not isinstance(new, str):
+        raise ToolError("old and new must be strings")
+    text = p.read_text()
+    updated, note = _tolerant_replace(text, old, new)
+    if updated is None:
+        raise ToolError(
+            f"`old` {note} in {_rel(p)}. Do NOT retry the same edit — either copy "
+            f"`old` verbatim from the file below, or (to replace most/all of it) "
+            f"call write_file with the full new contents.\n--- {_rel(p)} ---\n"
+            + _clip(text))
+    if p.suffix == ".py":
+        _validate_python(updated, p.name)
+    p.write_text(updated)
+    return f"edited {_rel(p)}" + (f" ({note})" if note else "")
+
+
+def tool_find_files(args: dict) -> str:
+    pattern = args["pattern"]
+    if not isinstance(pattern, str) or "/" in pattern and ".." in pattern:
+        raise ToolError("invalid pattern")
+    hits = sorted(_rel(p) for p in WORKSPACE.rglob(pattern)
+                  if p.is_file() and _visible(p))
+    return "\n".join(hits) if hits else "(no matches)"
+
+
+def tool_grep(args: dict) -> str:
+    try:
+        rx = re.compile(args["pattern"])
+    except re.error as e:
+        raise ToolError(f"bad regex: {e}") from e
+    out = []
+    for p in sorted(WORKSPACE.rglob("*")):
+        if not p.is_file() or p.suffix not in TEXT_EXTS or not _visible(p):
+            continue
+        try:
+            for i, line in enumerate(p.read_text().splitlines(), 1):
+                if rx.search(line):
+                    out.append(f"{_rel(p)}:{i}: {line.strip()}")
+        except (UnicodeDecodeError, OSError):
+            continue
+    return _clip("\n".join(out)) if out else "(no matches)"
+
+
+def _run(cmd, label: str) -> str:
+    try:
+        proc = subprocess.run(cmd, cwd=str(WORKSPACE), capture_output=True,
+                              text=True, timeout=CMD_TIMEOUT_S)
+    except subprocess.TimeoutExpired:
+        raise ToolError(f"{label} timed out after {CMD_TIMEOUT_S}s")
+    except FileNotFoundError as e:
+        raise ToolError(f"{label}: {e}") from e
+    body = proc.stdout + (f"\n[stderr]\n{proc.stderr}" if proc.stderr else "")
+    return _clip(f"exit={proc.returncode}\n{body}".rstrip())
+
+
+def tool_run_python(args: dict) -> str:
+    p = _resolve(args["path"])
+    if p.suffix != ".py":
+        raise ToolError("run_python only runs .py files")
+    if not p.is_file():
+        raise ToolError(f"no such file: {args['path']!r}")
+    return _run(["python", _rel(p)], "run_python")
+
+
+def tool_run_pytest(args: dict) -> str:
+    # -s (no capture) lets the perf test's [PERF] speedup line show in the output.
+    return _run(["python", "-m", "pytest", "-q", "-s"], "run_pytest")
+
+
+def tool_git_status(args: dict) -> str:
+    return _run(["git", "status", "--short"], "git_status") or "(clean)"
+
+
+def tool_git_diff(args: dict) -> str:
+    return _run(["git", "--no-pager", "diff"], "git_diff") or "(no diff)"
+
+
+def tool_finish(args: dict) -> str:
+    """End the session — but only if the suite is green. Runs pytest and raises
+    ToolError on any failure, so a premature finish is rejected and the agent
+    must keep fixing. Requires a non-empty summary of the changes made."""
+    summary = args.get("summary", "")
+    if not isinstance(summary, str) or not summary.strip():
+        raise ToolError("finish requires a non-empty 'summary' of your changes")
+    result = tool_run_pytest({})                 # "exit=<code>\n<pytest output>"
+    if not result.startswith("exit=0"):
+        raise ToolError("cannot finish — the test suite is not green:\n" + result)
+    return f"all tests pass — task complete. {summary}"
+
+
+_TOOLS = {
+    "list_dir": tool_list_dir, "read_file": tool_read_file,
+    "write_file": tool_write_file, "edit_file": tool_edit_file,
+    "find_files": tool_find_files, "grep": tool_grep,
+    "run_python": tool_run_python, "run_pytest": tool_run_pytest,
+    "git_status": tool_git_status, "git_diff": tool_git_diff,
+    "finish": tool_finish,
+}
+TOOL_NAMES = set(_TOOLS)
+
+
+# ── Parse + dispatch ────────────────────────────────────────────────────────
+
+_CALL_RE = re.compile(r"<function=(\w+)>(.*?)</function>", re.S)
+
+
+def parse_tool_calls(text: str):
+    """Extract ``(name, args_dict)`` pairs from model output (grammar-guaranteed
+    shape, so this is a formality). Malformed JSON / unknown tool raises."""
+    calls = []
+    for name, raw in _CALL_RE.findall(text):
+        raw = raw.strip() or "{}"
+        try:
+            args = json.loads(raw)
+        except json.JSONDecodeError as e:
+            raise ToolError(f"{name}: bad JSON args {raw!r}: {e}") from e
+        if name not in TOOL_NAMES:
+            raise ToolError(f"unknown tool {name!r}")
+        calls.append((name, args))
+    return calls
+
+
+def dispatch(name: str, args: dict) -> str:
+    """Execute one registry tool, converting any ToolError into an ``ERROR: ...``
+    string so the agent loop can feed it back instead of crashing."""
+    if name not in _TOOLS:
+        return f"ERROR: unknown tool {name!r}"
+    try:
+        return _TOOLS[name](args)
+    except ToolError as e:
+        return f"ERROR: {e}"
+    except KeyError as e:
+        return f"ERROR: missing argument {e}"
+    except Exception as e:  # pragma: no cover - unexpected
+        return f"ERROR: {type(e).__name__}: {e}"
+
+
+def tests_pass() -> bool:
+    """True iff the workspace pytest suite is fully green (used to auto-detect
+    task completion)."""
+    try:
+        proc = subprocess.run(["python", "-m", "pytest", "-q"], cwd=str(WORKSPACE),
+                              capture_output=True, text=True, timeout=CMD_TIMEOUT_S)
+        return proc.returncode == 0
+    except Exception:
+        return False
+
+
+# ── Workspace maintenance ───────────────────────────────────────────────────
+
+def reset_workspace() -> None:
+    """Restore the workspace to the seed project and (re)init a git repo with an
+    initial commit, so git_status/git_diff reflect the agent's changes."""
+    if WORKSPACE.exists():
+        shutil.rmtree(WORKSPACE)
+    shutil.copytree(SEED, WORKSPACE)
+    env = dict(GIT_AUTHOR_NAME="demo", GIT_AUTHOR_EMAIL="demo@example.com",
+               GIT_COMMITTER_NAME="demo", GIT_COMMITTER_EMAIL="demo@example.com")
+    import os
+    for cmd in (["git", "init", "-q"], ["git", "add", "-A"],
+                ["git", "commit", "-q", "-m", "seed"]):
+        subprocess.run(cmd, cwd=str(WORKSPACE), env={**os.environ, **env},
+                       capture_output=True, text=True)

--- a/demo/coding_agent_large/project_seed/test_topk_filter.py
+++ b/demo/coding_agent_large/project_seed/test_topk_filter.py
@@ -1,0 +1,70 @@
+"""Correctness + performance tests for batched_topk_filter.
+
+Correctness is checked against a slow reference (kept here as ground truth) on
+distinct-valued inputs (no boundary ties). Two tests specifically require the
+numpy optimization: the result must be an ndarray, and a large input must run
+fast — both fail for the pure-Python reference.
+"""
+import time
+
+import numpy as np
+
+from topk_filter import batched_topk_filter
+
+
+def _reference(scores, k):
+    out = []
+    for row in scores:
+        pairs = [(i, x) for i, x in enumerate(row)]
+        pairs.sort(key=lambda p: p[1], reverse=True)
+        keep = set(i for i, _ in pairs[:k])
+        out.append([x if i in keep else float("-inf") for i, x in enumerate(row)])
+    return out
+
+
+def _check(scores, k):
+    got = np.asarray(batched_topk_filter(scores, k), dtype=float)
+    ref = np.asarray(_reference(scores, k), dtype=float)
+    assert got.shape == ref.shape
+    assert np.array_equal(got, ref)
+
+
+def test_basic():
+    _check([[0.1, 0.9, 0.3, 0.7], [5.0, 1.0, 2.0, 4.0]], 2)
+
+
+def test_k_equals_width_keeps_all():
+    got = np.asarray(batched_topk_filter([[3.0, 1.0, 2.0]], 3), dtype=float)
+    assert np.array_equal(got, np.asarray([[3.0, 1.0, 2.0]], dtype=float))
+
+
+def test_random_matches_reference():
+    rng = np.random.default_rng(0)
+    scores = rng.permutation(64 * 200).reshape(64, 200).astype(float)  # distinct
+    for k in (1, 5, 50, 199):
+        _check(scores.tolist(), k)
+
+
+def test_returns_ndarray():
+    out = batched_topk_filter([[1.0, 2.0, 3.0]], 1)
+    assert isinstance(out, np.ndarray), "optimize with numpy: return an ndarray"
+
+
+def test_performance_is_vectorized():
+    rng = np.random.default_rng(1)
+    scores = rng.permutation(150 * 10000).reshape(150, 10000).astype(float)
+
+    t = time.perf_counter()
+    batched_topk_filter(scores, 50)
+    dt = time.perf_counter() - t
+
+    # Same input through the slow reference, so the output reports a speedup.
+    ref_in = scores.tolist()
+    t = time.perf_counter()
+    _reference(ref_in, 50)
+    dt_ref = time.perf_counter() - t
+
+    print(f"\n[PERF] batched_topk_filter {scores.shape} k=50: "
+          f"impl {dt * 1000:7.1f} ms  vs  reference {dt_ref * 1000:7.1f} ms  "
+          f"({dt_ref / dt:5.1f}x speedup)")
+    assert dt < 0.15, f"too slow ({dt:.3f}s) — vectorize with numpy, no Python loops"

--- a/demo/coding_agent_large/project_seed/topk_filter.py
+++ b/demo/coding_agent_large/project_seed/topk_filter.py
@@ -1,0 +1,15 @@
+"""Batched top-k filter: keep each row's top-k scores, set the rest to -inf.
+
+The reference implementation below is correct but slow (pure Python, sorts every
+row). The task is to make it fast with numpy without changing its behavior.
+"""
+
+
+def batched_topk_filter(scores, k):
+    out = []
+    for row in scores:
+        pairs = [(i, x) for i, x in enumerate(row)]
+        pairs.sort(key=lambda p: p[1], reverse=True)
+        keep = set(i for i, _ in pairs[:k])
+        out.append([x if i in keep else float("-inf") for i, x in enumerate(row)])
+    return out

--- a/demo/coding_agent_large/run.py
+++ b/demo/coding_agent_large/run.py
@@ -1,0 +1,331 @@
+"""Large constrained coding-agent demo — XGrammar structural tags + an 11-tool
+sandboxed runtime, driven through the MPK megakernel.
+
+The model REASONS in free text and emits one or more tool calls per turn as
+``<function=NAME>{json args}</function>`` (the ``triggered_tags`` grammar). Each
+turn's calls are executed inside a locked-down workspace and the results are fed
+back, looping until the model calls ``finish`` (or pytest is green). The grammar
+constrains the *shape* of every call — that it names a real tool and its args fit
+the tool's JSON schema; agent_runtime.py independently enforces all filesystem
+and execution safety.
+
+Tools live as JSON files under ``tools/`` (drop in a new file to add a tool — no
+code changes) and are loaded with ``mirage.mpk.create_tools``.
+
+Run it two ways:
+
+    # Live: constrained decoding through the MPK megakernel + Qwen3-8B (default; --model to change)
+    CUDA_VISIBLE_DEVICES=0 python demo/coding_agent_large/run.py
+
+    # Scripted: no GPU/model — drives the SAME sandbox through a fixed trajectory
+    # that solves the task, showing the flow + safety:
+    python demo/coding_agent_large/run.py --scripted
+"""
+
+import argparse
+import json
+import pathlib
+import sys
+import textwrap
+
+HERE = pathlib.Path(__file__).parent
+sys.path.insert(0, str(HERE))          # for `import agent_runtime`
+sys.path.insert(0, "python")           # for `import mirage` when run from repo root
+
+import agent_runtime as R              # noqa: E402
+
+TOOLS_DIR = HERE / "tools"
+MAX_TURNS = 60          # runaway backstop; the real stop is pass-or-context-limit
+
+TASK = ("The workspace has a slow, pure-Python `batched_topk_filter` in "
+        "topk_filter.py (keep each row's top-k scores, set the rest to -inf). "
+        "Optimize it with numpy so the whole test suite — correctness AND speed — "
+        "passes under `python -m pytest`, then call finish. Do not edit the tests.")
+
+SYSTEM = textwrap.dedent("""\
+    You are an autonomous coding agent working inside a sandboxed workspace.
+    Think briefly, then ACT by emitting one or more tool calls, each as
+    <function=NAME>{json args}</function>. You will see every tool's result
+    before your next turn. You MUST follow the guidelines.
+
+    Guidelines:
+      - Explore the files before editing; run the tests to see what fails.
+      - There may be MORE THAN ONE problem — fix every failing test.
+      - edit_file is for SMALL snippets (`old` must match once). To rewrite a
+        whole function or file, use write_file with the full new contents — do
+        not try to edit_file the entire file.
+      - If a call returns an ERROR, change your approach rather than repeating
+        the same call.
+      - ALWAYS call run_pytest immediately after a write_file or edit_file — your
+        very next action must be run_pytest to check the change. Never skip it.
+      - Only after a run_pytest shows ALL tests passing, call finish with a
+        summary of your changes (that ends the session). Never call finish
+        without a preceding run_pytest that passed.""")
+
+
+# ── display (Codex / Claude Code style) ─────────────────────────────────────
+
+_TTY = sys.stdout.isatty()
+def _sgr(code: str) -> str:
+    return code if _TTY else ""
+DIM, BOLD, GREEN, RED, RESET = (_sgr(c) for c in
+    # DIM is an explicit dark gray (256-color) rather than the faint attribute,
+    # so results/chrome read as a darker gray on truecolor terminals.
+    ("\033[38;5;239m", "\033[1m", "\033[32m", "\033[31m", "\033[0m"))
+
+
+def _fmt_args(args: dict, maxv: int = 56) -> str:
+    """Render call args compactly: a single arg as just its value, else key=value."""
+    def show(x):
+        s = x if isinstance(x, str) else json.dumps(x, ensure_ascii=False)
+        s = s.replace("\n", "⏎")
+        return s if len(s) <= maxv else s[:maxv - 1] + "…"
+    if not args:
+        return ""
+    if len(args) == 1:
+        return show(next(iter(args.values())))
+    return ", ".join(f"{k}={show(v)}" for k, v in args.items())
+
+
+def _print_result(result: str, max_lines: int = 6) -> None:
+    """Print a tool result branched under a ⎿ connector, long output truncated."""
+    color = RED if result.startswith("ERROR") else DIM
+    rows = result.splitlines() or ["(ok)"]
+    for i, ln in enumerate(rows[:max_lines]):
+        print(f"  {color}{'⎿' if i == 0 else ' '}{RESET} {DIM}{ln}{RESET}")
+    if len(rows) > max_lines:
+        print(f"    {DIM}… +{len(rows) - max_lines} lines{RESET}")
+
+
+def _print_reasoning(text: str) -> None:
+    """Show the model's free-text reasoning (before the first tool call) as prose."""
+    pre = text.split("<function=")[0].strip()
+    if pre:
+        print()
+        for para in pre.splitlines():
+            print(textwrap.fill(para, width=88) if para.strip() else "")
+
+
+def _print_final_pytest(reason: str = None, turns: int = None) -> bool:
+    """Run the suite one last time and print its full results + the [PERF]
+    performance comparison, with the summary/perf lines highlighted."""
+    out = R.dispatch("run_pytest", {})
+    ok = out.startswith("exit=0")
+    mark = f"{GREEN}✔{RESET}" if ok else f"{RED}■{RESET}"
+    header = reason or ("all tests pass" if ok else "tests still failing")
+    suffix = f"  {DIM}({turns} turns){RESET}" if turns else ""
+    print(f"\n{mark} {BOLD}{header}{RESET}{suffix}")
+    print(f"\n{BOLD}Final test results{RESET}")
+    for ln in out.splitlines():
+        if ln.startswith("exit="):
+            continue
+        if ln.startswith("[PERF]"):
+            c = BOLD + GREEN
+        elif "passed" in ln and "failed" not in ln and "error" not in ln.lower():
+            c = GREEN
+        elif "failed" in ln or "error" in ln.lower():
+            c = RED
+        else:
+            c = DIM
+        print(f"  {c}{ln}{RESET}")
+    return ok
+
+
+def execute_turn(text: str, verbose: bool = True):
+    """Run every tool call in a turn's text. Returns (feedback, done)."""
+    try:
+        calls = R.parse_tool_calls(text)
+    except R.ToolError as e:
+        return f"ERROR: {e}", False
+    if not calls:
+        return "(no tool call emitted — reply with at least one <function=...> call)", False
+    lines, done = [], False
+    for name, args in calls:
+        result = R.dispatch(name, args)      # finish is a real tool: it runs pytest
+        ok = not result.startswith("ERROR")
+        if verbose:                          # ⏺ tool(args)  then  ⎿ result
+            print()                          # line break before each tool call
+            dot = (GREEN if ok else RED) + "⏺" + RESET
+            print(f"{dot} {BOLD}{name}{RESET}({DIM}{_fmt_args(args)}{RESET})")
+            _print_result(result)
+        lines.append(f"[{name}]\n{result}")
+        if name == "finish" and ok:
+            done = True                      # finish succeeded → tests verified green
+            break
+    return "\n".join(lines), done
+
+
+# ── live model driver ───────────────────────────────────────────────────────
+
+def run_live(model: str = "Qwen/Qwen3-14B") -> None:
+    import threading
+    import time
+
+    from mirage.engine import ModelRunner, RunnerConfig
+    from mirage.mpk import create_tools, structured_tools as T
+
+    # Always start from the fresh slow seed so the agent has a real task; its
+    # optimized result persists in the workspace *after* the run (nothing resets
+    # at the end) — reusing a prior run's output would pre-solve the task.
+    R.reset_workspace()
+    tools = create_tools(str(TOOLS_DIR))
+    print(f"{DIM}building {model} megakernel ({len(tools)} tools)…{RESET}")
+
+    CTX = 6144           # per-request context budget (prompt + generation)
+    MIN_GEN = 256        # room a turn needs to reason + emit its calls
+    # Qwen3-8B is the validated single-GPU config for this ModelRunner +
+    # constrained-decoding path (all demo/qwen3 demos use it). Larger dense
+    # variants like Qwen3-14B are registered but NOT validated here — their
+    # shapes hit an SM100 TMA-alignment bug (a split-K linear dim that isn't
+    # 16B-aligned). Qwen3-30B-A3B is smarter but needs the separate multi-GPU
+    # demo path, not this engine. max_num_pages just needs to cover CTX.
+    cfg = RunnerConfig(model=model, vocab_size=153600,
+                       enable_constrained_decoding=True, do_sample=True,
+                       max_num_batched_requests=1, max_num_batched_tokens=8,
+                       max_seq_length=CTX, max_num_pages=32, page_size=4096)
+    runner = ModelRunner(cfg)
+    rt, tok = runner.runtime, runner.tokenizer
+    threading.Thread(target=runner, daemon=True).start()
+    time.sleep(2)
+
+    # After compilation: show the prompt (a clean divider from the build noise),
+    # then start the agent loop.
+    print(f"\n{DIM}model: {model}  ·  {len(tools)} tools: "
+          f"{', '.join(sorted(t['name'] for t in tools))}{RESET}")
+    print(f"\n{BOLD}>{RESET} " + textwrap.fill(TASK, width=86, subsequent_indent="  "))
+    print(f"\n{DIM}{'─' * 72}{RESET}")
+
+    conversation = [
+        {"role": "system", "content": SYSTEM + "\n\n" + T.tools_system_prompt(tools)},
+        {"role": "user", "content": TASK}]
+
+    # Keep going until the tests pass or the conversation no longer fits the
+    # context window; MAX_TURNS is only a runaway backstop.
+    reason, turn = None, 0
+    while True:
+        prompt = tok.apply_chat_template(
+            conversation, tokenize=True, add_generation_prompt=True,
+            enable_thinking=False, return_tensors="pt")[0]
+        used = prompt.shape[0]
+        if used + MIN_GEN >= CTX:
+            reason = f"context limit — prompt is {used}/{CTX} tokens"
+            break
+        if turn >= MAX_TURNS:
+            reason = f"backstop ({MAX_TURNS} turns)"
+            break
+
+        rid = turn
+        rt.set_request_grammar(rid, triggered_tags=tools)
+        rt.submit(rid, prompt)
+        try:
+            row, final = rt.wait_for_request(rid, timeout=300)
+        except TimeoutError:
+            reason = "request timed out"
+            break
+        text = tok.decode(rt.read_tokens_at_row(row, final)[prompt.shape[0]:],
+                          skip_special_tokens=True).strip()
+
+        print(f"\n{DIM}─── turn {turn} · {used}/{CTX} tokens ───{RESET}")
+        _print_reasoning(text)
+        conversation.append({"role": "assistant", "content": text})
+
+        feedback, finished = execute_turn(text)
+        if finished:   # the finish tool itself re-ran pytest and it was green
+            conversation.append({"role": "user", "content": "Tool results:\n" + feedback})
+            reason = "model called finish (verified green by re-running pytest)"
+            break
+        # A rejected finish already returned its ERROR in feedback. If the tests
+        # are green but the model hasn't ended yet, nudge it to finish.
+        if R.tests_pass():
+            feedback += ('\n[note] all tests pass. Call '
+                         '<function=finish>{"summary": "..."}</function> with a '
+                         'summary of the changes you made to end the session.')
+        conversation.append({"role": "user", "content": "Tool results:\n" + feedback})
+        turn += 1
+
+    _print_final_pytest(reason, turn + 1)
+    print(f"\n{DIM}edited file: {R.WORKSPACE / 'topk_filter.py'}{RESET}")
+    rt.shutdown()
+
+
+# ── scripted driver (no GPU/model) ──────────────────────────────────────────
+
+# The numpy solution the scripted run writes (what a good agent would produce).
+SOLUTION = '''"""Batched top-k filter: keep each row's top-k scores, set the rest to -inf."""
+
+import numpy as np
+
+
+def batched_topk_filter(scores, k):
+    scores = np.asarray(scores, dtype=float)
+    n, v = scores.shape
+    if k >= v:
+        return scores.copy()
+    kth = np.partition(scores, v - k, axis=1)[:, v - k]   # k-th largest per row
+    return np.where(scores >= kth[:, None], scores, -np.inf)
+'''
+
+
+def _call(name: str, **args) -> str:
+    return f"<function={name}>{json.dumps(args)}</function>"
+
+
+def run_scripted() -> None:
+    R.reset_workspace()
+    print(f"{DIM}scripted (no model)  ·  {len(R.TOOL_NAMES)} tools  ·  "
+          f"fixed solving trajectory{RESET}")
+    print(f"\n{BOLD}>{RESET} " + textwrap.fill(TASK, width=86, subsequent_indent="  "))
+    print(f"\n{DIM}{'─' * 72}{RESET}")
+
+    trajectory = [
+        _call("list_dir", path="."),
+        _call("read_file", path="topk_filter.py"),
+        _call("read_file", path="test_topk_filter.py"),
+        _call("run_pytest"),                                 # 3 pass, 2 fail
+        _call("write_file", path="topk_filter.py", content=SOLUTION),
+        _call("run_pytest"),                                 # 5 pass
+        _call("git_diff"),
+        _call("finish", summary="Vectorized batched_topk_filter with numpy "
+              "(np.partition + np.where); correctness and speed tests pass."),
+    ]
+
+    for turn, call in enumerate(trajectory):
+        print(f"\n{DIM}─── step {turn} ───{RESET}")
+        _, done = execute_turn(call)
+        if done:
+            break
+
+    print(f"\n{DIM}─── safety: the runtime rejects these even if the grammar were "
+          f"bypassed ───{RESET}")
+    for label, call in [
+        ("absolute path",   _call("read_file", path="/etc/passwd")),
+        ("path traversal",  _call("read_file", path="../../secret.txt")),
+        ("bad extension",   _call("write_file", path="evil.sh", content="rm -rf /")),
+        ("broken python",   _call("write_file", path="broken.py", content="def (")),
+        ("edit the tests",  _call("edit_file", path="test_topk_filter.py",
+                                  old="assert", new="pass  # assert")),
+    ]:
+        print(f"\n{BOLD}{label}{RESET}")
+        execute_turn(call)
+
+    _print_final_pytest()
+    print(f"\n{DIM}edited file: {R.WORKSPACE / 'topk_filter.py'}{RESET}")
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--scripted", action="store_true",
+                   help="run without a model; drive the sandbox directly")
+    p.add_argument("--model", default="Qwen/Qwen3-14B",
+                   help="HF model id (Qwen3 family). Qwen3-8B is the validated "
+                        "single-GPU config; larger dense variants may hit an "
+                        "SM100 TMA-alignment bug.")
+    args = p.parse_args()
+    if args.scripted:
+        run_scripted()
+    else:
+        run_live(args.model)
+
+
+if __name__ == "__main__":
+    main()

--- a/demo/coding_agent_large/tools/edit_file.json
+++ b/demo/coding_agent_large/tools/edit_file.json
@@ -1,0 +1,14 @@
+{
+  "name": "edit_file",
+  "description": "Replace a SMALL snippet: the exact text old with new (old must occur once; trailing-whitespace tolerant). For rewriting a whole function or file, use write_file with the full contents instead. Python results must still parse.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "path": {"type": "string"},
+      "old": {"type": "string"},
+      "new": {"type": "string"}
+    },
+    "required": ["path", "old", "new"],
+    "additionalProperties": false
+  }
+}

--- a/demo/coding_agent_large/tools/find_files.json
+++ b/demo/coding_agent_large/tools/find_files.json
@@ -1,0 +1,12 @@
+{
+  "name": "find_files",
+  "description": "Find files whose path matches a glob pattern such as *.py or test_*.py.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "pattern": {"type": "string"}
+    },
+    "required": ["pattern"],
+    "additionalProperties": false
+  }
+}

--- a/demo/coding_agent_large/tools/finish.json
+++ b/demo/coding_agent_large/tools/finish.json
@@ -1,0 +1,12 @@
+{
+  "name": "finish",
+  "description": "End the session with a summary of the changes you made. This re-runs the full test suite and only succeeds if ALL tests pass; if any fail it returns an error and you must keep fixing.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "summary": {"type": "string"}
+    },
+    "required": ["summary"],
+    "additionalProperties": false
+  }
+}

--- a/demo/coding_agent_large/tools/git_diff.json
+++ b/demo/coding_agent_large/tools/git_diff.json
@@ -1,0 +1,9 @@
+{
+  "name": "git_diff",
+  "description": "Show the unstaged git diff of the workspace against the initial commit.",
+  "parameters": {
+    "type": "object",
+    "properties": {},
+    "additionalProperties": false
+  }
+}

--- a/demo/coding_agent_large/tools/git_status.json
+++ b/demo/coding_agent_large/tools/git_status.json
@@ -1,0 +1,9 @@
+{
+  "name": "git_status",
+  "description": "Show the short git status of the workspace (which files changed).",
+  "parameters": {
+    "type": "object",
+    "properties": {},
+    "additionalProperties": false
+  }
+}

--- a/demo/coding_agent_large/tools/grep.json
+++ b/demo/coding_agent_large/tools/grep.json
@@ -1,0 +1,12 @@
+{
+  "name": "grep",
+  "description": "Search the contents of workspace files for a regular expression; returns matching path:line: text.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "pattern": {"type": "string"}
+    },
+    "required": ["pattern"],
+    "additionalProperties": false
+  }
+}

--- a/demo/coding_agent_large/tools/list_dir.json
+++ b/demo/coding_agent_large/tools/list_dir.json
@@ -1,0 +1,12 @@
+{
+  "name": "list_dir",
+  "description": "List files under a workspace directory, recursively. Use . for the workspace root.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "path": {"type": "string", "description": "directory relative to the workspace root"}
+    },
+    "required": ["path"],
+    "additionalProperties": false
+  }
+}

--- a/demo/coding_agent_large/tools/read_file.json
+++ b/demo/coding_agent_large/tools/read_file.json
@@ -1,0 +1,12 @@
+{
+  "name": "read_file",
+  "description": "Read a text or source file from the workspace and return its contents.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "path": {"type": "string", "description": "workspace-relative path, e.g. src/calculator.py"}
+    },
+    "required": ["path"],
+    "additionalProperties": false
+  }
+}

--- a/demo/coding_agent_large/tools/run_pytest.json
+++ b/demo/coding_agent_large/tools/run_pytest.json
@@ -1,0 +1,9 @@
+{
+  "name": "run_pytest",
+  "description": "Run the pytest suite in the workspace and return a summary of passes and failures.",
+  "parameters": {
+    "type": "object",
+    "properties": {},
+    "additionalProperties": false
+  }
+}

--- a/demo/coding_agent_large/tools/run_python.json
+++ b/demo/coding_agent_large/tools/run_python.json
@@ -1,0 +1,12 @@
+{
+  "name": "run_python",
+  "description": "Run a Python file in the workspace with no shell and capture stdout/stderr.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "path": {"type": "string"}
+    },
+    "required": ["path"],
+    "additionalProperties": false
+  }
+}

--- a/demo/coding_agent_large/tools/write_file.json
+++ b/demo/coding_agent_large/tools/write_file.json
@@ -1,0 +1,13 @@
+{
+  "name": "write_file",
+  "description": "Create or overwrite a file. Python (.py) content must be syntactically valid.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "path": {"type": "string"},
+      "content": {"type": "string"}
+    },
+    "required": ["path", "content"],
+    "additionalProperties": false
+  }
+}

--- a/demo/constrained_decoding/agent_tools.py
+++ b/demo/constrained_decoding/agent_tools.py
@@ -1,0 +1,70 @@
+"""
+Agentic coding assistant (à la Claude Code / Codex) driven by a JSON tool
+registry + XGrammar structural tags. The model reasons in FREE text and, the
+moment it emits ``<function=``, xgrammar switches it to CONSTRAINED — the rest
+must be a schema-valid call to one of the registered tools.
+
+Tools live as JSON files under ``tool_registry/``; add a tool by dropping in a
+new file (registry→structural-tag helpers live in
+``mirage.mpk.structured_tools``). Run:
+
+    CUDA_VISIBLE_DEVICES=1 python demo/constrained_decoding/agent_tools.py
+"""
+
+import json
+import pathlib
+import re
+import sys
+import threading
+import time
+
+sys.path.insert(0, "python")
+import torch  # noqa: E402,F401
+
+from mirage.mpk import create_tools, structured_tools as T  # noqa: E402
+
+HERE = pathlib.Path(__file__).parent
+USER = ("Add a `greet(name)` function to utils.py that prints a greeting, then "
+        "run the test suite with pytest.")
+
+
+def main():
+    from mirage.engine import ModelRunner, RunnerConfig
+
+    # tool JSON files → registry → (optional) routing
+    tools = create_tools(HERE / "tool_registry")
+    tools = T.select_tools(tools, USER)          # placeholder: returns all
+    print(f"registry: {len(tools)} tools ->", [t["name"] for t in tools])
+
+    cfg = RunnerConfig(model="Qwen/Qwen3-8B", vocab_size=153600,
+                       enable_constrained_decoding=True, do_sample=True,
+                       max_num_batched_requests=1, max_num_batched_tokens=8,
+                       max_seq_length=512, max_num_pages=32, page_size=4096)
+    runner = ModelRunner(cfg)              # xgrammar auto-initialized from the flag
+    rt, tok = runner.runtime, runner.tokenizer
+    rt.set_request_grammar(0, triggered_tags=tools)   # free text until <function=, then constrained
+
+    prompt = tok.apply_chat_template(
+        [{"role": "system", "content": T.tools_system_prompt(tools)},
+         {"role": "user", "content": USER}],
+        tokenize=True, add_generation_prompt=True, enable_thinking=False,
+        return_tensors="pt")[0]
+
+    threading.Thread(target=runner, daemon=True).start()
+    time.sleep(2)
+    rt.submit(0, prompt)
+    row, final = rt.wait_for_request(0, timeout=180)
+    out = tok.decode(rt.read_tokens_at_row(row, final)[prompt.shape[0]:],
+                     skip_special_tokens=True)
+
+    print("\n===== GENERATED =====\n" + out)
+    print("\n===== PARSED TOOL CALLS =====")
+    names = {t["name"] for t in tools}
+    for name, args in re.findall(r"<function=(\w+)>(.*?)</function>", out, re.S):
+        parsed = json.loads(args)
+        print(f"  {name}({json.dumps(parsed)})  known_tool={name in names}")
+    rt.shutdown()                          # grammar auto-released on completion
+
+
+if __name__ == "__main__":
+    main()

--- a/demo/constrained_decoding/demo.py
+++ b/demo/constrained_decoding/demo.py
@@ -23,9 +23,11 @@ Examples:
 import argparse
 import importlib.util
 import pathlib
+import re
 
 import torch
 
+HERE = pathlib.Path(__file__).parent
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 STRUCTURED_PY = REPO_ROOT / "python" / "mirage" / "mpk" / "structured.py"
 
@@ -156,33 +158,59 @@ def _is_complete(mgr, spec, out_ids) -> bool:
 
 # ── Real online_pinned serving (usage template) ────────────────────────────
 
-def run_online_pinned(model: str, vocab_size: int, schema: str):
+def run_online_pinned(model: str, vocab_size: int, sample: bool, tool_call: bool):
     """The real serving path. The Qwen3 builder inserts
     ``apply_token_bitmask_layer`` before argmax when
     ``enable_constrained_decoding=True``.  ``vocab_size`` must be the *padded*
-    logit width the masking task sees (153600 for Qwen3)."""
-    from mirage.engine import ModelRunner, RunnerConfig  # noqa: F401
+    logit width the masking task sees (153600 for Qwen3).
+
+    With ``tool_call`` a structural tag is used: the model generates FREE
+    (unconstrained) text and, the moment it emits the trigger ``<function=``,
+    xgrammar switches it to CONSTRAINED — the rest must be a schema-valid call to
+    one of the tools loaded from ``tool_registry/`` (the ONLY tools the model may
+    call). Otherwise a bounded-integer JSON schema is enforced.
+    """
+    import json
+    import threading
+    from mirage.engine import ModelRunner, RunnerConfig
 
     cfg = RunnerConfig(model=model, vocab_size=vocab_size,
-                       enable_constrained_decoding=True,
+                       enable_constrained_decoding=True, do_sample=sample,
                        max_num_batched_requests=1, max_seq_length=512)
-    runner = ModelRunner(cfg)
-    rt = runner.runtime
-    rt.init_xgrammar(runner.tokenizer, cfg.vocab_size)
+    runner = ModelRunner(cfg)              # xgrammar auto-initialized from the flag
+    rt, tok = runner.runtime, runner.tokenizer
 
-    rid = 0
-    rt.set_request_grammar(rid, json_schema=schema)
+    if tool_call:
+        from mirage.mpk import create_tools, structured_tools as T
+        tools = create_tools(HERE / "tool_registry")   # only the registry tools
+        names = {t["name"] for t in tools}
+        rt.set_request_grammar(0, triggered_tags=tools)
+        print(f"registry: {len(tools)} tools ->", sorted(names))
+        msgs = [{"role": "system", "content": T.tools_system_prompt(tools)},
+                {"role": "user", "content": "Show me the git status of the repo."}]
+        prompt = tok.apply_chat_template(msgs, tokenize=True, add_generation_prompt=True,
+                                         enable_thinking=False, return_tensors="pt")[0]
+    else:
+        schema = ('{"type":"object","properties":{"id":'
+                  '{"type":"integer","minimum":0,"maximum":999999}},"required":["id"]}')
+        rt.set_request_grammar(0, json_schema=schema, any_whitespace=False)
+        prompt = tok("Give me a JSON object: ", return_tensors="pt").input_ids[0]
 
-    import threading
     threading.Thread(target=runner, daemon=True).start()  # drives mpk()
-
-    prompt = runner.tokenizer("Give me a JSON object: ", return_tensors="pt").input_ids[0]
-    rt.submit(rid, prompt)
-    buffer_row, final_step = rt.wait_for_request(rid, timeout=120)
-    ids = rt.read_tokens_at_row(buffer_row, final_step)
-    print(runner.tokenizer.decode(ids, skip_special_tokens=True))
-    rt.release_grammar(rid)
-    rt.shutdown()
+    rt.submit(0, prompt)
+    row, final = rt.wait_for_request(0, timeout=120)
+    out = tok.decode(rt.read_tokens_at_row(row, final)[prompt.shape[0]:],
+                     skip_special_tokens=True)
+    print("OUTPUT:", repr(out))
+    if tool_call:
+        calls = re.findall(r"<function=(\w+)>(.*?)</function>", out, re.S)
+        print("free text before call:",
+              repr(out[:out.index("<function=")]) if calls else "(none)")
+        for name, args in calls:
+            print(f"tool call: {name}({json.loads(args)})  known_tool={name in names}")
+        if not calls:
+            print("tool call: (no call emitted)")
+    rt.shutdown()                          # grammar auto-released on completion
 
 
 def main():
@@ -195,12 +223,17 @@ def main():
                    help="simulated-mode grammar")
     p.add_argument("--max-tokens", type=int, default=32)
     p.add_argument("--seed", type=int, default=0)
+    p.add_argument("--sample", action="store_true",
+                   help="sample (Gumbel-max) instead of greedy argmax")
+    p.add_argument("--structural-tag", action="store_true",
+                   help="tool-call structural tag: free text until <function=, "
+                        "then schema-constrained (unconstrained→constrained switch)")
     args = p.parse_args()
 
     if args.model is not None:
         assert args.vocab_size is not None, "--vocab-size is required with --model"
-        schema = '{"type":"object","properties":{"id":{"type":"integer"}},"required":["id"]}'
-        run_online_pinned(args.model, args.vocab_size, schema)
+        run_online_pinned(args.model, args.vocab_size, args.sample,
+                          args.structural_tag)
     else:
         run_simulate(args.grammar, args.max_tokens, args.seed)
 

--- a/demo/constrained_decoding/demo.py
+++ b/demo/constrained_decoding/demo.py
@@ -1,0 +1,209 @@
+"""
+Constrained decoding (xgrammar) demo for MPK.
+
+Two modes:
+
+  --simulate   (default) A self-contained decode loop that drives the real
+               StructuredGenerationManager over synthetic logits, masking each
+               step exactly as the GPU apply_token_bitmask task does, and shows
+               that every generated token is grammar-valid.  Runs anywhere with
+               xgrammar installed — no model, no megakernel.
+
+  --model NAME The real online_pinned serving path (requires the model + a
+               megakernel built with apply_token_bitmask_layer wired in before
+               the argmax/sampling layer).  Shown as the usage template; see the
+               NOTE in run_online_pinned().
+
+Examples:
+  python demo.py                       # simulated JSON-grammar generation
+  python demo.py --grammar email       # simulated regex (email) generation
+  python demo.py --model Qwen/Qwen3-8B # real serving (needs model + wiring)
+"""
+
+import argparse
+import importlib.util
+import pathlib
+
+import torch
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+STRUCTURED_PY = REPO_ROOT / "python" / "mirage" / "mpk" / "structured.py"
+
+
+def _load_structured():
+    spec = importlib.util.spec_from_file_location("mpk_structured", STRUCTURED_PY)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.StructuredGenerationManager
+
+
+# ── Simulated decode loop ──────────────────────────────────────────────────
+#
+# A tiny character-level "model": the vocab is single characters and the
+# "logits" are random, so the ONLY thing keeping the output well-formed is the
+# grammar mask.  This drives the actual StructuredGenerationManager and applies
+# the mask the same way apply_token_bitmask_sm100.cuh does (allowed → keep,
+# disallowed → -inf), then greedily samples.
+
+def _char_vocab():
+    # printable chars sufficient for small JSON / email grammars
+    chars = list(' \t\n{}[]":,.@-_0123456789'
+                 'abcdefghijklmnopqrstuvwxyz'
+                 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+                 'truefalsn')  # ensure true/false/null letters present
+    # de-dup, stable order
+    seen, vocab = set(), []
+    for c in chars:
+        if c not in seen:
+            seen.add(c)
+            vocab.append(c)
+    return vocab
+
+
+def run_simulate(grammar_kind: str, max_tokens: int, seed: int):
+    import xgrammar as xgr
+
+    StructuredGenerationManager = _load_structured()
+    torch.manual_seed(seed)
+
+    vocab = _char_vocab()
+    V = len(vocab)
+    words = (V + 31) // 32
+    ti = xgr.TokenizerInfo(vocab, vocab_type=xgr.VocabType.RAW, vocab_size=V)
+
+    if grammar_kind == "email":
+        spec = dict(regex=r"[a-z0-9_]+@[a-z]+\.[a-z]+")
+        desc = "regex e-mail"
+    else:
+        spec = dict(ebnf=r'''root   ::= "{" ws "\"id\"" ws ":" ws number ws "}"
+number ::= [0-9]+
+ws     ::= [ ]*''')
+        desc = "EBNF json-ish object"
+
+    # Mock pinned buffers (CPU tensors == page-locked memory in the real path).
+    n_req, max_seq = 1, max_tokens + 8
+    token_bitmask = torch.full((n_req, words), -1, dtype=torch.int32)
+    mask_seq = torch.zeros(n_req, dtype=torch.int32)
+    flag = torch.zeros(1, dtype=torch.int32)
+    tokens = torch.zeros(n_req, max_seq, dtype=torch.int64)
+    pinned_step = torch.zeros(n_req, dtype=torch.int32)
+    row_map = {0: 0}
+
+    mgr = StructuredGenerationManager(
+        token_bitmask=token_bitmask, mask_seq=mask_seq, constrained_flag=flag,
+        tokens=tokens, pinned_step=pinned_step,
+        find_row_for_rid=lambda rid: row_map.get(rid, -1),
+    )
+    mgr.init_xgrammar(tokenizer_info=ti, vocab_size=V)
+    mgr.set_request_grammar(0, **spec)
+
+    print(f"grammar: {desc}")
+    print(f"vocab size: {V}, constrained_flag={flag[0].item()}")
+
+    row = 0
+    out_ids = []
+    for s in range(max_tokens):
+        pinned_step[row] = s
+        mgr.tick()  # host: accept prev token, fill mask for step s, publish seq
+
+        # device side: a random "logit" vector, masked exactly like the kernel.
+        logits = torch.randn(V)
+        if flag[0].item() == 1 and mask_seq[row].item() >= s:
+            row_mask = token_bitmask[row]
+            allowed = torch.tensor(
+                [bool((row_mask[i // 32].item() >> (i % 32)) & 1) for i in range(V)]
+            )
+            logits = torch.where(allowed, logits, torch.full_like(logits, float("-inf")))
+
+        tok = int(torch.argmax(logits).item())
+        tokens[row, s] = tok
+        out_ids.append(tok)
+
+        # stop if the grammar is satisfied (the matcher accepts this token first
+        # inside the next tick; check terminal by peeking a fork)
+        text = "".join(vocab[t] for t in out_ids)
+        if mgr._matchers.get(row) is None:
+            break
+        # crude termination: a fresh matcher replay tells us if we're complete
+        if _is_complete(mgr, spec, out_ids):
+            break
+
+    text = "".join(vocab[t] for t in out_ids)
+    print(f"generated ({len(out_ids)} tokens): {text!r}")
+    if grammar_kind != "email":
+        import json
+        try:
+            json.loads(text)
+            print("✓ output parses as JSON")
+        except Exception as e:
+            print(f"(note) JSON parse: {e}")
+    return text
+
+
+def _is_complete(mgr, spec, out_ids) -> bool:
+    """Replay the token sequence on a fresh matcher and report completion."""
+    import xgrammar as xgr
+    if "regex" in spec:
+        cg = mgr._compiler.compile_regex(spec["regex"])
+    else:
+        cg = mgr._compiler.compile_grammar(spec["ebnf"])
+    m = xgr.GrammarMatcher(cg)
+    for t in out_ids:
+        if not m.accept_token(t):
+            return True  # rejected → can't continue; treat as done
+    return m.is_terminated()
+
+
+# ── Real online_pinned serving (usage template) ────────────────────────────
+
+def run_online_pinned(model: str, vocab_size: int, schema: str):
+    """The real serving path. The Qwen3 builder inserts
+    ``apply_token_bitmask_layer`` before argmax when
+    ``enable_constrained_decoding=True``.  ``vocab_size`` must be the *padded*
+    logit width the masking task sees (153600 for Qwen3)."""
+    from mirage.engine import ModelRunner, RunnerConfig  # noqa: F401
+
+    cfg = RunnerConfig(model=model, vocab_size=vocab_size,
+                       enable_constrained_decoding=True,
+                       max_num_batched_requests=1, max_seq_length=512)
+    runner = ModelRunner(cfg)
+    rt = runner.runtime
+    rt.init_xgrammar(runner.tokenizer, cfg.vocab_size)
+
+    rid = 0
+    rt.set_request_grammar(rid, json_schema=schema)
+
+    import threading
+    threading.Thread(target=runner, daemon=True).start()  # drives mpk()
+
+    prompt = runner.tokenizer("Give me a JSON object: ", return_tensors="pt").input_ids[0]
+    rt.submit(rid, prompt)
+    buffer_row, final_step = rt.wait_for_request(rid, timeout=120)
+    ids = rt.read_tokens_at_row(buffer_row, final_step)
+    print(runner.tokenizer.decode(ids, skip_special_tokens=True))
+    rt.release_grammar(rid)
+    rt.shutdown()
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--model", default=None,
+                   help="HF model name → real online_pinned path (needs wiring)")
+    p.add_argument("--vocab-size", type=int, default=None,
+                   help="model logit dim (required with --model)")
+    p.add_argument("--grammar", choices=["json", "email"], default="json",
+                   help="simulated-mode grammar")
+    p.add_argument("--max-tokens", type=int, default=32)
+    p.add_argument("--seed", type=int, default=0)
+    args = p.parse_args()
+
+    if args.model is not None:
+        assert args.vocab_size is not None, "--vocab-size is required with --model"
+        schema = '{"type":"object","properties":{"id":{"type":"integer"}},"required":["id"]}'
+        run_online_pinned(args.model, args.vocab_size, schema)
+    else:
+        run_simulate(args.grammar, args.max_tokens, args.seed)
+
+
+if __name__ == "__main__":
+    main()

--- a/demo/constrained_decoding/tool_registry/fs/list_dir.json
+++ b/demo/constrained_decoding/tool_registry/fs/list_dir.json
@@ -1,0 +1,16 @@
+{
+  "name": "list_dir",
+  "description": "List the entries of a directory.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "path": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "path"
+    ],
+    "additionalProperties": false
+  }
+}

--- a/demo/constrained_decoding/tool_registry/fs/read_file.json
+++ b/demo/constrained_decoding/tool_registry/fs/read_file.json
@@ -1,0 +1,17 @@
+{
+  "name": "read_file",
+  "description": "Read the full contents of a file.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "path": {
+        "type": "string",
+        "description": "File path to read."
+      }
+    },
+    "required": [
+      "path"
+    ],
+    "additionalProperties": false
+  }
+}

--- a/demo/constrained_decoding/tool_registry/fs/write_file.json
+++ b/demo/constrained_decoding/tool_registry/fs/write_file.json
@@ -1,0 +1,20 @@
+{
+  "name": "write_file",
+  "description": "Create or overwrite a file with the given content.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "path": {
+        "type": "string"
+      },
+      "content": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "path",
+      "content"
+    ],
+    "additionalProperties": false
+  }
+}

--- a/demo/constrained_decoding/tool_registry/git/git_apply_patch.json
+++ b/demo/constrained_decoding/tool_registry/git/git_apply_patch.json
@@ -1,0 +1,16 @@
+{
+  "name": "git_apply_patch",
+  "description": "Apply a unified-diff patch to the repo.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "patch": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "patch"
+    ],
+    "additionalProperties": false
+  }
+}

--- a/demo/constrained_decoding/tool_registry/git/git_diff.json
+++ b/demo/constrained_decoding/tool_registry/git/git_diff.json
@@ -1,0 +1,14 @@
+{
+  "name": "git_diff",
+  "description": "Show a git diff, optionally scoped to a path.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "path": {
+        "type": "string"
+      }
+    },
+    "required": [],
+    "additionalProperties": false
+  }
+}

--- a/demo/constrained_decoding/tool_registry/git/git_status.json
+++ b/demo/constrained_decoding/tool_registry/git/git_status.json
@@ -1,0 +1,10 @@
+{
+  "name": "git_status",
+  "description": "Show the git working-tree status.",
+  "parameters": {
+    "type": "object",
+    "properties": {},
+    "required": [],
+    "additionalProperties": false
+  }
+}

--- a/demo/constrained_decoding/tool_registry/search/grep.json
+++ b/demo/constrained_decoding/tool_registry/search/grep.json
@@ -1,0 +1,19 @@
+{
+  "name": "grep",
+  "description": "Search for a regex pattern within a path.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "pattern": {
+        "type": "string"
+      },
+      "path": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "pattern"
+    ],
+    "additionalProperties": false
+  }
+}

--- a/demo/constrained_decoding/tool_registry/search/ripgrep.json
+++ b/demo/constrained_decoding/tool_registry/search/ripgrep.json
@@ -1,0 +1,22 @@
+{
+  "name": "ripgrep",
+  "description": "Fast recursive search (ripgrep) with an optional glob.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "pattern": {
+        "type": "string"
+      },
+      "path": {
+        "type": "string"
+      },
+      "glob": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "pattern"
+    ],
+    "additionalProperties": false
+  }
+}

--- a/demo/constrained_decoding/tool_registry/shell/run_command.json
+++ b/demo/constrained_decoding/tool_registry/shell/run_command.json
@@ -1,0 +1,16 @@
+{
+  "name": "run_command",
+  "description": "Run a shell command and return its output.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "command": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "command"
+    ],
+    "additionalProperties": false
+  }
+}

--- a/include/mirage/kernel/task_register.h
+++ b/include/mirage/kernel/task_register.h
@@ -103,6 +103,8 @@ public:
                                         std::vector<int> const &params);
   int register_sampling_sm100_task(threadblock::Graph const &bgraph,
                                    std::vector<int> const &params);
+  int register_apply_token_bitmask_sm100_task(threadblock::Graph const &bgraph,
+                                              std::vector<int> const &params);
   int register_tensor_init_task(threadblock::Graph const &bgraph,
                                 std::vector<int> const &params);
   int register_elementwise_add_sm100_task(threadblock::Graph const &bgraph,

--- a/include/mirage/persistent_kernel/persistent_kernel.cuh
+++ b/include/mirage/persistent_kernel/persistent_kernel.cuh
@@ -618,7 +618,12 @@ __device__ __forceinline__ bool
     }
     config.prompt_length[row] = prompt_len;
     config.step[row] = initial_step;
-    // Let CPU discover which row this rid is on by scanning pinned_rid_at_row.
+    // Reset per-row CPU state before publishing the rid so a recycled row never
+    // exposes the previous occupant's progress/mask. mask_seq is set below the
+    // first step so the masking task waits for this request's fresh mask.
+    st_release_sys_i32(&config.pinned_step[row], (int32_t)initial_step);
+    st_release_sys_i32(&config.pinned_mask_seq[row], (int32_t)(initial_step - 1));
+    // CPU discovers the row by scanning pinned_rid_at_row.
     config.pinned_rid_at_row[row] = (int32_t)new_rid;
 
     // Clear the ring slot so CPU can reuse it.

--- a/include/mirage/persistent_kernel/persistent_kernel.cuh
+++ b/include/mirage/persistent_kernel/persistent_kernel.cuh
@@ -1450,6 +1450,9 @@ static std::map<std::string, void *> global_model_tensors;
 // meta_tensors[20]: pinned_step
 // meta_tensors[21]: pinned_inbox_tokens
 // meta_tensors[22]: pinned_rid_at_row
+// meta_tensors[23]: pinned_token_bitmask     (constrained decoding)
+// meta_tensors[24]: pinned_mask_seq          (constrained decoding)
+// meta_tensors[25]: pinned_constrained_flag  (constrained decoding)
 
 extern "C" void init_request_resources() {
   init_kernel<<<dim3(1, 1, 1), dim3(INIT_NUM_THREADS, 1, 1)>>>(
@@ -1480,7 +1483,7 @@ extern "C" void
   // meta_tensors[11..22]: pinned ring pointers (MODE_ONLINE_PINNED only,
   //   passed as CPU-side void* from Python's pinned tensors)
 #if defined(MODE_ONLINE_PINNED)
-  assert(meta_tensors.size() == 23);
+  assert(meta_tensors.size() == 26);
 #else
   assert(meta_tensors.size() == 11);
 #endif
@@ -1525,6 +1528,12 @@ extern "C" void
       static_cast<int64_t *>(meta_tensors[21]);
   global_runtime_config.pinned_rid_at_row =
       static_cast<int32_t *>(meta_tensors[22]);
+  global_runtime_config.pinned_token_bitmask =
+      static_cast<int32_t *>(meta_tensors[23]);
+  global_runtime_config.pinned_mask_seq =
+      static_cast<int32_t volatile *>(meta_tensors[24]);
+  global_runtime_config.pinned_constrained_flag =
+      static_cast<int32_t volatile *>(meta_tensors[25]);
 #endif
   global_runtime_config.num_workers = num_workers;
   global_runtime_config.num_local_schedulers = num_local_schedulers;

--- a/include/mirage/persistent_kernel/persistent_kernel.cuh
+++ b/include/mirage/persistent_kernel/persistent_kernel.cuh
@@ -622,7 +622,8 @@ __device__ __forceinline__ bool
     // exposes the previous occupant's progress/mask. mask_seq is set below the
     // first step so the masking task waits for this request's fresh mask.
     st_release_sys_i32(&config.pinned_step[row], (int32_t)initial_step);
-    st_release_sys_i32(&config.pinned_mask_seq[row], (int32_t)(initial_step - 1));
+    st_release_sys_i32(&config.pinned_mask_seq[row],
+                       (int32_t)(initial_step - 1));
     // CPU discovers the row by scanning pinned_rid_at_row.
     config.pinned_rid_at_row[row] = (int32_t)new_rid;
 

--- a/include/mirage/persistent_kernel/runtime_header.h
+++ b/include/mirage/persistent_kernel/runtime_header.h
@@ -160,6 +160,9 @@ enum TaskType {
   TASK_LINEAR_FP8_SM100 = 276,
   TASK_LINEAR_FP8_WITH_RESIDUAL_SM100 = 277,
   TASK_MLA_KV_GATHER_SM100 = 278,
+  // Constrained decoding: mask logits in place with a CPU-produced token
+  // bitmask (xgrammar). Flag-gated; no-op when constrained decoding is off.
+  TASK_APPLY_TOKEN_BITMASK_SM100 = 279,
   TASK_MOE_TOPK_SIGMOID_SM100 = 280,
   TASK_ELEMENTWISE_ADD_SM100 = 281,
   TASK_SOFTMAX_GATHER_SM100 = 282,
@@ -393,6 +396,18 @@ struct RuntimeConfig {
   // allocating a buffer row so CPU can discover which row its request is
   // on by scanning rows, then poll pinned_step[row] for per-step streaming.
   int32_t *pinned_rid_at_row; // [total_inflight], pinned
+  // ── Constrained decoding (xgrammar) ─────────────────────────────────────
+  // CPU writes a packed token bitmask (bit j set ⇒ token j allowed) per
+  // buffer row, then publishes pinned_mask_seq[row] = step it is valid for.
+  // The apply_token_bitmask task waits (ld.acquire.sys) until the published
+  // seq matches the row's current decode step, then masks logits in place.
+  // All three are pinned (CPU-writable, GPU-readable). When
+  // pinned_constrained_flag[0] == 0 the masking task is a no-op (unconstrained
+  // decode pays nothing); switching the flag at runtime toggles constrained
+  // vs unconstrained decoding on the same compiled kernel.
+  int32_t *pinned_token_bitmask; // [total_inflight * ceil(vocab/32)], pinned
+  int32_t volatile *pinned_mask_seq; // [total_inflight], pinned
+  int32_t volatile *pinned_constrained_flag; // [1], pinned: 0=off, 1=on
   // Running queue rid tracking: request_rids[i] stores the original rid
   // for active batch slot i (GPU device memory).
   int *request_rids; // [MPK_MAX_NUM_BATCHED_REQUESTS]

--- a/include/mirage/persistent_kernel/runtime_header.h
+++ b/include/mirage/persistent_kernel/runtime_header.h
@@ -406,7 +406,7 @@ struct RuntimeConfig {
   // decode pays nothing); switching the flag at runtime toggles constrained
   // vs unconstrained decoding on the same compiled kernel.
   int32_t *pinned_token_bitmask; // [total_inflight * ceil(vocab/32)], pinned
-  int32_t volatile *pinned_mask_seq; // [total_inflight], pinned
+  int32_t volatile *pinned_mask_seq;         // [total_inflight], pinned
   int32_t volatile *pinned_constrained_flag; // [1], pinned: 0=off, 1=on
   // Running queue rid tracking: request_rids[i] stores the original rid
   // for active batch slot i (GPU device memory).

--- a/include/mirage/persistent_kernel/tasks/blackwell/apply_token_bitmask_sm100.cuh
+++ b/include/mirage/persistent_kernel/tasks/blackwell/apply_token_bitmask_sm100.cuh
@@ -1,0 +1,106 @@
+/* Copyright 2025 CMU
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+#include <math.h>
+
+namespace kernel {
+
+// System-scope acquire load (pairs with the CPU's release store on mask_seq).
+// Implemented inline so this header has no dependency on mpk_atoms.cuh include
+// order.
+static __device__ __forceinline__ int32_t
+    apply_mask_ld_acquire_sys_i32(int32_t volatile const *addr) {
+  int32_t v;
+  asm volatile("ld.acquire.sys.b32 %0, [%1];" : "=r"(v) : "l"(addr));
+  return v;
+}
+
+// Constrained-decoding logit masking (xgrammar).
+//
+// in_ptr     : [batch_size, vocab_size], bf16, the raw logits (read-only).
+// out_ptr    : [batch_size, vocab_size], bf16, the masked logits (written).
+//              Distinct from in_ptr — downstream argmax/sampling reads out_ptr.
+//              (A distinct output, rather than in-place, keeps the MPK
+//              producer/consumer event wiring unambiguous: this task is the
+//              sole producer of out_ptr.)
+// bitmask    : [total_inflight, bitmask_words] packed int32, bit j set ⇒ token
+//              j allowed.  Indexed by buffer row (not batch position).
+// mask_seq   : [total_inflight] int32, pinned. The CPU publishes
+//              mask_seq[row] = decode step the row's bitmask is valid for.
+// flag       : [1] int32, pinned. 0 ⇒ unconstrained → plain copy (no wait, no
+//              bit tests); 1 ⇒ wait for the CPU mask and apply it.
+// request_ids: [batch_size] int, maps batch position → buffer row (-1 = idle).
+// step       : [total_inflight] int, the row's current decode step (the step
+//              whose logits we are about to sample). The task waits until the
+//              CPU has published a mask for at least this step.
+//
+// Contract: when flag==1 the CPU MUST publish a valid bitmask + mask_seq for
+// every active row each step (an all-ones mask for rows with no grammar).
+template <typename T, int BATCH_SIZE>
+__device__ __forceinline__ void apply_token_bitmask_sm100_kernel(
+    void const *__restrict__ in_ptr,
+    void *__restrict__ out_ptr,
+    int32_t const *__restrict__ bitmask,
+    int32_t volatile const *__restrict__ mask_seq,
+    int32_t volatile const *__restrict__ flag,
+    int const *__restrict__ request_ids,
+    int const *__restrict__ step,
+    int vocab_size,
+    int bitmask_words,
+    int num_active_tokens) {
+  T const *__restrict__ in = static_cast<T const *>(in_ptr);
+  T *__restrict__ out = static_cast<T *>(out_ptr);
+  T const neg_inf = static_cast<T>(-INFINITY);
+
+  // The masking task is present in every compiled graph; the runtime flag is
+  // read once and toggles between a plain copy (unconstrained) and a masked
+  // copy (constrained), so flipping it switches decoding modes with no
+  // recompile.
+  bool const constrained = (apply_mask_ld_acquire_sys_i32(flag) != 0);
+
+  for (int b = 0; b < num_active_tokens; b++) {
+    int row = request_ids[b];
+    bool const do_mask = constrained && (row >= 0);
+    int32_t const *__restrict__ row_mask = nullptr;
+
+    if (do_mask) {
+      // Wait until the CPU has produced this row's mask for the current step.
+      // mask_seq increases monotonically (one mask per decode step, in lockstep
+      // with token production), so ">= target" is the catch-up condition.
+      if (threadIdx.x == 0) {
+        int target = step[row];
+        while (apply_mask_ld_acquire_sys_i32(&mask_seq[row]) < target) {
+          __nanosleep(20);
+        }
+      }
+      __syncthreads();
+      row_mask = bitmask + static_cast<size_t>(row) * bitmask_words;
+    }
+
+    size_t const base = static_cast<size_t>(b) * vocab_size;
+    for (int v = threadIdx.x; v < vocab_size; v += blockDim.x) {
+      T val = in[base + v];
+      if (do_mask && (((row_mask[v >> 5] >> (v & 31)) & 1) == 0)) {
+        val = neg_inf; // disallowed token ⇒ zero probability downstream
+      }
+      out[base + v] = val;
+    }
+    __syncthreads();
+  }
+}
+
+} // namespace kernel

--- a/include/mirage/persistent_kernel/tasks/blackwell/apply_token_bitmask_sm100.cuh
+++ b/include/mirage/persistent_kernel/tasks/blackwell/apply_token_bitmask_sm100.cuh
@@ -21,7 +21,7 @@ namespace kernel {
 
 // System-scope acquire load, pairing with the CPU's release store on mask_seq.
 static __device__ __forceinline__ int32_t
-    apply_mask_ld_acquire_sys_i32(int32_t volatile const *addr) {
+    apply_mask_ld_acquire_sys_i32(int32_t const volatile *addr) {
   int32_t v;
   asm volatile("ld.acquire.sys.b32 %0, [%1];" : "=r"(v) : "l"(addr));
   return v;
@@ -36,12 +36,12 @@ template <typename T, int BATCH_SIZE>
 __device__ __forceinline__ void apply_token_bitmask_sm100_kernel(
     void const *__restrict__ in_ptr,
     void *__restrict__ out_ptr,
-    int32_t const *__restrict__ bitmask,        // [total_inflight, bitmask_words]
-    int32_t volatile const *__restrict__ mask_seq,  // [total_inflight], pinned
-    int32_t volatile const *__restrict__ flag,       // [1], pinned: 0=off
-    int const *__restrict__ request_ids,        // [num_requests], slot -> row
-    int const *__restrict__ step,               // [total_inflight]
-    int const *__restrict__ qo_indptr,          // [num_requests+1]
+    int32_t const *__restrict__ bitmask, // [total_inflight, bitmask_words]
+    int32_t const volatile *__restrict__ mask_seq, // [total_inflight], pinned
+    int32_t const volatile *__restrict__ flag,     // [1], pinned: 0=off
+    int const *__restrict__ request_ids, // [num_requests], slot -> row
+    int const *__restrict__ step,        // [total_inflight]
+    int const *__restrict__ qo_indptr,   // [num_requests+1]
     int vocab_size,
     int bitmask_words,
     int num_requests) {
@@ -49,8 +49,8 @@ __device__ __forceinline__ void apply_token_bitmask_sm100_kernel(
   T *__restrict__ out = static_cast<T *>(out_ptr);
   T const neg_inf = static_cast<T>(-INFINITY);
 
-  for (size_t i = threadIdx.x;
-       i < static_cast<size_t>(BATCH_SIZE) * vocab_size; i += blockDim.x) {
+  for (size_t i = threadIdx.x; i < static_cast<size_t>(BATCH_SIZE) * vocab_size;
+       i += blockDim.x) {
     out[i] = in[i];
   }
   __syncthreads();

--- a/include/mirage/persistent_kernel/tasks/blackwell/apply_token_bitmask_sm100.cuh
+++ b/include/mirage/persistent_kernel/tasks/blackwell/apply_token_bitmask_sm100.cuh
@@ -19,9 +19,7 @@
 
 namespace kernel {
 
-// System-scope acquire load (pairs with the CPU's release store on mask_seq).
-// Implemented inline so this header has no dependency on mpk_atoms.cuh include
-// order.
+// System-scope acquire load, pairing with the CPU's release store on mask_seq.
 static __device__ __forceinline__ int32_t
     apply_mask_ld_acquire_sys_i32(int32_t volatile const *addr) {
   int32_t v;
@@ -29,75 +27,57 @@ static __device__ __forceinline__ int32_t
   return v;
 }
 
-// Constrained-decoding logit masking (xgrammar).
-//
-// in_ptr     : [batch_size, vocab_size], bf16, the raw logits (read-only).
-// out_ptr    : [batch_size, vocab_size], bf16, the masked logits (written).
-//              Distinct from in_ptr — downstream argmax/sampling reads out_ptr.
-//              (A distinct output, rather than in-place, keeps the MPK
-//              producer/consumer event wiring unambiguous: this task is the
-//              sole producer of out_ptr.)
-// bitmask    : [total_inflight, bitmask_words] packed int32, bit j set ⇒ token
-//              j allowed.  Indexed by buffer row (not batch position).
-// mask_seq   : [total_inflight] int32, pinned. The CPU publishes
-//              mask_seq[row] = decode step the row's bitmask is valid for.
-// flag       : [1] int32, pinned. 0 ⇒ unconstrained → plain copy (no wait, no
-//              bit tests); 1 ⇒ wait for the CPU mask and apply it.
-// request_ids: [batch_size] int, maps batch position → buffer row (-1 = idle).
-// step       : [total_inflight] int, the row's current decode step (the step
-//              whose logits we are about to sample). The task waits until the
-//              CPU has published a mask for at least this step.
-//
-// Contract: when flag==1 the CPU MUST publish a valid bitmask + mask_seq for
-// every active row each step (an all-ones mask for rows with no grammar).
+// Constrained decoding: copy [BATCH_SIZE, vocab] logits to out, then (when flag
+// is set) mask each active request's next-token row to xgrammar's bitmask.
+// Looping over requests keeps request_ids/qo_indptr (sized by request count) in
+// bounds; request b's next-token logits are row qo_indptr[b+1]-1. The CPU
+// publishes mask_seq[row]=step and the bitmask before that step is decoded.
 template <typename T, int BATCH_SIZE>
 __device__ __forceinline__ void apply_token_bitmask_sm100_kernel(
     void const *__restrict__ in_ptr,
     void *__restrict__ out_ptr,
-    int32_t const *__restrict__ bitmask,
-    int32_t volatile const *__restrict__ mask_seq,
-    int32_t volatile const *__restrict__ flag,
-    int const *__restrict__ request_ids,
-    int const *__restrict__ step,
+    int32_t const *__restrict__ bitmask,        // [total_inflight, bitmask_words]
+    int32_t volatile const *__restrict__ mask_seq,  // [total_inflight], pinned
+    int32_t volatile const *__restrict__ flag,       // [1], pinned: 0=off
+    int const *__restrict__ request_ids,        // [num_requests], slot -> row
+    int const *__restrict__ step,               // [total_inflight]
+    int const *__restrict__ qo_indptr,          // [num_requests+1]
     int vocab_size,
     int bitmask_words,
-    int num_active_tokens) {
+    int num_requests) {
   T const *__restrict__ in = static_cast<T const *>(in_ptr);
   T *__restrict__ out = static_cast<T *>(out_ptr);
   T const neg_inf = static_cast<T>(-INFINITY);
 
-  // The masking task is present in every compiled graph; the runtime flag is
-  // read once and toggles between a plain copy (unconstrained) and a masked
-  // copy (constrained), so flipping it switches decoding modes with no
-  // recompile.
-  bool const constrained = (apply_mask_ld_acquire_sys_i32(flag) != 0);
+  for (size_t i = threadIdx.x;
+       i < static_cast<size_t>(BATCH_SIZE) * vocab_size; i += blockDim.x) {
+    out[i] = in[i];
+  }
+  __syncthreads();
 
-  for (int b = 0; b < num_active_tokens; b++) {
+  if (apply_mask_ld_acquire_sys_i32(flag) == 0) {
+    return; // unconstrained
+  }
+
+  for (int b = 0; b < num_requests; b++) {
     int row = request_ids[b];
-    bool const do_mask = constrained && (row >= 0);
-    int32_t const *__restrict__ row_mask = nullptr;
-
-    if (do_mask) {
-      // Wait until the CPU has produced this row's mask for the current step.
-      // mask_seq increases monotonically (one mask per decode step, in lockstep
-      // with token production), so ">= target" is the catch-up condition.
-      if (threadIdx.x == 0) {
-        int target = step[row];
-        while (apply_mask_ld_acquire_sys_i32(&mask_seq[row]) < target) {
-          __nanosleep(20);
-        }
-      }
-      __syncthreads();
-      row_mask = bitmask + static_cast<size_t>(row) * bitmask_words;
+    int pos = (row >= 0) ? qo_indptr[b + 1] - 1 : -1;
+    if (pos < 0) {
+      continue;
     }
-
-    size_t const base = static_cast<size_t>(b) * vocab_size;
-    for (int v = threadIdx.x; v < vocab_size; v += blockDim.x) {
-      T val = in[base + v];
-      if (do_mask && (((row_mask[v >> 5] >> (v & 31)) & 1) == 0)) {
-        val = neg_inf; // disallowed token ⇒ zero probability downstream
+    if (threadIdx.x == 0) {
+      while (apply_mask_ld_acquire_sys_i32(&mask_seq[row]) < step[row]) {
+        __nanosleep(20);
       }
-      out[base + v] = val;
+    }
+    __syncthreads();
+    int32_t const *__restrict__ row_mask =
+        bitmask + static_cast<size_t>(row) * bitmask_words;
+    size_t const base = static_cast<size_t>(pos) * vocab_size;
+    for (int v = threadIdx.x; v < vocab_size; v += blockDim.x) {
+      if (((row_mask[v >> 5] >> (v & 31)) & 1) == 0) {
+        out[base + v] = neg_inf;
+      }
     }
     __syncthreads();
   }

--- a/include/mirage/persistent_kernel/tasks/blackwell/task_header.cuh
+++ b/include/mirage/persistent_kernel/tasks/blackwell/task_header.cuh
@@ -23,6 +23,7 @@
 #if defined(USE_NVSHMEM) && defined(MIRAGE_GRACE_BLACKWELL)
 #include "tasks/blackwell/allreduce.cuh"
 #endif
+#include "apply_token_bitmask_sm100.cuh"
 #include "argmax_sm100.cuh"
 #include "attention_sm100.cuh"
 #include "dflash_attention_sm100.cuh"

--- a/python/mirage/engine/model_runner.py
+++ b/python/mirage/engine/model_runner.py
@@ -47,6 +47,10 @@ class RunnerConfig:
     """Build the apply_token_bitmask masking layer into the graph (online_pinned
     only). Runtime constrained/unconstrained is then a flag flip."""
 
+    do_sample: bool = False
+    """Sample (Gumbel-max) instead of greedy argmax."""
+    sampling_seed: int = 42
+
     tensor_parallel_size: int = 1
     """Number of GPUs for tensor parallelism (matches ``mpirun -n`` count)."""
 
@@ -100,6 +104,8 @@ class ModelRunner:
             model_config=MirageModelConfig(with_lm_head=True),
             use_cutlass_kernel=config.use_cutlass_kernel,
             enable_constrained_decoding=config.enable_constrained_decoding,
+            do_sample=config.do_sample,
+            sampling_seed=config.sampling_seed,
             **self.meta_tensors,
         )
         self.mpk = MPK(mpk_meta)
@@ -107,6 +113,15 @@ class ModelRunner:
         self.runtime = OnlinePinnedRuntime(self.mpk)
         self.tokenizer = self.mpk.tokenizer
         self.mpk.compile(output_dir=config.output_dir)
+
+        # Constrained decoding: the runtime already has the tokenizer and the
+        # (padded) logit width, so initialize xgrammar automatically — callers
+        # just attach grammars per request via runtime.set_request_grammar().
+        if config.enable_constrained_decoding:
+            assert config.vocab_size is not None, (
+                "enable_constrained_decoding=True requires RunnerConfig.vocab_size "
+                "(the model's padded logit width, e.g. 153600 for Qwen3)")
+            self.runtime.init_xgrammar(self.tokenizer, config.vocab_size)
 
     # ── Execution ─────────────────────────────────────────────────────────────
 

--- a/python/mirage/engine/model_runner.py
+++ b/python/mirage/engine/model_runner.py
@@ -38,6 +38,15 @@ class RunnerConfig:
     pinned_ring_capacity: int = 8
     """Power-of-2 capacity for the CPU↔GPU pinned ring buffers."""
 
+    vocab_size: Optional[int] = None
+    """Vocabulary size (logit dim). Sizes the constrained-decoding (xgrammar)
+    token bitmask. MUST match the model's *padded* logit dimension (the width
+    of the logits buffer the masking task sees, e.g. 153600 for Qwen3)."""
+
+    enable_constrained_decoding: bool = False
+    """Build the apply_token_bitmask masking layer into the graph (online_pinned
+    only). Runtime constrained/unconstrained is then a flag flip."""
+
     tensor_parallel_size: int = 1
     """Number of GPUs for tensor parallelism (matches ``mpirun -n`` count)."""
 
@@ -90,6 +99,7 @@ class ModelRunner:
             model_path=config.model_path,
             model_config=MirageModelConfig(with_lm_head=True),
             use_cutlass_kernel=config.use_cutlass_kernel,
+            enable_constrained_decoding=config.enable_constrained_decoding,
             **self.meta_tensors,
         )
         self.mpk = MPK(mpk_meta)
@@ -180,4 +190,15 @@ class ModelRunner:
             pinned_step=torch.zeros(n_req, dtype=torch.int32).pin_memory(),
             pinned_inbox_tokens=torch.zeros(cap, config.max_seq_length, dtype=torch.int64).pin_memory(),
             pinned_rid_at_row=torch.full((n_req,), -1, dtype=torch.int32).pin_memory(),
+            # ── Constrained decoding (xgrammar) ─────────────────────────────
+            # bitmask: per buffer row, ceil(vocab/32) packed int32 words.
+            # Init to all-ones (-1 == 0xFFFFFFFF) so the default ("every token
+            # allowed") is a safe no-op even if the flag is left on.
+            # mask_seq / flag init to 0 (off).
+            pinned_token_bitmask=torch.full(
+                (n_req, ((config.vocab_size or 32) + 31) // 32),
+                -1, dtype=torch.int32,
+            ).pin_memory(),
+            pinned_mask_seq=torch.zeros(n_req, dtype=torch.int32).pin_memory(),
+            pinned_constrained_flag=torch.zeros(1, dtype=torch.int32).pin_memory(),
         )

--- a/python/mirage/mpk/__init__.py
+++ b/python/mirage/mpk/__init__.py
@@ -2,6 +2,7 @@ from .mpk import MPK, MPKMetadata
 from .speculative import spec_decode_class
 from .persistent_kernel import PersistentKernel
 from .online_pinned_runtime import OnlinePinnedRuntime
+from .structured import StructuredGenerationManager
 
-__all__ = ["MPK", "MPKMetadata", "spec_decode_class", "PersistentKernel", "OnlinePinnedRuntime"]
+__all__ = ["MPK", "MPKMetadata", "spec_decode_class", "PersistentKernel", "OnlinePinnedRuntime", "StructuredGenerationManager"]
 

--- a/python/mirage/mpk/__init__.py
+++ b/python/mirage/mpk/__init__.py
@@ -3,6 +3,7 @@ from .speculative import spec_decode_class
 from .persistent_kernel import PersistentKernel
 from .online_pinned_runtime import OnlinePinnedRuntime
 from .structured import StructuredGenerationManager
+from .structured_tools import create_tools  # xgrammar-free; builders import it lazily
 
-__all__ = ["MPK", "MPKMetadata", "spec_decode_class", "PersistentKernel", "OnlinePinnedRuntime", "StructuredGenerationManager"]
+__all__ = ["MPK", "MPKMetadata", "spec_decode_class", "PersistentKernel", "OnlinePinnedRuntime", "StructuredGenerationManager", "create_tools"]
 

--- a/python/mirage/mpk/models/qwen3/builder.py
+++ b/python/mirage/mpk/models/qwen3/builder.py
@@ -9,6 +9,25 @@ from ....core import bfloat16, int64
 
 from typing import Optional
 
+
+def _aligned_splitk(reduction: int, ideal: int, align: int = 64) -> int:
+    """Pick a split-K factor (grid.y) that keeps every split 16B-aligned.
+
+    ``splitk_linear_layer`` maps the reduction dim (K) onto grid.y, so split
+    ``y`` starts at byte offset ``y * (K/grid.y) * 2`` (bf16). SM100 TMA requires
+    a 16B-aligned base pointer, so ``K/grid.y`` must divide K into equal pieces
+    that are a multiple of ``align``=64 elements (the TMA copy tile, matching the
+    validated configs). Among such factors, pick the split count closest to
+    ``ideal`` (perf heuristic), breaking ties toward the larger — 4 is the
+    validated Qwen3-8B value. E.g. Qwen3-8B (K=4096/12288, ideal=4) -> 4
+    (unchanged); Qwen3-14B (K=5120/17408, ideal=3) -> 4 (3 gives misaligned
+    1707/5803 splits; 4 divides both into 1280/4352, aligned).
+    """
+    cands = [s for s in range(1, 2 * max(1, ideal) + 1)
+             if reduction % s == 0 and (reduction // s) % align == 0]
+    return min(cands, key=lambda s: (abs(s - ideal), -s)) if cands else 1
+
+
 @register_model_builder("Qwen3", "Qwen/Qwen3-8B", "Qwen/Qwen3-1.7B", "Qwen/Qwen3-14B", "Qwen/Qwen3-0.6B", "Qwen/Qwen3.5-0.8B", "Qwen3.5-0.8B")
 class Qwen3Builder(GraphBuilder):
     def __init__(self, mpk: PersistentKernel, weights: Optional[dict] = None):
@@ -382,7 +401,9 @@ class Qwen3Builder(GraphBuilder):
                     input=self.attn_out,
                     weight=self.w,
                     output=self.attn_proj_out,
-                    grid_dim=(self.hidden_size // 128, 128 * 128 // self.hidden_size, 1),
+                    grid_dim=(self.hidden_size // 128,
+                              _aligned_splitk(self.num_local_q_heads * self.head_dim,
+                                              128 * 128 // self.hidden_size), 1),
                     block_dim=(256, 1, 1),
                 )
             else:
@@ -497,7 +518,9 @@ class Qwen3Builder(GraphBuilder):
                     input=self.silu_mul_out,
                     weight=self.w,
                     output=self.mlp_out,
-                    grid_dim=(self.hidden_size // 128, 128 * 128 // self.hidden_size, 1),
+                    grid_dim=(self.hidden_size // 128,
+                              _aligned_splitk(self.intermediate_size // self.world_size,
+                                              128 * 128 // self.hidden_size), 1),
                     block_dim=(256, 1, 1),
                 )
             else:
@@ -618,10 +641,8 @@ class Qwen3Builder(GraphBuilder):
             argmax_partial_grid_dim = (self.mpk.num_workers, 1, 1)
             argmax_reduce_grid_dim = (1, 1, 1)
 
-            # Constrained decoding (xgrammar): mask the logits with the
-            # CPU-produced token bitmask before argmax. Only in online_pinned
-            # mode (per-step CPU rendezvous) and only when enabled at build
-            # time; gated at runtime by pinned_constrained_flag (free when off).
+            # Constrained decoding: mask logits before token selection
+            # (online_pinned + enable_constrained_decoding; gated at runtime).
             argmax_input = self.argmax_in
             if (self.mpk.mode == "online_pinned"
                     and getattr(self.mpk, "enable_constrained_decoding", False)):
@@ -639,18 +660,27 @@ class Qwen3Builder(GraphBuilder):
                 )
                 argmax_input = self.masked_logits
 
-            self.mpk.argmax_partial_layer(
-                input=argmax_input,
-                output=(self.argmax_part_value, self.argmax_part_index),
-                grid_dim=argmax_partial_grid_dim,
-                block_dim=(128, 1, 1),
-            )
-            self.mpk.argmax_reduce_layer(
-                input=(self.argmax_part_value, self.argmax_part_index),
-                output=argmax_out,
-                grid_dim=argmax_reduce_grid_dim,
-                block_dim=(128, 1, 1),
-            )
+            if getattr(self.mpk, "do_sample", False):
+                self.mpk.sampling_sm100_layer(
+                    logits=argmax_input,
+                    output=argmax_out,
+                    grid_dim=(1, 1, 1),
+                    block_dim=(256, 1, 1),
+                    seed=getattr(self.mpk, "sampling_seed", 42),
+                )
+            else:
+                self.mpk.argmax_partial_layer(
+                    input=argmax_input,
+                    output=(self.argmax_part_value, self.argmax_part_index),
+                    grid_dim=argmax_partial_grid_dim,
+                    block_dim=(128, 1, 1),
+                )
+                self.mpk.argmax_reduce_layer(
+                    input=(self.argmax_part_value, self.argmax_part_index),
+                    output=argmax_out,
+                    grid_dim=argmax_reduce_grid_dim,
+                    block_dim=(128, 1, 1),
+                )
             # TODO(Jianan Ji): spec_decode_config handling (see previous implementation)
             # if spec_decode_config:
             #     verify_out = self.mpk.verify_layer_dispatcher(

--- a/python/mirage/mpk/models/qwen3/builder.py
+++ b/python/mirage/mpk/models/qwen3/builder.py
@@ -617,8 +617,30 @@ class Qwen3Builder(GraphBuilder):
             # else:
             argmax_partial_grid_dim = (self.mpk.num_workers, 1, 1)
             argmax_reduce_grid_dim = (1, 1, 1)
+
+            # Constrained decoding (xgrammar): mask the logits with the
+            # CPU-produced token bitmask before argmax. Only in online_pinned
+            # mode (per-step CPU rendezvous) and only when enabled at build
+            # time; gated at runtime by pinned_constrained_flag (free when off).
+            argmax_input = self.argmax_in
+            if (self.mpk.mode == "online_pinned"
+                    and getattr(self.mpk, "enable_constrained_decoding", False)):
+                self.masked_logits = self.mpk.new_tensor(
+                    dims=(self.max_num_batched_tokens, self.padded_vocab_size),
+                    dtype=bfloat16,
+                    name="masked_logits",
+                    io_category="cuda_tensor",
+                )
+                self.mpk.apply_token_bitmask_layer(
+                    logits=self.argmax_in,
+                    output=self.masked_logits,
+                    grid_dim=(1, 1, 1),
+                    block_dim=(128, 1, 1),
+                )
+                argmax_input = self.masked_logits
+
             self.mpk.argmax_partial_layer(
-                input=self.argmax_in,
+                input=argmax_input,
                 output=(self.argmax_part_value, self.argmax_part_index),
                 grid_dim=argmax_partial_grid_dim,
                 block_dim=(128, 1, 1),

--- a/python/mirage/mpk/mpk.py
+++ b/python/mirage/mpk/mpk.py
@@ -68,6 +68,14 @@ class MPKMetadata:
     pinned_step: Optional[torch.Tensor] = None
     pinned_inbox_tokens: Optional[torch.Tensor] = None
     pinned_rid_at_row: Optional[torch.Tensor] = None
+    # Constrained decoding (xgrammar) pinned buffers
+    pinned_token_bitmask: Optional[torch.Tensor] = None
+    pinned_mask_seq: Optional[torch.Tensor] = None
+    pinned_constrained_flag: Optional[torch.Tensor] = None
+    # Build-time toggle: insert the apply_token_bitmask masking layer into the
+    # graph (online_pinned only). Runtime constrained/unconstrained is then
+    # controlled by pinned_constrained_flag.
+    enable_constrained_decoding: bool = False
     # spec decode config
     spec_decode: Optional[str] = None
     spec_decode_config: Optional[object] = None
@@ -211,6 +219,10 @@ class MPK:
         self.pinned_step             = args.pinned_step
         self.pinned_inbox_tokens     = args.pinned_inbox_tokens
         self.pinned_rid_at_row       = args.pinned_rid_at_row
+        self.pinned_token_bitmask    = args.pinned_token_bitmask
+        self.pinned_mask_seq         = args.pinned_mask_seq
+        self.pinned_constrained_flag = args.pinned_constrained_flag
+        self.enable_constrained_decoding = args.enable_constrained_decoding
 
         self.profiler_tensor = args.profiler_tensor
         self.spec_decode_config = args.spec_decode_config
@@ -253,6 +265,9 @@ class MPK:
             "pinned_step":             args.pinned_step,
             "pinned_inbox_tokens":     args.pinned_inbox_tokens,
             "pinned_rid_at_row":       args.pinned_rid_at_row,
+            "pinned_token_bitmask":    args.pinned_token_bitmask,
+            "pinned_mask_seq":         args.pinned_mask_seq,
+            "pinned_constrained_flag": args.pinned_constrained_flag,
         }
         self.persistent_kernel = PersistentKernel(
             mode=args.mode,
@@ -272,6 +287,7 @@ class MPK:
             spec_decode_config=self.spec_decode_config,
             use_cutlass_kernel=args.use_cutlass_kernel,
             pinned_ring_capacity=args.pinned_ring_capacity,
+            enable_constrained_decoding=args.enable_constrained_decoding,
         )
         self.meta_tensors_ptr = [tensor.data_ptr() for tensor in meta_tensors.values()]
         self.profiler_buffer_ptr = (

--- a/python/mirage/mpk/mpk.py
+++ b/python/mirage/mpk/mpk.py
@@ -76,6 +76,9 @@ class MPKMetadata:
     # graph (online_pinned only). Runtime constrained/unconstrained is then
     # controlled by pinned_constrained_flag.
     enable_constrained_decoding: bool = False
+    # Sampling (Gumbel-max) instead of greedy argmax for token selection.
+    do_sample: bool = False
+    sampling_seed: int = 42
     # spec decode config
     spec_decode: Optional[str] = None
     spec_decode_config: Optional[object] = None
@@ -223,6 +226,8 @@ class MPK:
         self.pinned_mask_seq         = args.pinned_mask_seq
         self.pinned_constrained_flag = args.pinned_constrained_flag
         self.enable_constrained_decoding = args.enable_constrained_decoding
+        self.do_sample = args.do_sample
+        self.sampling_seed = args.sampling_seed
 
         self.profiler_tensor = args.profiler_tensor
         self.spec_decode_config = args.spec_decode_config
@@ -288,6 +293,8 @@ class MPK:
             use_cutlass_kernel=args.use_cutlass_kernel,
             pinned_ring_capacity=args.pinned_ring_capacity,
             enable_constrained_decoding=args.enable_constrained_decoding,
+            do_sample=args.do_sample,
+            sampling_seed=args.sampling_seed,
         )
         self.meta_tensors_ptr = [tensor.data_ptr() for tensor in meta_tensors.values()]
         self.profiler_buffer_ptr = (

--- a/python/mirage/mpk/online_pinned_runtime.py
+++ b/python/mirage/mpk/online_pinned_runtime.py
@@ -72,6 +72,7 @@ class OnlinePinnedRuntime:
             pinned_step=self._pinned_step,
             find_row_for_rid=self.find_row_for_rid,
             prompt_lengths=getattr(mpk, "prompt_lengths", None),
+            active_rows=self.active_rows,
         )
 
         # CPU-private ring cursors.
@@ -205,6 +206,14 @@ class OnlinePinnedRuntime:
                 self._completions[rid] = (buffer_row, final_step)
             finished.append((rid, buffer_row, final_step))
 
+        # Auto-release each completed request's grammar state, keyed by the
+        # completion ring's buffer_row (authoritative: the GPU has already reset
+        # pinned_rid_at_row for this row, so a rid-based lookup would miss it and
+        # leave the global constrained flag stuck on). Idempotent. This is why
+        # release_grammar() is not needed in the normal path.
+        for rid, buffer_row, _ in finished:
+            self.structured.release(rid, row=buffer_row)
+
         # Flush all waiting requests while ring slots are free.
         while self.flush_waiting():
             pass
@@ -226,21 +235,40 @@ class OnlinePinnedRuntime:
 
     def init_xgrammar(self, tokenizer, vocab_size: int) -> None:
         """Build the xgrammar compiler + tokenizer info (see
-        :meth:`structured.StructuredGenerationManager.init_xgrammar`)."""
+        :meth:`structured.StructuredGenerationManager.init_xgrammar`).
+
+        ``ModelRunner`` calls this automatically when
+        ``enable_constrained_decoding=True``; call it yourself only when driving
+        ``OnlinePinnedRuntime`` without a ``ModelRunner``."""
         self.structured.init_xgrammar(tokenizer, vocab_size)
 
     def set_request_grammar(self, rid: int, *, json_schema=None, ebnf=None,
-                            regex=None) -> None:
-        """Attach a grammar to a request (call once, near submit())."""
+                            regex=None, structural_tag=None,
+                            triggered_tags=None, tags_with_separator=None,
+                            dispatch=None, model=None,
+                            any_whitespace=True) -> None:
+        """Attach a grammar to a request (call once, near submit()).
+
+        Pass a raw grammar source (``json_schema`` / ``ebnf`` / ``regex`` /
+        ``structural_tag``) or a tool list from
+        :func:`~mirage.mpk.create_tools` via ``triggered_tags=`` /
+        ``tags_with_separator=`` / ``dispatch=`` (optionally ``model=`` for the
+        model's native format). See
+        :meth:`structured.StructuredGenerationManager.set_request_grammar`."""
         self.structured.set_request_grammar(
-            rid, json_schema=json_schema, ebnf=ebnf, regex=regex)
+            rid, json_schema=json_schema, ebnf=ebnf, regex=regex,
+            structural_tag=structural_tag, triggered_tags=triggered_tags,
+            tags_with_separator=tags_with_separator, dispatch=dispatch,
+            model=model, any_whitespace=any_whitespace)
 
     def set_constrained(self, on: bool) -> None:
         """Flip the global runtime constrained-decoding flag."""
         self.structured.set_constrained(on)
 
     def release_grammar(self, rid: int) -> None:
-        """Drop a request's matcher (call on completion)."""
+        """Drop a request's grammar state. Optional in the normal path — the
+        runtime auto-releases on completion (see :meth:`drain_completions`); use
+        this only to abort a request's grammar early. Idempotent."""
         self.structured.release(rid)
 
     def wait_for_request(
@@ -304,6 +332,12 @@ class OnlinePinnedRuntime:
             if int(self._pinned_rid_at_row[r].item()) == rid:
                 return r
         return -1
+
+    def active_rows(self) -> List[int]:
+        """Buffer rows currently holding a live request (rid != -1). Used by the
+        constrained-decoding tick to publish a mask for every active row."""
+        return [r for r in range(self._total_inflight)
+                if int(self._pinned_rid_at_row[r].item()) >= 0]
 
     @property
     def waiting_count(self) -> int:

--- a/python/mirage/mpk/online_pinned_runtime.py
+++ b/python/mirage/mpk/online_pinned_runtime.py
@@ -59,6 +59,21 @@ class OnlinePinnedRuntime:
         self._inbox_tokens      = mpk.pinned_inbox_tokens     # int64[cap, max_seq_len], pinned
         self._pinned_rid_at_row = mpk.pinned_rid_at_row       # int32[max_batched], pinned
 
+        # ── Constrained decoding (xgrammar) ───────────────────────────────
+        # Optional; activated by init_xgrammar() + set_request_grammar().
+        # All xgrammar state lives in StructuredGenerationManager (structured.py);
+        # this runtime just drives its per-step tick from the drain loop.
+        from .structured import StructuredGenerationManager
+        self.structured = StructuredGenerationManager(
+            token_bitmask=getattr(mpk, "pinned_token_bitmask", None),
+            mask_seq=getattr(mpk, "pinned_mask_seq", None),
+            constrained_flag=getattr(mpk, "pinned_constrained_flag", None),
+            tokens=mpk.tokens,
+            pinned_step=self._pinned_step,
+            find_row_for_rid=self.find_row_for_rid,
+            prompt_lengths=getattr(mpk, "prompt_lengths", None),
+        )
+
         # CPU-private ring cursors.
         self._cpu_req_tail  = 0  # next ring slot to write
         self._cpu_req_ack   = 0  # last slot known to be consumed by GPU
@@ -202,9 +217,31 @@ class OnlinePinnedRuntime:
         while not self._drain_stop.is_set():
             try:
                 self.drain_completions()
+                self.structured.tick()
             except Exception:
                 pass
             self._drain_stop.wait(0.0002)
+
+    # ── Constrained decoding (xgrammar) — delegates to structured.py ──────
+
+    def init_xgrammar(self, tokenizer, vocab_size: int) -> None:
+        """Build the xgrammar compiler + tokenizer info (see
+        :meth:`structured.StructuredGenerationManager.init_xgrammar`)."""
+        self.structured.init_xgrammar(tokenizer, vocab_size)
+
+    def set_request_grammar(self, rid: int, *, json_schema=None, ebnf=None,
+                            regex=None) -> None:
+        """Attach a grammar to a request (call once, near submit())."""
+        self.structured.set_request_grammar(
+            rid, json_schema=json_schema, ebnf=ebnf, regex=regex)
+
+    def set_constrained(self, on: bool) -> None:
+        """Flip the global runtime constrained-decoding flag."""
+        self.structured.set_constrained(on)
+
+    def release_grammar(self, rid: int) -> None:
+        """Drop a request's matcher (call on completion)."""
+        self.structured.release(rid)
 
     def wait_for_request(
         self,
@@ -293,3 +330,4 @@ class OnlinePinnedRuntime:
         self._req_ready.zero_()
         self._req_request_id.zero_()
         self._pinned_rid_at_row.fill_(-1)
+        self.structured.reset()

--- a/python/mirage/mpk/persistent_kernel.py
+++ b/python/mirage/mpk/persistent_kernel.py
@@ -326,11 +326,15 @@ class PersistentKernel:
         pinned_ring_capacity: int = 0,
         test_mode: bool = False,
         enable_constrained_decoding: bool = False,
+        do_sample: bool = False,
+        sampling_seed: int = 42,
     ):
         self.__finalized__ = False
         self._is_compiled = False
         self.test_mode = test_mode
         self.enable_constrained_decoding = enable_constrained_decoding
+        self.do_sample = do_sample
+        self.sampling_seed = sampling_seed
 
         if mode not in valid_persistent_kernel_modes:
             raise ValueError(f"Invalid persistent kernel mode: {mode}")
@@ -2117,34 +2121,15 @@ class PersistentKernel:
         # Register task with seed parameter
         self.kn_graph.register_task(tb_graph, "sampling_sm100", [seed])
 
-    def apply_token_bitmask_layer(
-        self,
-        logits: DTensor,        # [batch_size, vocab_size], raw logits (input)
-        output: DTensor,        # [batch_size, vocab_size], masked logits
-        grid_dim: tuple,
-        block_dim: tuple,
-    ):
-        """Constrained decoding (xgrammar): write masked logits to ``output``
-        using a CPU-produced token bitmask delivered via the pinned ring
-        buffers.  Feed ``output`` (not ``logits``) into the following argmax /
-        sampling layer.
-
-        This task is present in every compiled graph but is gated at runtime by
-        ``pinned_constrained_flag``: flag 0 ⇒ plain copy logits→output (no CPU
-        wait, no bit tests); flag 1 ⇒ wait for the CPU mask and mask disallowed
-        tokens to -inf.  Flipping the flag switches constrained vs unconstrained
-        decoding on the same compiled kernel.  Only valid in ``online_pinned``
-        mode (the per-step CPU rendezvous is meaningless in the offline
-        one-shot path).
-        """
-        assert logits.num_dims == 2  # (batch_size, vocab_size)
-        assert output.num_dims == 2  # (batch_size, vocab_size)
-        assert self.mode == "online_pinned", (
-            "apply_token_bitmask_layer requires mode='online_pinned'"
-        )
+    def apply_token_bitmask_layer(self, logits, output, grid_dim, block_dim):
+        """Constrained decoding: write masked logits to ``output`` (feed that, not
+        ``logits``, into the following argmax/sampling layer). Gated at runtime by
+        pinned_constrained_flag (flag 0 ⇒ plain copy). online_pinned only."""
+        assert logits.num_dims == 2 and output.num_dims == 2
+        assert self.mode == "online_pinned"
         tb_graph = TBGraph(CyTBGraph(grid_dim, block_dim, 1, 64))
-        tb_graph.new_input(logits, (0, -1, -1), -1, True)  # input[0]: raw logits
-        tb_graph.new_input(output, (0, -1, -1), -1, True)  # output[0]: masked
+        tb_graph.new_input(logits, (0, -1, -1), -1, True)
+        tb_graph.new_input(output, (0, -1, -1), -1, True)
         self.kn_graph.customized([logits, output], tb_graph)
         self.kn_graph.register_task(tb_graph, "apply_token_bitmask_sm100", [])
 

--- a/python/mirage/mpk/persistent_kernel.py
+++ b/python/mirage/mpk/persistent_kernel.py
@@ -325,10 +325,12 @@ class PersistentKernel:
         eos_token_id: int64 = -1,
         pinned_ring_capacity: int = 0,
         test_mode: bool = False,
+        enable_constrained_decoding: bool = False,
     ):
         self.__finalized__ = False
         self._is_compiled = False
         self.test_mode = test_mode
+        self.enable_constrained_decoding = enable_constrained_decoding
 
         if mode not in valid_persistent_kernel_modes:
             raise ValueError(f"Invalid persistent kernel mode: {mode}")
@@ -2115,6 +2117,37 @@ class PersistentKernel:
         # Register task with seed parameter
         self.kn_graph.register_task(tb_graph, "sampling_sm100", [seed])
 
+    def apply_token_bitmask_layer(
+        self,
+        logits: DTensor,        # [batch_size, vocab_size], raw logits (input)
+        output: DTensor,        # [batch_size, vocab_size], masked logits
+        grid_dim: tuple,
+        block_dim: tuple,
+    ):
+        """Constrained decoding (xgrammar): write masked logits to ``output``
+        using a CPU-produced token bitmask delivered via the pinned ring
+        buffers.  Feed ``output`` (not ``logits``) into the following argmax /
+        sampling layer.
+
+        This task is present in every compiled graph but is gated at runtime by
+        ``pinned_constrained_flag``: flag 0 ⇒ plain copy logits→output (no CPU
+        wait, no bit tests); flag 1 ⇒ wait for the CPU mask and mask disallowed
+        tokens to -inf.  Flipping the flag switches constrained vs unconstrained
+        decoding on the same compiled kernel.  Only valid in ``online_pinned``
+        mode (the per-step CPU rendezvous is meaningless in the offline
+        one-shot path).
+        """
+        assert logits.num_dims == 2  # (batch_size, vocab_size)
+        assert output.num_dims == 2  # (batch_size, vocab_size)
+        assert self.mode == "online_pinned", (
+            "apply_token_bitmask_layer requires mode='online_pinned'"
+        )
+        tb_graph = TBGraph(CyTBGraph(grid_dim, block_dim, 1, 64))
+        tb_graph.new_input(logits, (0, -1, -1), -1, True)  # input[0]: raw logits
+        tb_graph.new_input(output, (0, -1, -1), -1, True)  # output[0]: masked
+        self.kn_graph.customized([logits, output], tb_graph)
+        self.kn_graph.register_task(tb_graph, "apply_token_bitmask_sm100", [])
+
     def find_ngram_partial_layer(
         self, input: DTensor, output: DTensor, grid_dim: tuple, block_dim: tuple, ngram_size: int = 3):
         # Currently assume that input/output
@@ -2748,6 +2781,9 @@ class PersistentKernel:
             "pinned_step",
             "pinned_inbox_tokens",
             "pinned_rid_at_row",
+            "pinned_token_bitmask",
+            "pinned_mask_seq",
+            "pinned_constrained_flag",
         ]
         meta_tensors_ptr = []
         for key in expected_order:
@@ -2870,6 +2906,9 @@ class PersistentKernel:
             meta_tensors.append(self.meta_tensors["pinned_step"])
             meta_tensors.append(self.meta_tensors["pinned_inbox_tokens"])
             meta_tensors.append(self.meta_tensors["pinned_rid_at_row"])
+            meta_tensors.append(self.meta_tensors["pinned_token_bitmask"])
+            meta_tensors.append(self.meta_tensors["pinned_mask_seq"])
+            meta_tensors.append(self.meta_tensors["pinned_constrained_flag"])
         meta_tensors_ptr = [tensor.data_ptr() for tensor in meta_tensors]
         profiler_buffer_ptr = (
             self.profiler_tensor.data_ptr() if self.profiler_tensor is not None else 0

--- a/python/mirage/mpk/structured.py
+++ b/python/mirage/mpk/structured.py
@@ -1,0 +1,231 @@
+"""
+Structured generation (constrained decoding) for MPK via xgrammar.
+
+This module owns all xgrammar state — the grammar compiler, the per-request
+``GrammarMatcher`` objects, and the per-step bitmask fill — and writes into the
+pinned CPU↔GPU buffers that the ``apply_token_bitmask`` MPK task reads:
+
+  * ``pinned_token_bitmask``    [n_req, ceil(vocab/32)] int32 — bit j set ⇒ token
+                                j allowed, indexed by buffer row.
+  * ``pinned_mask_seq``         [n_req] int32 — published step a row's mask is
+                                valid for; the GPU task waits (ld.acquire.sys)
+                                until this catches up to the row's decode step.
+  * ``pinned_constrained_flag`` [1] int32 — global runtime toggle. 0 ⇒ the GPU
+                                masking task is a no-op (unconstrained decode
+                                costs nothing); 1 ⇒ masks are applied.
+
+The grammar *advance* + bitmask *fill* run on the CPU each decode step,
+overlapped with the GPU forward pass, so the mask is ready by the time the
+tail masking task runs.  :class:`StructuredGenerationManager` is driven by
+:class:`~mirage.mpk.online_pinned_runtime.OnlinePinnedRuntime`, which calls
+:meth:`tick` from its background drain loop.
+"""
+
+import threading
+from typing import Dict
+
+
+class StructuredGenerationManager:
+    """Encapsulates xgrammar grammar state and per-step bitmask production.
+
+    Parameters
+    ----------
+    token_bitmask    : pinned int32 [n_req, ceil(vocab/32)]
+    mask_seq         : pinned int32 [n_req]
+    constrained_flag : pinned int32 [1]
+    tokens           : the (device) token buffer [n_req, max_seq_len]
+    pinned_step      : pinned int32 [n_req], the GPU-published decode step/row
+    find_row_for_rid : callable rid -> buffer row (or -1 if not yet assigned)
+    """
+
+    def __init__(self, token_bitmask, mask_seq, constrained_flag, tokens,
+                 pinned_step, find_row_for_rid, prompt_lengths=None):
+        self._token_bitmask = token_bitmask
+        self._mask_seq = mask_seq
+        self._constrained_flag = constrained_flag
+        self._tokens = tokens
+        self._pinned_step = pinned_step
+        self._find_row_for_rid = find_row_for_rid
+        self._prompt_lengths = prompt_lengths   # [n_req] int32, indexed by row
+
+        self._xgr = None                       # xgrammar module (lazy import)
+        self._compiler = None
+        self._tokenizer_info = None
+        self._vocab_size = None
+        self._compiled_cache: Dict[tuple, object] = {}   # spec-key -> CompiledGrammar
+        self._matchers: Dict[int, object] = {}           # buffer_row -> GrammarMatcher
+        self._pending: Dict[int, object] = {}            # rid -> GrammarMatcher (row TBD)
+        self._prompt_len: Dict[int, int] = {}            # row -> prompt length (decode boundary)
+        self._last_step: Dict[int, int] = {}             # row -> last step a mask was published
+        self._lock = threading.Lock()
+
+    @property
+    def available(self) -> bool:
+        """True if the kernel was built with the constrained-decoding buffers."""
+        return self._token_bitmask is not None
+
+    # ── Setup ─────────────────────────────────────────────────────────────
+
+    def init_xgrammar(self, tokenizer=None, vocab_size: int = None,
+                      tokenizer_info=None) -> None:
+        """Build the xgrammar compiler + tokenizer info.
+
+        Pass either a HuggingFace ``tokenizer`` (the common case) or a
+        pre-built ``tokenizer_info`` (e.g. for testing). ``vocab_size`` MUST
+        equal the model's logit dimension (padding included) — it sizes the
+        bitmask the GPU masking task reads.
+        """
+        import xgrammar as xgr  # lazy: only needed when constraining
+
+        assert self.available, (
+            "constrained decoding requires the pinned bitmask buffers; ensure "
+            "the kernel was built in online_pinned mode with constrained "
+            "decoding meta tensors"
+        )
+        if tokenizer_info is None:
+            tokenizer_info = xgr.TokenizerInfo.from_huggingface(
+                tokenizer, vocab_size=vocab_size
+            )
+        if vocab_size is None:
+            vocab_size = tokenizer_info.vocab_size
+        expected_words = self._token_bitmask.shape[1]
+        got_words = (vocab_size + 31) // 32
+        assert got_words == expected_words, (
+            f"vocab_size={vocab_size} (→{got_words} mask words) does not match "
+            f"the allocated bitmask width {expected_words}; RunnerConfig."
+            f"vocab_size must equal the model's logit dim"
+        )
+        self._xgr = xgr
+        self._vocab_size = vocab_size
+        self._tokenizer_info = tokenizer_info
+        self._compiler = xgr.GrammarCompiler(self._tokenizer_info)
+
+    def _compile(self, json_schema=None, ebnf=None, regex=None):
+        assert self._compiler is not None, "call init_xgrammar() first"
+        if json_schema is not None:
+            key = ("schema", json_schema)
+        elif ebnf is not None:
+            key = ("ebnf", ebnf)
+        elif regex is not None:
+            key = ("regex", regex)
+        else:
+            key = ("json",)
+        cached = self._compiled_cache.get(key)
+        if cached is not None:
+            return cached
+        c = self._compiler
+        if json_schema is not None:
+            compiled = c.compile_json_schema(json_schema)
+        elif ebnf is not None:
+            compiled = c.compile_grammar(ebnf)
+        elif regex is not None:
+            compiled = c.compile_regex(regex)
+        else:
+            compiled = c.compile_builtin_json_grammar()
+        self._compiled_cache[key] = compiled
+        return compiled
+
+    def set_request_grammar(self, rid: int, *, json_schema=None, ebnf=None,
+                            regex=None) -> None:
+        """Attach a grammar to a request (call once, near submit()).
+
+        The matcher binds to the request's buffer row lazily once the GPU
+        assigns one, and is advanced per decode step by :meth:`tick`.  Turns
+        on the global constrained flag.
+        """
+        compiled = self._compile(json_schema=json_schema, ebnf=ebnf, regex=regex)
+        matcher = self._xgr.GrammarMatcher(compiled)
+        with self._lock:
+            self._pending[rid] = matcher
+        self.set_constrained(True)
+
+    def set_constrained(self, on: bool) -> None:
+        """Flip the global runtime flag the GPU masking task reads."""
+        if self._constrained_flag is not None:
+            self._constrained_flag[0] = 1 if on else 0
+
+    # ── Per-step driver ───────────────────────────────────────────────────
+
+    def tick(self) -> None:
+        """Advance every active matcher and publish its mask for the current
+        step.  Cheap no-op when no grammars are active.
+
+        Contract (validated against a live online_pinned Qwen3 decode):
+          * pinned_step[row] == config.step[row]; the most recently generated
+            token lives at tokens[row, pinned_step] (cf. the EOS check on
+            tokens[row, step+num_tokens]).
+          * PREFILL (step < prompt_length[row]): the model is consuming the
+            prompt; its argmax outputs are NOT written to tokens (the kernel
+            only writes when step+j+1 >= prompt_len). We must NOT accept these
+            "tokens" — doing so feeds garbage to the matcher and terminates it,
+            which then stops publishing masks and deadlocks the kernel. Instead
+            we keep publishing the *fresh*-grammar mask: it constrains the first
+            generated token, which is produced inside the final prefill chunk.
+          * DECODE (step >= prompt_length[row]): accept the just-generated token
+            tokens[row, step], then fill the mask for the next token.
+          * The first published mask for a row is always the fresh grammar (no
+            accept), regardless of phase.
+        """
+        if self._compiler is None:
+            return
+        # Bind pending grammars to rows the GPU has now assigned, recording the
+        # row's prompt length (the prefill/decode boundary).
+        if self._pending:
+            with self._lock:
+                for rid in list(self._pending):
+                    row = self._find_row_for_rid(rid)
+                    if row >= 0:
+                        self._matchers[row] = self._pending.pop(rid)
+                        self._prompt_len[row] = (
+                            int(self._prompt_lengths[row].item())
+                            if self._prompt_lengths is not None else 0)
+                        self._last_step[row] = -1
+        for row, matcher in list(self._matchers.items()):
+            if matcher.is_terminated():
+                self._matchers.pop(row, None)  # done; don't feed it more tokens
+                continue
+            step = int(self._pinned_step[row].item())
+            if step == self._last_step.get(row, -1):
+                continue  # mask for this step already published
+            plen = self._prompt_len.get(row, 0)
+            first = self._last_step.get(row, -1) < 0
+            # Accept only during decode, and never on the very first mask.
+            if step >= plen and not first:
+                tok = int(self._tokens[row, step].item())
+                try:
+                    matcher.accept_token(tok)
+                except Exception:
+                    pass
+            # Fill this row's bitmask directly into the pinned buffer, then
+            # publish the seq (data-before-flag: the pinned writes complete
+            # before the seq store the GPU acquires on).
+            matcher.fill_next_token_bitmask(self._token_bitmask, index=row)
+            self._mask_seq[row] = step
+            self._last_step[row] = step
+            if matcher.is_terminated():
+                self._matchers.pop(row, None)
+
+    # ── Teardown ──────────────────────────────────────────────────────────
+
+    def release(self, rid: int) -> None:
+        """Drop a request's matcher (call on completion)."""
+        with self._lock:
+            self._pending.pop(rid, None)
+        row = self._find_row_for_rid(rid)
+        if row >= 0:
+            self._matchers.pop(row, None)
+            self._prompt_len.pop(row, None)
+            self._last_step.pop(row, None)
+        if not self._matchers and not self._pending:
+            self.set_constrained(False)
+
+    def reset(self) -> None:
+        """Clear all grammar state for a new session."""
+        with self._lock:
+            self._matchers.clear()
+            self._pending.clear()
+            self._prompt_len.clear()
+            self._last_step.clear()
+        if self._mask_seq is not None:
+            self._mask_seq.zero_()
+        self.set_constrained(False)

--- a/python/mirage/mpk/structured.py
+++ b/python/mirage/mpk/structured.py
@@ -1,24 +1,14 @@
 """
-Structured generation (constrained decoding) for MPK via xgrammar.
+Constrained decoding for MPK via xgrammar.
 
-This module owns all xgrammar state — the grammar compiler, the per-request
-``GrammarMatcher`` objects, and the per-step bitmask fill — and writes into the
-pinned CPU↔GPU buffers that the ``apply_token_bitmask`` MPK task reads:
+Owns the xgrammar state (compiler, per-request ``GrammarMatcher`` objects) and,
+each decode step, advances the matchers and fills the pinned bitmask the
+``apply_token_bitmask`` GPU task reads. Driven by ``OnlinePinnedRuntime``, which
+calls :meth:`tick` from its drain loop.
 
-  * ``pinned_token_bitmask``    [n_req, ceil(vocab/32)] int32 — bit j set ⇒ token
-                                j allowed, indexed by buffer row.
-  * ``pinned_mask_seq``         [n_req] int32 — published step a row's mask is
-                                valid for; the GPU task waits (ld.acquire.sys)
-                                until this catches up to the row's decode step.
-  * ``pinned_constrained_flag`` [1] int32 — global runtime toggle. 0 ⇒ the GPU
-                                masking task is a no-op (unconstrained decode
-                                costs nothing); 1 ⇒ masks are applied.
-
-The grammar *advance* + bitmask *fill* run on the CPU each decode step,
-overlapped with the GPU forward pass, so the mask is ready by the time the
-tail masking task runs.  :class:`StructuredGenerationManager` is driven by
-:class:`~mirage.mpk.online_pinned_runtime.OnlinePinnedRuntime`, which calls
-:meth:`tick` from its background drain loop.
+Pinned buffers (indexed by buffer row): ``token_bitmask`` [n_req, ceil(vocab/32)]
+(bit j set ⇒ token j allowed), ``mask_seq`` [n_req] (the GPU waits until this
+reaches the row's decode step), ``constrained_flag`` [1] (global on/off).
 """
 
 import threading
@@ -26,206 +16,264 @@ from typing import Dict
 
 
 class StructuredGenerationManager:
-    """Encapsulates xgrammar grammar state and per-step bitmask production.
+    """xgrammar state + per-step bitmask production.
 
-    Parameters
-    ----------
-    token_bitmask    : pinned int32 [n_req, ceil(vocab/32)]
-    mask_seq         : pinned int32 [n_req]
-    constrained_flag : pinned int32 [1]
-    tokens           : the (device) token buffer [n_req, max_seq_len]
-    pinned_step      : pinned int32 [n_req], the GPU-published decode step/row
-    find_row_for_rid : callable rid -> buffer row (or -1 if not yet assigned)
+    token_bitmask / mask_seq / constrained_flag are the pinned buffers; tokens
+    and pinned_step are the (device/pinned) token buffer and per-row decode step;
+    find_row_for_rid maps rid -> buffer row (-1 if unassigned); prompt_lengths is
+    the per-row prompt length (the prefill/decode boundary).
     """
 
     def __init__(self, token_bitmask, mask_seq, constrained_flag, tokens,
-                 pinned_step, find_row_for_rid, prompt_lengths=None):
+                 pinned_step, find_row_for_rid, prompt_lengths=None,
+                 active_rows=None):
         self._token_bitmask = token_bitmask
         self._mask_seq = mask_seq
         self._constrained_flag = constrained_flag
         self._tokens = tokens
         self._pinned_step = pinned_step
         self._find_row_for_rid = find_row_for_rid
-        self._prompt_lengths = prompt_lengths   # [n_req] int32, indexed by row
+        self._prompt_lengths = prompt_lengths
+        self._active_rows = active_rows           # callable -> list of active rows
 
-        self._xgr = None                       # xgrammar module (lazy import)
+        self._xgr = None
         self._compiler = None
-        self._tokenizer_info = None
-        self._vocab_size = None
-        self._compiled_cache: Dict[tuple, object] = {}   # spec-key -> CompiledGrammar
-        self._matchers: Dict[int, object] = {}           # buffer_row -> GrammarMatcher
-        self._pending: Dict[int, object] = {}            # rid -> GrammarMatcher (row TBD)
-        self._prompt_len: Dict[int, int] = {}            # row -> prompt length (decode boundary)
-        self._last_step: Dict[int, int] = {}             # row -> last step a mask was published
+        self._real_vocab = None                   # ids >= this are padding/reserved
+        self._allow_all = None                    # mask row: real allowed, padding not
+        self._cache: Dict[tuple, object] = {}     # spec -> CompiledGrammar
+        self._matchers: Dict[int, object] = {}    # row -> GrammarMatcher
+        self._pending: Dict[int, object] = {}     # rid -> GrammarMatcher (row TBD)
+        self._prompt_len: Dict[int, int] = {}     # row -> prompt length
+        self._last_step: Dict[int, int] = {}      # row -> last published step
+        self._row_rid: Dict[int, int] = {}        # row -> rid whose matcher it holds
+        self._active_rids: set = set()            # rids with a live grammar; the
+        #                                           global flag is on iff non-empty
         self._lock = threading.Lock()
 
     @property
     def available(self) -> bool:
-        """True if the kernel was built with the constrained-decoding buffers."""
         return self._token_bitmask is not None
 
-    # ── Setup ─────────────────────────────────────────────────────────────
-
-    def init_xgrammar(self, tokenizer=None, vocab_size: int = None,
+    def init_xgrammar(self, tokenizer=None, vocab_size=None,
                       tokenizer_info=None) -> None:
-        """Build the xgrammar compiler + tokenizer info.
+        """Build the compiler. ``vocab_size`` must equal the model's (padded)
+        logit dim — it sizes the bitmask. Pass a HF ``tokenizer`` or a pre-built
+        ``tokenizer_info``."""
+        import xgrammar as xgr
 
-        Pass either a HuggingFace ``tokenizer`` (the common case) or a
-        pre-built ``tokenizer_info`` (e.g. for testing). ``vocab_size`` MUST
-        equal the model's logit dimension (padding included) — it sizes the
-        bitmask the GPU masking task reads.
-        """
-        import xgrammar as xgr  # lazy: only needed when constraining
-
-        assert self.available, (
-            "constrained decoding requires the pinned bitmask buffers; ensure "
-            "the kernel was built in online_pinned mode with constrained "
-            "decoding meta tensors"
-        )
+        assert self.available, "kernel was not built with constrained-decoding buffers"
         if tokenizer_info is None:
             tokenizer_info = xgr.TokenizerInfo.from_huggingface(
-                tokenizer, vocab_size=vocab_size
-            )
-        if vocab_size is None:
-            vocab_size = tokenizer_info.vocab_size
-        expected_words = self._token_bitmask.shape[1]
-        got_words = (vocab_size + 31) // 32
-        assert got_words == expected_words, (
-            f"vocab_size={vocab_size} (→{got_words} mask words) does not match "
-            f"the allocated bitmask width {expected_words}; RunnerConfig."
-            f"vocab_size must equal the model's logit dim"
-        )
+                tokenizer, vocab_size=vocab_size)
+        vocab_size = vocab_size or tokenizer_info.vocab_size
+        assert (vocab_size + 31) // 32 == self._token_bitmask.shape[1], (
+            f"vocab_size={vocab_size} does not match bitmask width "
+            f"{self._token_bitmask.shape[1]} (must equal the model's logit dim)")
         self._xgr = xgr
-        self._vocab_size = vocab_size
-        self._tokenizer_info = tokenizer_info
-        self._compiler = xgr.GrammarCompiler(self._tokenizer_info)
+        self._compiler = xgr.GrammarCompiler(tokenizer_info)
 
-    def _compile(self, json_schema=None, ebnf=None, regex=None):
+        # Padding hardening. Token ids >= real_vocab are embedding padding /
+        # reserved slots (≈0 logits, not decodable) that must never be sampled.
+        # len(tokenizer) is a safe lower bound — all real/chat-special tokens are
+        # below it. Precompute a mask row with those bits cleared, used to AND
+        # every published mask and as the unconstrained fallback, so padding is
+        # disallowed everywhere and the argmax can't be lured onto it.
+        self._real_vocab = None
+        if tokenizer is not None:
+            try:
+                n = len(tokenizer)
+                if 0 < n < vocab_size:
+                    self._real_vocab = n
+            except Exception:
+                pass
+        self._allow_all = self._token_bitmask.new_full(
+            (self._token_bitmask.shape[1],), -1)
+        if self._real_vocab is not None:
+            w, b = divmod(self._real_vocab, 32)
+            self._allow_all[w:] = 0
+            if b:
+                self._allow_all[w] = (1 << b) - 1
+
+    def _compile(self, json_schema=None, ebnf=None, regex=None,
+                 structural_tag=None, any_whitespace=True):
         assert self._compiler is not None, "call init_xgrammar() first"
-        if json_schema is not None:
-            key = ("schema", json_schema)
-        elif ebnf is not None:
-            key = ("ebnf", ebnf)
-        elif regex is not None:
-            key = ("regex", regex)
-        else:
-            key = ("json",)
-        cached = self._compiled_cache.get(key)
-        if cached is not None:
-            return cached
         c = self._compiler
         if json_schema is not None:
-            compiled = c.compile_json_schema(json_schema)
+            # any_whitespace=False forbids arbitrary inter-token whitespace
+            # (keeps canonical separators), avoiding runaway spaces/newlines.
+            key = ("schema", json_schema, any_whitespace)
+            build = lambda: c.compile_json_schema(json_schema, any_whitespace=any_whitespace)
         elif ebnf is not None:
-            compiled = c.compile_grammar(ebnf)
+            key, build = ("ebnf", ebnf), lambda: c.compile_grammar(ebnf)
         elif regex is not None:
-            compiled = c.compile_regex(regex)
+            key, build = ("regex", regex), lambda: c.compile_regex(regex)
+        elif structural_tag is not None:  # StructuralTag object / JSON str / dict
+            key, build = ("stag", repr(structural_tag)), lambda: c.compile_structural_tag(structural_tag)
         else:
-            compiled = c.compile_builtin_json_grammar()
-        self._compiled_cache[key] = compiled
-        return compiled
+            key, build = ("json",), c.compile_builtin_json_grammar
+        if key not in self._cache:
+            self._cache[key] = build()
+        return self._cache[key]
 
     def set_request_grammar(self, rid: int, *, json_schema=None, ebnf=None,
-                            regex=None) -> None:
-        """Attach a grammar to a request (call once, near submit()).
+                            regex=None, structural_tag=None,
+                            triggered_tags=None, tags_with_separator=None,
+                            dispatch=None, model=None,
+                            any_whitespace=True) -> None:
+        """Attach a grammar to a request. Provide exactly one grammar source:
 
-        The matcher binds to the request's buffer row lazily once the GPU
-        assigns one, and is advanced per decode step by :meth:`tick`.  Turns
-        on the global constrained flag.
+          * a raw source — ``json_schema`` / ``ebnf`` / ``regex`` /
+            ``structural_tag`` (none of these ⇒ builtin JSON); or
+          * a tool list (from :func:`~mirage.mpk.create_tools`) via one of
+            ``triggered_tags`` (free text + calls), ``tags_with_separator``
+            (tool-only), or ``dispatch`` (many tools / loop). Add ``model=``
+            (e.g. ``"qwen_3"``) to emit the tools in that model's *native*
+            tool-call format instead of the chosen wrapper.
+
+        ``any_whitespace=False`` (JSON schema only) forbids arbitrary whitespace.
+        Binds to the row lazily and turns on the global flag.
         """
-        compiled = self._compile(json_schema=json_schema, ebnf=ebnf, regex=regex)
-        matcher = self._xgr.GrammarMatcher(compiled)
+        tool_args = [t for t in (triggered_tags, tags_with_separator, dispatch)
+                     if t is not None]
+        assert len(tool_args) <= 1, (
+            "pass tools via only one of triggered_tags= / tags_with_separator= / "
+            "dispatch=")
+        assert model is None or tool_args, (
+            "model= requires a tool list (triggered_tags= / tags_with_separator= "
+            "/ dispatch=)")
+        if tool_args:
+            assert json_schema is ebnf is regex is structural_tag is None, (
+                "pass a tool list OR a raw grammar source, not both")
+            from . import structured_tools as T
+            tools = tool_args[0]
+            if model is not None:
+                structural_tag = T.build_model_structural_tag(tools, model=model)
+            elif triggered_tags is not None:
+                structural_tag = T.build_triggered_tags_structural_tag(tools)
+            elif tags_with_separator is not None:
+                structural_tag = T.build_tags_with_separator_structural_tag(tools)
+            else:
+                structural_tag = T.build_dispatch_structural_tag(tools)
+        matcher = self._xgr.GrammarMatcher(self._compile(
+            json_schema=json_schema, ebnf=ebnf, regex=regex,
+            structural_tag=structural_tag, any_whitespace=any_whitespace))
         with self._lock:
             self._pending[rid] = matcher
+            self._active_rids.add(rid)
         self.set_constrained(True)
 
     def set_constrained(self, on: bool) -> None:
-        """Flip the global runtime flag the GPU masking task reads."""
         if self._constrained_flag is not None:
             self._constrained_flag[0] = 1 if on else 0
 
-    # ── Per-step driver ───────────────────────────────────────────────────
-
     def tick(self) -> None:
-        """Advance every active matcher and publish its mask for the current
-        step.  Cheap no-op when no grammars are active.
+        """Bind newly-admitted grammars and, while the flag is on, publish a mask
+        for EVERY active row each step (all-ones for rows without a live matcher).
 
-        Contract (validated against a live online_pinned Qwen3 decode):
-          * pinned_step[row] == config.step[row]; the most recently generated
-            token lives at tokens[row, pinned_step] (cf. the EOS check on
-            tokens[row, step+num_tokens]).
-          * PREFILL (step < prompt_length[row]): the model is consuming the
-            prompt; its argmax outputs are NOT written to tokens (the kernel
-            only writes when step+j+1 >= prompt_len). We must NOT accept these
-            "tokens" — doing so feeds garbage to the matcher and terminates it,
-            which then stops publishing masks and deadlocks the kernel. Instead
-            we keep publishing the *fresh*-grammar mask: it constrains the first
-            generated token, which is produced inside the final prefill chunk.
-          * DECODE (step >= prompt_length[row]): accept the just-generated token
-            tokens[row, step], then fill the mask for the next token.
-          * The first published mask for a row is always the fresh grammar (no
-            accept), regardless of phase.
+        The device masking task spin-waits on ``mask_seq[row] >= step`` for every
+        active request when the flag is on, so an active row that is unconstrained
+        (mixed batch), whose grammar has terminated, or is a leftover of a
+        just-completed constrained request must still get a (permissive) mask
+        published or the kernel hangs. When the flag is off the task early-returns
+        without reading mask_seq, so there is nothing to publish.
+
+        pinned_step[row] is the row's decode step; the newest generated token sits
+        at tokens[row, step]. During prefill (step < prompt_len) argmax outputs
+        are not written to tokens, so we publish the fresh mask and accept
+        nothing; in decode we accept tokens[row, step] before filling the next.
         """
         if self._compiler is None:
             return
-        # Bind pending grammars to rows the GPU has now assigned, recording the
-        # row's prompt length (the prefill/decode boundary).
-        if self._pending:
-            with self._lock:
+        # Held for the whole body so a concurrent release()/set_request_grammar()
+        # (drain_completions runs on both the drain thread and wait_for_request's
+        # thread) can't mutate the matcher dicts mid-iteration.
+        with self._lock:
+            if self._pending:
                 for rid in list(self._pending):
                     row = self._find_row_for_rid(rid)
                     if row >= 0:
                         self._matchers[row] = self._pending.pop(rid)
-                        self._prompt_len[row] = (
-                            int(self._prompt_lengths[row].item())
-                            if self._prompt_lengths is not None else 0)
+                        self._row_rid[row] = rid
+                        self._prompt_len[row] = (int(self._prompt_lengths[row].item())
+                                                 if self._prompt_lengths is not None else 0)
                         self._last_step[row] = -1
-        for row, matcher in list(self._matchers.items()):
-            if matcher.is_terminated():
-                self._matchers.pop(row, None)  # done; don't feed it more tokens
-                continue
-            step = int(self._pinned_step[row].item())
-            if step == self._last_step.get(row, -1):
-                continue  # mask for this step already published
-            plen = self._prompt_len.get(row, 0)
-            first = self._last_step.get(row, -1) < 0
-            # Accept only during decode, and never on the very first mask.
-            if step >= plen and not first:
-                tok = int(self._tokens[row, step].item())
-                try:
-                    matcher.accept_token(tok)
-                except Exception:
-                    pass
-            # Fill this row's bitmask directly into the pinned buffer, then
-            # publish the seq (data-before-flag: the pinned writes complete
-            # before the seq store the GPU acquires on).
-            matcher.fill_next_token_bitmask(self._token_bitmask, index=row)
-            self._mask_seq[row] = step
-            self._last_step[row] = step
-            if matcher.is_terminated():
-                self._matchers.pop(row, None)
+            if self._constrained_flag is None or int(self._constrained_flag[0]) == 0:
+                return
+            rows = (self._active_rows() if self._active_rows is not None
+                    else list(self._matchers))
+            for row in rows:
+                step = int(self._pinned_step[row].item())
+                if step == self._last_step.get(row, -1):
+                    continue
+                matcher = self._matchers.get(row)
+                if matcher is not None and matcher.is_terminated():
+                    self._matchers.pop(row, None)
+                    self._row_rid.pop(row, None)
+                    matcher = None
+                if matcher is not None and step >= self._prompt_len.get(row, 0) \
+                        and self._last_step.get(row, -1) >= 0:   # decode, not first
+                    tok = int(self._tokens[row, step].item())
+                    if self._real_vocab is not None and tok >= self._real_vocab:
+                        # Padding/reserved id (e.g. 153599) — not a grammar token;
+                        # skip accept_token so xgrammar doesn't spam a rejection
+                        # warning, and treat it as the recovery trigger below.
+                        accepted = False
+                    else:
+                        try:
+                            accepted = matcher.accept_token(tok)
+                        except Exception:
+                            accepted = False
+                    if not accepted:
+                        # The model sampled a grammar-invalid token. Under correct
+                        # masking it can only sample allowed tokens, so this means a
+                        # degenerate all-disallowed step where the argmax fell back
+                        # to a padding id — which would otherwise spin forever,
+                        # re-rejecting the same token each step. Stop constraining
+                        # this row so the request can finish (it decodes freely
+                        # under the padding-disallowed fallback mask below).
+                        self._matchers.pop(row, None)
+                        self._row_rid.pop(row, None)
+                        matcher = None
+                if matcher is not None:
+                    matcher.fill_next_token_bitmask(self._token_bitmask, index=row)
+                    self._token_bitmask[row] &= self._allow_all   # hard-disallow padding
+                else:
+                    # no live grammar for this active row → allow every real token
+                    self._token_bitmask[row].copy_(self._allow_all)
+                self._mask_seq[row] = step      # data-before-flag: bitmask written first
+                self._last_step[row] = step
 
-    # ── Teardown ──────────────────────────────────────────────────────────
+    def release(self, rid: int, row: int = None) -> None:
+        """Drop a request's grammar state; clear the global flag once no grammars
+        remain.
 
-    def release(self, rid: int) -> None:
-        """Drop a request's matcher (call on completion)."""
+        Idempotent and thread-safe. The runtime calls this automatically on
+        completion (from ``drain_completions``) with the completion ring's
+        authoritative ``row`` — required because the GPU resets pinned_rid_at_row
+        to -1 at completion, so a rid-based ``find_row_for_rid`` lookup would miss
+        the row and leave the flag stuck on. ``row`` is cleaned only if it still
+        holds this rid's matcher (guards a row already recycled to a new request).
+        Callers normally never invoke this; use it only to abort a grammar early.
+        """
         with self._lock:
             self._pending.pop(rid, None)
-        row = self._find_row_for_rid(rid)
-        if row >= 0:
-            self._matchers.pop(row, None)
-            self._prompt_len.pop(row, None)
-            self._last_step.pop(row, None)
-        if not self._matchers and not self._pending:
+            self._active_rids.discard(rid)
+            if row is None:
+                row = self._find_row_for_rid(rid)
+            if row is not None and row >= 0 and self._row_rid.get(row, rid) == rid:
+                for d in (self._matchers, self._prompt_len, self._last_step,
+                          self._row_rid):
+                    d.pop(row, None)
+            active = bool(self._active_rids)
+        if not active:
             self.set_constrained(False)
 
     def reset(self) -> None:
-        """Clear all grammar state for a new session."""
         with self._lock:
-            self._matchers.clear()
-            self._pending.clear()
-            self._prompt_len.clear()
-            self._last_step.clear()
+            for d in (self._matchers, self._pending, self._prompt_len,
+                      self._last_step, self._row_rid):
+                d.clear()
+            self._active_rids.clear()
         if self._mask_seq is not None:
             self._mask_seq.zero_()
         self.set_constrained(False)

--- a/python/mirage/mpk/structured_tools.py
+++ b/python/mirage/mpk/structured_tools.py
@@ -1,0 +1,164 @@
+"""
+Tool registry → XGrammar structural tags (composable API), scalable to hundreds
+of tools.
+
+Reusable helpers for turning a registry of tool definitions into an xgrammar
+``StructuralTag`` for constrained tool-calling. The friendly path is
+:func:`create_tools` + ``OnlinePinnedRuntime.set_request_grammar``::
+
+    from mirage.mpk import create_tools
+    tools = create_tools("path/to/tool_registry")     # dir of *.json …
+    tools = create_tools([json_str1, json_str2])      # … or a list of JSON strings
+    rt.set_request_grammar(rid, triggered_tags=tools) # free text + calls
+    #   ...tags_with_separator=tools  (tool-only) | dispatch=tools (many tools)
+    #   ...add model="qwen_3" to emit the tools in the model's native format
+
+The lower-level flow (if you need the ``StructuralTag`` object directly):
+    tool JSON files on disk / JSON strings
+      → create_tools()               (→ list of tool dicts)
+      → select_tools()               (optional routing to a relevant subset)
+      → build_*_structural_tag()     (tools → xgrammar StructuralTag)
+      → GrammarCompiler.compile_structural_tag(tag)  (constrained decoding)
+
+Each tool is a dict ``{name, description, parameters(JSON Schema)}``. Drop a new
+JSON file anywhere under the registry folder to add a tool — no code changes.
+
+xgrammar is imported lazily inside the builders so ``import mirage.mpk`` and
+``create_tools`` work without it (only the ``build_*``/``tool_to_tag`` helpers
+require xgrammar).
+
+Notes vs. the deprecated API (StructuralTagItem / from_legacy_structural_tag):
+  * We build typed pydantic Format objects (xgrammar.structural_tag.*), not raw
+    dicts. If you do use a dict, it must be the full StructuralTag shape
+    ``{"type": "structural_tag", "format": {...}}`` — a bare ``{"format": ...}``
+    is rejected by the compiler.
+  * build_model_structural_tag() takes a *template name* (e.g. "qwen_3",
+    "llama", "deepseek_v3_1"), NOT a HuggingFace model id, and emits that
+    model's native tool-call format (Qwen: ``<tool_call>{"name":...}</tool_call>``).
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+from typing import Iterable, List, Optional, Union
+
+TRIGGER = "<function="  # custom tool-call prefix for the triggered/dispatch tags
+
+
+# ── Registry ────────────────────────────────────────────────────────────────
+
+def create_tools(source: Union[str, pathlib.Path, Iterable]) -> List[dict]:
+    """Build a tool list from a registry directory **or** an iterable of JSON.
+
+    ``source`` is either:
+      * a directory path (str / ``Path``) — load every ``*.json`` under it
+        recursively (same as :func:`load_tools`); or
+      * an iterable of JSON strings and/or already-parsed tool dicts.
+
+    Each tool must be ``{"name", "parameters"(JSON Schema)[, "description"]}``.
+    """
+    if isinstance(source, (str, pathlib.Path)):
+        p = pathlib.Path(source)
+        assert p.is_dir(), (
+            f"create_tools: {source!r} is not a directory; pass a registry dir "
+            f"or a list of JSON strings/dicts")
+        return load_tools(p)
+    tools = []
+    for item in source:
+        t = json.loads(item) if isinstance(item, str) else dict(item)
+        assert "name" in t and "parameters" in t, f"bad tool def: {t}"
+        tools.append(t)
+    return tools
+
+
+def load_tools(tool_registry_dir: Union[str, pathlib.Path]) -> List[dict]:
+    """Load every ``*.json`` tool definition under a registry folder (recursive)."""
+    root = pathlib.Path(tool_registry_dir)
+    tools = [json.loads(p.read_text()) for p in sorted(root.rglob("*.json"))]
+    for t in tools:
+        assert "name" in t and "parameters" in t, f"bad tool def: {t}"
+    return tools
+
+
+def select_tools(tools: List[dict], user_message: str,
+                 max_tools: Optional[int] = None) -> List[dict]:
+    """Routing hook: pick the relevant tools for a request. Placeholder returns
+    all tools (optionally the first ``max_tools``); replace the body with
+    embedding/keyword retrieval so hundreds of tools aren't all exposed per call.
+    """
+    # e.g. rank by name/description overlap with user_message, then truncate.
+    return tools if max_tools is None else tools[:max_tools]
+
+
+# ── OpenAI-style view + prompt text ─────────────────────────────────────────
+
+def to_openai_tools(tools: List[dict]) -> List[dict]:
+    return [{"type": "function", "function": {
+        "name": t["name"], "description": t.get("description", ""),
+        "parameters": t["parameters"], "strict": True}} for t in tools]
+
+
+def tools_system_prompt(tools: List[dict], trigger: str = TRIGGER) -> str:
+    """The grammar constrains *structure*; the model still needs to know the tools
+    exist. Render their names/descriptions for the system prompt."""
+    lines = [f"- {t['name']}: {t.get('description', '')}" for t in tools]
+    return ("You may call tools. Available tools:\n" + "\n".join(lines) +
+            f"\nInvoke a tool as {trigger}NAME>{{json args}}</function>.")
+
+
+# ── Structural-tag builders (custom <function=NAME> format) ─────────────────
+
+def tool_to_tag(tool: dict, trigger: str = TRIGGER):
+    """One tool → a TagFormat: begin <function=NAME>, JSON-schema body, end."""
+    import xgrammar.structural_tag as st
+    return st.TagFormat(
+        begin=f"{trigger}{tool['name']}>",
+        content=st.JSONSchemaFormat(json_schema=tool["parameters"]),
+        end="</function>")
+
+
+def build_triggered_tags_structural_tag(
+        tools: List[dict], trigger: str = TRIGGER,
+        at_least_one: bool = False, stop_after_first: bool = False):
+    """Free text is allowed until ``trigger`` appears, then one of the tools'
+    schemas is enforced. Interleaves prose and (multiple) tool calls."""
+    import xgrammar.structural_tag as st
+    return st.StructuralTag(format=st.TriggeredTagsFormat(
+        triggers=[trigger], tags=[tool_to_tag(t, trigger) for t in tools],
+        at_least_one=at_least_one, stop_after_first=stop_after_first))
+
+
+def build_tags_with_separator_structural_tag(
+        tools: List[dict], separator: str = "\n", trigger: str = TRIGGER,
+        at_least_one: bool = True, stop_after_first: bool = False):
+    """Tool-call-only output (no free text): one or more calls joined by
+    ``separator``."""
+    import xgrammar.structural_tag as st
+    return st.StructuralTag(format=st.TagsWithSeparatorFormat(
+        tags=[tool_to_tag(t, trigger) for t in tools], separator=separator,
+        at_least_one=at_least_one, stop_after_first=stop_after_first))
+
+
+def build_dispatch_structural_tag(
+        tools: List[dict], trigger: str = TRIGGER, loop: bool = True):
+    """Prefix-dispatch form — efficient when there are many distinct tool
+    prefixes. Each rule maps ``<function=NAME>`` to (schema, "</function>")."""
+    import xgrammar.structural_tag as st
+    rules = [[f"{trigger}{t['name']}>", st.SequenceFormat(elements=[
+                st.JSONSchemaFormat(json_schema=t["parameters"]),
+                st.ConstStringFormat(value="</function>")])]
+             for t in tools]
+    return st.StructuralTag(format=st.DispatchFormat(rules=rules, loop=loop))
+
+
+def build_model_structural_tag(
+        tools: List[dict], model: str = "qwen_3", tool_choice: str = "auto",
+        reasoning: bool = True):
+    """Use the model's NATIVE tool-call format via get_model_structural_tag.
+    ``model`` is a format name (qwen_3, qwen_3_coder, llama, deepseek_v3_1,
+    kimi, harmony, …), NOT a HuggingFace model id."""
+    import xgrammar as xgr
+    return xgr.get_model_structural_tag(
+        model=model, tools=to_openai_tools(tools),
+        tool_choice=tool_choice, reasoning=reasoning)

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ tg4perfetto @ git+https://github.com/flashinfer-ai/tg4perfetto.git
 cuda-python
 fastapi
 uvicorn
+xgrammar

--- a/src/kernel/graph.cc
+++ b/src/kernel/graph.cc
@@ -635,6 +635,11 @@ void Graph::register_task(char const *task_type, std::vector<int> params) {
     int variant_id =
         task_register->register_sampling_sm100_task(customized->bgraph, params);
     task_config[op] = std::make_tuple(1, 1, TASK_SAMPLING_SM100, variant_id);
+  } else if (name == "apply_token_bitmask_sm100") {
+    int variant_id = task_register->register_apply_token_bitmask_sm100_task(
+        customized->bgraph, params);
+    task_config[op] =
+        std::make_tuple(1, 1, TASK_APPLY_TOKEN_BITMASK_SM100, variant_id);
   } else if (name == "tensor_init") {
     int variant_id =
         task_register->register_tensor_init_task(customized->bgraph, params);
@@ -886,7 +891,9 @@ void Graph::register_task(char const *task_type, std::vector<int> params) {
   }
 
   else {
-    printf("Unsupported task name: %s\n", name);
+    // name is a std::string — use c_str() (passing std::string to %s is UB and
+    // prints garbage, which previously masked "missing task_config" errors).
+    printf("Unsupported task name: %s\n", name.c_str());
     assert(false && "Unsupported task type");
   }
 }

--- a/src/kernel/runtime.cc
+++ b/src/kernel/runtime.cc
@@ -1795,6 +1795,8 @@ TaskGraphResult print_task_graph(
   task_type_to_name[TASK_ARGMAX_PARTIAL_SM100] = "TASK_ARGMAX_PARTIAL_SM100";
   task_type_to_name[TASK_ARGMAX_REDUCE_SM100] = "TASK_ARGMAX_REDUCE_SM100";
   task_type_to_name[TASK_SAMPLING_SM100] = "TASK_SAMPLING_SM100";
+  task_type_to_name[TASK_APPLY_TOKEN_BITMASK_SM100] =
+      "TASK_APPLY_TOKEN_BITMASK_SM100";
   task_type_to_name[TASK_MLA_DECODE_SM100] = "TASK_MLA_DECODE_SM100";
   task_type_to_name[TASK_MLA_REDUCE_SM100] = "TASK_MLA_REDUCE_SM100";
   task_type_to_name[TASK_MLA_PREFILL_SM100] = "TASK_MLA_PREFILL_SM100";

--- a/src/kernel/task_register.cc
+++ b/src/kernel/task_register.cc
@@ -2209,6 +2209,47 @@ int TaskRegister::register_sampling_sm100_task(threadblock::Graph const &bgraph,
   return register_task_variant(TASK_SAMPLING_SM100, code.to_string());
 }
 
+int TaskRegister::register_apply_token_bitmask_sm100_task(
+    threadblock::Graph const &bgraph, std::vector<int> const &params) {
+  // Constrained-decoding logit masking (xgrammar). Reads raw logits (input[0]),
+  // writes masked logits to a distinct output[0] consumed by argmax/sampling.
+  assert(params.size() == 0);
+  std::vector<tb::TBInputOp *> input_ops;
+  std::vector<tb::TBInputOp *> output_ops;
+  int num_inputs = 1;
+  int num_outputs = 1;
+
+  assert(bgraph.operators.size() == (size_t)num_inputs + num_outputs);
+  for (auto const &op : bgraph.operators) {
+    assert(op->op_type == mirage::type::TB_INPUT_OP);
+    if (input_ops.size() < (size_t)num_inputs) {
+      input_ops.push_back(static_cast<tb::TBInputOp *>(op));
+    } else {
+      output_ops.push_back(static_cast<tb::TBInputOp *>(op));
+    }
+  }
+  assert(input_ops[0]->output_tensors[0].num_dims == 2);
+  int batch_size = input_ops[0]->output_tensors[0].dim[0];
+  int vocab_size = input_ops[0]->output_tensors[0].dim[1];
+  int bitmask_words = (vocab_size + 31) / 32;
+
+  mirage::transpiler::CodeKeeper code;
+  code.inc_indent();
+  code.e("kernel::apply_token_bitmask_sm100_kernel<bfloat16, $>(", batch_size);
+  code.e("    task_desc->input_ptrs[0],");  // raw logits
+  code.e("    task_desc->output_ptrs[0],"); // masked logits (distinct)
+  code.e("    runtime_config.pinned_token_bitmask,");
+  code.e("    runtime_config.pinned_mask_seq,");
+  code.e("    runtime_config.pinned_constrained_flag,");
+  code.e("    runtime_config.request_ids,");
+  code.e("    runtime_config.step,");
+  code.e("    $,", vocab_size);
+  code.e("    $,", bitmask_words);
+  code.e("    $);", batch_size);
+  return register_task_variant(TASK_APPLY_TOKEN_BITMASK_SM100,
+                               code.to_string());
+}
+
 int TaskRegister::register_tensor_init_task(threadblock::Graph const &bgraph,
                                             std::vector<int> const &params) {
   assert(params.size() == 0);

--- a/src/kernel/task_register.cc
+++ b/src/kernel/task_register.cc
@@ -2199,12 +2199,12 @@ int TaskRegister::register_sampling_sm100_task(threadblock::Graph const &bgraph,
 
   mirage::transpiler::CodeKeeper code;
   code.inc_indent();
-  code.e("kernel::sampling_from_logits_kernel<256, 4, bfloat16, int>(");
+  code.e("kernel::sampling_from_logits_kernel<256, 4, bfloat16, long long>(");
   code.e("    static_cast<bfloat16*>(task_desc->input_ptrs[0]),");
-  code.e("    static_cast<int*>(task_desc->output_ptrs[0]),");
+  code.e("    static_cast<long long*>(task_desc->output_ptrs[0]),");
   code.e("    $,", vocab_size);
   code.e("    $,", seed);
-  code.e("    0,  // philox_offset");
+  code.e("    (unsigned long long)runtime_config.step[0],  // per-step offset");
   code.e("    $);", batch_size);
   return register_task_variant(TASK_SAMPLING_SM100, code.to_string());
 }
@@ -2243,9 +2243,12 @@ int TaskRegister::register_apply_token_bitmask_sm100_task(
   code.e("    runtime_config.pinned_constrained_flag,");
   code.e("    runtime_config.request_ids,");
   code.e("    runtime_config.step,");
+  code.e("    runtime_config.qo_indptr_buffer,");
   code.e("    $,", vocab_size);
   code.e("    $,", bitmask_words);
-  code.e("    $);", batch_size);
+  // Loop over requests (request_ids/qo_indptr are sized by request count), not
+  // the logits batch dim, to keep those reads in bounds.
+  code.e("    MPK_MAX_NUM_BATCHED_REQUESTS);");
   return register_task_variant(TASK_APPLY_TOKEN_BITMASK_SM100,
                                code.to_string());
 }

--- a/tests/runtime_python/blackwell/sm100_constrained_decoding/test_apply_token_bitmask.py
+++ b/tests/runtime_python/blackwell/sm100_constrained_decoding/test_apply_token_bitmask.py
@@ -1,0 +1,253 @@
+"""
+Tests for MPK constrained decoding (xgrammar).
+
+Two independent checks, both runnable on a Blackwell (sm_100) box with xgrammar
+installed — neither needs the full megakernel build:
+
+1. test_structured_manager_host
+   Drives StructuredGenerationManager with mock pinned buffers (plain CPU
+   tensors) and a synthetic xgrammar grammar, validating the per-step bitmask
+   fill, mask_seq publishing, accept_token sequencing, and the global flag.
+   This exercises the host step-sync contract in structured.py.
+
+2. test_apply_token_bitmask_kernel_cuda
+   Compiles apply_token_bitmask_sm100.cuh standalone and runs it on the GPU,
+   checking the masked output against a CPU reference for both the flag-off
+   (plain copy) and flag-on (masked) paths, including the idle-row (-1) case.
+
+Run directly:   python test_apply_token_bitmask.py
+Run via pytest: pytest test_apply_token_bitmask.py
+"""
+
+import importlib.util
+import os
+import pathlib
+import shutil
+import subprocess
+import tempfile
+
+import pytest
+import torch
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+STRUCTURED_PY = REPO_ROOT / "python" / "mirage" / "mpk" / "structured.py"
+KERNEL_DIR = REPO_ROOT / "include" / "mirage" / "persistent_kernel" / "tasks" / "blackwell"
+
+
+def _load_structured():
+    """Import structured.py directly (no heavy mirage package import)."""
+    spec = importlib.util.spec_from_file_location("mpk_structured", STRUCTURED_PY)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.StructuredGenerationManager
+
+
+def _toy_tokenizer_info(vocab=("a", "b", "c", "d", "e", "f", "g", "h")):
+    import xgrammar as xgr
+
+    ti = xgr.TokenizerInfo(list(vocab), vocab_type=xgr.VocabType.RAW,
+                           vocab_size=len(vocab))
+    return ti, vocab
+
+
+# ── 1. Host logic ─────────────────────────────────────────────────────────
+
+def test_structured_manager_host():
+    xgr = pytest.importorskip("xgrammar")
+    StructuredGenerationManager = _load_structured()
+
+    ti, vocab = _toy_tokenizer_info()
+    V = ti.vocab_size
+    words = (V + 31) // 32
+    n_req, max_seq = 4, 16
+
+    # Mock pinned buffers (CPU tensors stand in for page-locked memory).
+    token_bitmask = torch.full((n_req, words), -1, dtype=torch.int32)
+    mask_seq = torch.zeros(n_req, dtype=torch.int32)
+    flag = torch.zeros(1, dtype=torch.int32)
+    tokens = torch.zeros(n_req, max_seq, dtype=torch.int64)
+    pinned_step = torch.zeros(n_req, dtype=torch.int32)
+    prompt_lengths = torch.zeros(n_req, dtype=torch.int32)
+
+    row_map = {}  # rid -> buffer row (simulates the GPU's assignment)
+
+    def find_row_for_rid(rid):
+        return row_map.get(rid, -1)
+
+    mgr = StructuredGenerationManager(
+        token_bitmask=token_bitmask, mask_seq=mask_seq, constrained_flag=flag,
+        tokens=tokens, pinned_step=pinned_step,
+        find_row_for_rid=find_row_for_rid, prompt_lengths=prompt_lengths,
+    )
+    mgr.init_xgrammar(tokenizer_info=ti, vocab_size=V)
+
+    EBNF = 'root ::= ("a" | "b")+'
+    mgr.set_request_grammar(0, ebnf=EBNF)
+    assert flag[0].item() == 1, "set_request_grammar must turn on the flag"
+
+    # GPU assigns request 0 to row 2; prompt occupies tokens[0..2] (len 3), so
+    # generation begins at position 3.
+    row = 2
+    row_map[0] = row
+    prompt_lengths[row] = 3
+
+    # PREFILL tick (pinned_step 2 < prompt_len): the model is consuming the
+    # prompt. The manager publishes the *fresh* grammar mask and must NOT accept
+    # any token (prefill argmax outputs are not real generations).
+    pinned_step[row] = 2
+    mgr.tick()
+    assert mask_seq[row].item() == 2
+    allowed = [i for i in range(V)
+               if (token_bitmask[row, i // 32].item() >> (i % 32)) & 1]
+    assert allowed == [0, 1], f"prefill fresh mask should allow a/b, got {allowed}"
+
+    # DECODE tick: the first generated token 'a' (id 0) lands at tokens[row, 3];
+    # the manager accepts it and masks the next position.
+    tokens[row, 3] = 0
+    pinned_step[row] = 3
+    mgr.tick()
+    assert mask_seq[row].item() == 3
+
+    # Cross-check the published mask against a fresh matcher that accepted the
+    # same token — the manager's accept_token sequencing must match.
+    cg = mgr._compiler.compile_grammar(EBNF)
+    ref = xgr.GrammarMatcher(cg)
+    assert ref.accept_token(0)
+    ref_bm = xgr.allocate_token_bitmask(1, V)
+    ref.fill_next_token_bitmask(ref_bm, index=0)
+    assert token_bitmask[row, 0].item() == ref_bm[0, 0].item(), \
+        "manager mask diverged from reference after accept_token"
+
+    # Idempotent within a step: a second tick at the same step does nothing.
+    snap = token_bitmask[row, 0].item()
+    mgr.tick()
+    assert token_bitmask[row, 0].item() == snap
+
+    # Releasing the only grammar turns the flag back off.
+    mgr.release(0)
+    assert flag[0].item() == 0, "flag must clear when no grammars remain"
+
+
+# ── 2. CUDA kernel correctness ────────────────────────────────────────────
+
+_CU_SRC = r"""
+#include <cuda_bf16.h>
+#include <cstdio>
+#include <cmath>
+#include <vector>
+typedef __nv_bfloat16 bfloat16;
+#include "apply_token_bitmask_sm100.cuh"
+
+__global__ void probe(void const* in, void* out, int32_t* bm, int32_t* seq,
+                      int32_t* flag, int* rid, int* step,
+                      int v, int w, int n) {
+  kernel::apply_token_bitmask_sm100_kernel<bfloat16, 8>(
+      in, out, bm, seq, flag, rid, step, v, w, n);
+}
+
+#define CK(x) do{ cudaError_t e=(x); if(e){ \
+  printf("CUDA error %s at line %d\n", cudaGetErrorString(e), __LINE__); \
+  return 2; } }while(0)
+
+int main() {
+  const int batch = 3, vocab = 40, words = (vocab + 31) / 32, n_req = 4;
+  std::vector<int> rid = {0, 1, -1};       // row0, row1, idle
+  std::vector<int> step(n_req, 5);
+  std::vector<int32_t> seq(n_req, 5);      // mask already published for step 5
+  std::vector<int32_t> bm(n_req * words, 0);
+  // row 0: even tokens allowed; row 1: tokens < 10 allowed
+  for (int t = 0; t < vocab; t++) {
+    if (t % 2 == 0) bm[0 * words + t / 32] |= (1 << (t % 32));
+    if (t < 10)     bm[1 * words + t / 32] |= (1 << (t % 32));
+  }
+  std::vector<float> hin(batch * vocab, 1.0f);
+  std::vector<bfloat16> hin_bf(batch * vocab);
+  for (size_t i = 0; i < hin.size(); i++) hin_bf[i] = __float2bfloat16(hin[i]);
+
+  bfloat16 *d_in, *d_out; int32_t *d_bm, *d_seq, *d_flag; int *d_rid, *d_step;
+  CK(cudaMalloc(&d_in,  batch * vocab * sizeof(bfloat16)));
+  CK(cudaMalloc(&d_out, batch * vocab * sizeof(bfloat16)));
+  CK(cudaMalloc(&d_bm,  bm.size() * sizeof(int32_t)));
+  CK(cudaMalloc(&d_seq, n_req * sizeof(int32_t)));
+  CK(cudaMalloc(&d_flag, sizeof(int32_t)));
+  CK(cudaMalloc(&d_rid, batch * sizeof(int)));
+  CK(cudaMalloc(&d_step, n_req * sizeof(int)));
+  CK(cudaMemcpy(d_in, hin_bf.data(), hin_bf.size()*sizeof(bfloat16), cudaMemcpyHostToDevice));
+  CK(cudaMemcpy(d_bm, bm.data(), bm.size()*sizeof(int32_t), cudaMemcpyHostToDevice));
+  CK(cudaMemcpy(d_seq, seq.data(), n_req*sizeof(int32_t), cudaMemcpyHostToDevice));
+  CK(cudaMemcpy(d_rid, rid.data(), batch*sizeof(int), cudaMemcpyHostToDevice));
+  CK(cudaMemcpy(d_step, step.data(), n_req*sizeof(int), cudaMemcpyHostToDevice));
+
+  std::vector<bfloat16> hout(batch * vocab);
+  for (int fl = 0; fl < 2; fl++) {
+    int32_t flag = fl;
+    CK(cudaMemcpy(d_flag, &flag, sizeof(int32_t), cudaMemcpyHostToDevice));
+    CK(cudaMemset(d_out, 0, batch * vocab * sizeof(bfloat16)));
+    probe<<<1, 256>>>(d_in, d_out, d_bm, d_seq, d_flag, d_rid, d_step,
+                      vocab, words, batch);
+    CK(cudaGetLastError());
+    CK(cudaDeviceSynchronize());
+    CK(cudaMemcpy(hout.data(), d_out, hout.size()*sizeof(bfloat16), cudaMemcpyDeviceToHost));
+
+    for (int b = 0; b < batch; b++) {
+      int row = rid[b];
+      for (int t = 0; t < vocab; t++) {
+        float got = __bfloat162float(hout[b * vocab + t]);
+        float want = 1.0f;
+        bool do_mask = (fl == 1) && (row >= 0);
+        if (do_mask) {
+          bool allowed = (bm[row * words + t / 32] >> (t % 32)) & 1;
+          if (!allowed) want = -INFINITY;
+        }
+        bool ok = (std::isinf(want) && std::isinf(got) && got < 0)
+                  || (want == got);
+        if (!ok) {
+          printf("MISMATCH flag=%d b=%d t=%d row=%d got=%f want=%f\n",
+                 fl, b, t, row, got, want);
+          return 1;
+        }
+      }
+    }
+  }
+  printf("KERNEL OK\n");
+  return 0;
+}
+"""
+
+
+def _nvcc():
+    return shutil.which("nvcc")
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs a CUDA GPU")
+@pytest.mark.skipif(_nvcc() is None, reason="needs nvcc")
+def test_apply_token_bitmask_kernel_cuda():
+    cc = torch.cuda.get_device_capability(0)
+    arch = f"sm_{cc[0]}{cc[1]}a" if cc[0] >= 9 else f"sm_{cc[0]}{cc[1]}"
+    with tempfile.TemporaryDirectory() as d:
+        src = os.path.join(d, "check.cu")
+        binp = os.path.join(d, "check")
+        with open(src, "w") as f:
+            f.write(_CU_SRC)
+        compile_cmd = [
+            _nvcc(), "-std=c++17", f"-arch={arch}", src, "-o", binp,
+            "-I", str(KERNEL_DIR),
+        ]
+        cp = subprocess.run(compile_cmd, capture_output=True, text=True)
+        assert cp.returncode == 0, f"nvcc failed:\n{cp.stderr}"
+        rp = subprocess.run([binp], capture_output=True, text=True)
+        assert rp.returncode == 0, f"kernel test failed:\n{rp.stdout}\n{rp.stderr}"
+        assert "KERNEL OK" in rp.stdout
+
+
+if __name__ == "__main__":
+    print("[host] StructuredGenerationManager ...", flush=True)
+    test_structured_manager_host()
+    print("  PASS")
+    if torch.cuda.is_available() and _nvcc() is not None:
+        print("[cuda] apply_token_bitmask kernel ...", flush=True)
+        test_apply_token_bitmask_kernel_cuda()
+        print("  PASS")
+    else:
+        print("[cuda] skipped (no GPU/nvcc)")
+    print("ALL PASS")

--- a/tests/runtime_python/blackwell/sm100_constrained_decoding/test_apply_token_bitmask.py
+++ b/tests/runtime_python/blackwell/sm100_constrained_decoding/test_apply_token_bitmask.py
@@ -1,22 +1,12 @@
 """
-Tests for MPK constrained decoding (xgrammar).
+Tests for MPK constrained decoding (xgrammar). Run:
+    pytest test_apply_token_bitmask.py        # or: python test_apply_token_bitmask.py
 
-Two independent checks, both runnable on a Blackwell (sm_100) box with xgrammar
-installed — neither needs the full megakernel build:
-
-1. test_structured_manager_host
-   Drives StructuredGenerationManager with mock pinned buffers (plain CPU
-   tensors) and a synthetic xgrammar grammar, validating the per-step bitmask
-   fill, mask_seq publishing, accept_token sequencing, and the global flag.
-   This exercises the host step-sync contract in structured.py.
-
-2. test_apply_token_bitmask_kernel_cuda
-   Compiles apply_token_bitmask_sm100.cuh standalone and runs it on the GPU,
-   checking the masked output against a CPU reference for both the flag-off
-   (plain copy) and flag-on (masked) paths, including the idle-row (-1) case.
-
-Run directly:   python test_apply_token_bitmask.py
-Run via pytest: pytest test_apply_token_bitmask.py
+Host tests drive StructuredGenerationManager with mock pinned buffers (CPU
+tensors) + a synthetic grammar, checking the per-step bitmask fill, accept
+sequencing, prefill/decode handling, and the flag. The CUDA test compiles
+apply_token_bitmask_sm100.cuh and runs it on the GPU vs a CPU reference. None
+need the full megakernel build.
 """
 
 import importlib.util
@@ -30,105 +20,104 @@ import pytest
 import torch
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
-STRUCTURED_PY = REPO_ROOT / "python" / "mirage" / "mpk" / "structured.py"
-KERNEL_DIR = REPO_ROOT / "include" / "mirage" / "persistent_kernel" / "tasks" / "blackwell"
+STRUCTURED_PY = REPO_ROOT / "python/mirage/mpk/structured.py"
+KERNEL_DIR = REPO_ROOT / "include/mirage/persistent_kernel/tasks/blackwell"
 
 
-def _load_structured():
-    """Import structured.py directly (no heavy mirage package import)."""
-    spec = importlib.util.spec_from_file_location("mpk_structured", STRUCTURED_PY)
-    mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
-    return mod.StructuredGenerationManager
-
-
-def _toy_tokenizer_info(vocab=("a", "b", "c", "d", "e", "f", "g", "h")):
+def _setup(vocab, n_req=4, max_seq=48):
+    """Build a StructuredGenerationManager over a toy char vocab + mock pinned
+    buffers. Returns (mgr, buffers, rows, vocab, V, allowed(row))."""
     import xgrammar as xgr
+    spec = importlib.util.spec_from_file_location("mpk_structured", STRUCTURED_PY)
+    mod = importlib.util.module_from_spec(spec); spec.loader.exec_module(mod)
 
-    ti = xgr.TokenizerInfo(list(vocab), vocab_type=xgr.VocabType.RAW,
-                           vocab_size=len(vocab))
-    return ti, vocab
-
-
-# ── 1. Host logic ─────────────────────────────────────────────────────────
-
-def test_structured_manager_host():
-    xgr = pytest.importorskip("xgrammar")
-    StructuredGenerationManager = _load_structured()
-
-    ti, vocab = _toy_tokenizer_info()
-    V = ti.vocab_size
-    words = (V + 31) // 32
-    n_req, max_seq = 4, 16
-
-    # Mock pinned buffers (CPU tensors stand in for page-locked memory).
-    token_bitmask = torch.full((n_req, words), -1, dtype=torch.int32)
-    mask_seq = torch.zeros(n_req, dtype=torch.int32)
-    flag = torch.zeros(1, dtype=torch.int32)
-    tokens = torch.zeros(n_req, max_seq, dtype=torch.int64)
-    pinned_step = torch.zeros(n_req, dtype=torch.int32)
-    prompt_lengths = torch.zeros(n_req, dtype=torch.int32)
-
-    row_map = {}  # rid -> buffer row (simulates the GPU's assignment)
-
-    def find_row_for_rid(rid):
-        return row_map.get(rid, -1)
-
-    mgr = StructuredGenerationManager(
-        token_bitmask=token_bitmask, mask_seq=mask_seq, constrained_flag=flag,
-        tokens=tokens, pinned_step=pinned_step,
-        find_row_for_rid=find_row_for_rid, prompt_lengths=prompt_lengths,
-    )
+    vocab = list(vocab)
+    V = len(vocab); words = (V + 31) // 32
+    ti = xgr.TokenizerInfo(vocab, vocab_type=xgr.VocabType.RAW, vocab_size=V)
+    B = dict(token_bitmask=torch.full((n_req, words), -1, dtype=torch.int32),
+             mask_seq=torch.zeros(n_req, dtype=torch.int32),
+             constrained_flag=torch.zeros(1, dtype=torch.int32),
+             tokens=torch.zeros(n_req, max_seq, dtype=torch.int64),
+             pinned_step=torch.zeros(n_req, dtype=torch.int32),
+             prompt_lengths=torch.zeros(n_req, dtype=torch.int32))
+    rows = {}
+    mgr = mod.StructuredGenerationManager(
+        find_row_for_rid=lambda r: rows.get(r, -1), **B)
     mgr.init_xgrammar(tokenizer_info=ti, vocab_size=V)
 
+    def allowed(row):
+        bm = B["token_bitmask"]
+        return [i for i in range(V) if (bm[row, i // 32].item() >> (i % 32)) & 1]
+    return mgr, B, rows, vocab, V, allowed
+
+
+def test_structured_manager_host():
+    """Base grammar: prefill (fresh mask, no accept) → decode (accept + mask),
+    cross-checked against a reference matcher, plus flag + idempotency."""
+    import xgrammar as xgr
+    pytest.importorskip("xgrammar")
     EBNF = 'root ::= ("a" | "b")+'
+    mgr, B, rows, vocab, V, allowed = _setup("abcdefgh")
     mgr.set_request_grammar(0, ebnf=EBNF)
-    assert flag[0].item() == 1, "set_request_grammar must turn on the flag"
+    assert int(B["constrained_flag"][0]) == 1
 
-    # GPU assigns request 0 to row 2; prompt occupies tokens[0..2] (len 3), so
-    # generation begins at position 3.
-    row = 2
-    row_map[0] = row
-    prompt_lengths[row] = 3
+    row = 2; rows[0] = row; B["prompt_lengths"][row] = 3
+    # Prefill (step < prompt_len): fresh mask, no token accepted.
+    B["pinned_step"][row] = 2; mgr.tick()
+    assert int(B["mask_seq"][row]) == 2 and allowed(row) == [0, 1]
+    # Decode: first token 'a' (id 0) lands at tokens[row, 3]; accept + mask next.
+    B["tokens"][row, 3] = 0; B["pinned_step"][row] = 3; mgr.tick()
+    assert int(B["mask_seq"][row]) == 3
 
-    # PREFILL tick (pinned_step 2 < prompt_len): the model is consuming the
-    # prompt. The manager publishes the *fresh* grammar mask and must NOT accept
-    # any token (prefill argmax outputs are not real generations).
-    pinned_step[row] = 2
-    mgr.tick()
-    assert mask_seq[row].item() == 2
-    allowed = [i for i in range(V)
-               if (token_bitmask[row, i // 32].item() >> (i % 32)) & 1]
-    assert allowed == [0, 1], f"prefill fresh mask should allow a/b, got {allowed}"
-
-    # DECODE tick: the first generated token 'a' (id 0) lands at tokens[row, 3];
-    # the manager accepts it and masks the next position.
-    tokens[row, 3] = 0
-    pinned_step[row] = 3
-    mgr.tick()
-    assert mask_seq[row].item() == 3
-
-    # Cross-check the published mask against a fresh matcher that accepted the
-    # same token — the manager's accept_token sequencing must match.
-    cg = mgr._compiler.compile_grammar(EBNF)
-    ref = xgr.GrammarMatcher(cg)
+    ref = xgr.GrammarMatcher(mgr._compiler.compile_grammar(EBNF))
     assert ref.accept_token(0)
-    ref_bm = xgr.allocate_token_bitmask(1, V)
-    ref.fill_next_token_bitmask(ref_bm, index=0)
-    assert token_bitmask[row, 0].item() == ref_bm[0, 0].item(), \
-        "manager mask diverged from reference after accept_token"
+    rb = xgr.allocate_token_bitmask(1, V); ref.fill_next_token_bitmask(rb, index=0)
+    assert B["token_bitmask"][row, 0].item() == rb[0, 0].item()
 
-    # Idempotent within a step: a second tick at the same step does nothing.
-    snap = token_bitmask[row, 0].item()
-    mgr.tick()
-    assert token_bitmask[row, 0].item() == snap
-
-    # Releasing the only grammar turns the flag back off.
-    mgr.release(0)
-    assert flag[0].item() == 0, "flag must clear when no grammars remain"
+    snap = B["token_bitmask"][row, 0].item(); mgr.tick()  # idempotent within a step
+    assert B["token_bitmask"][row, 0].item() == snap
+    mgr.release(0); assert int(B["constrained_flag"][0]) == 0
 
 
-# ── 2. CUDA kernel correctness ────────────────────────────────────────────
+def test_structured_manager_structural_tag():
+    """Structural tag (tool-calling): free text until the trigger, then the
+    schema. Driven through the manager's decode path; after the trigger+begin
+    only '{' is allowed."""
+    import json
+    import xgrammar as xgr
+    pytest.importorskip("xgrammar")
+    mgr, B, rows, vocab, V, allowed = _setup(' \t\n{}[]":,.0123456789'
+                                             'abcdefghijklmnopqrstuvwxyz<>=/_')
+    import xgrammar.structural_tag as st
+    idx = {c: i for i, c in enumerate(vocab)}
+    schema = {"type": "object", "properties": {"x": {"type": "integer"}}, "required": ["x"]}
+    stag = st.StructuralTag(format=st.TriggeredTagsFormat(
+        triggers=["<function="],
+        tags=[st.TagFormat(begin="<function=get_weather>",
+                           content=st.JSONSchemaFormat(json_schema=schema),
+                           end="</function>")]))
+    mgr.set_request_grammar(0, structural_tag=stag)
+    assert int(B["constrained_flag"][0]) == 1
+
+    row = 1; rows[0] = row; P = 2; B["prompt_lengths"][row] = P
+    B["pinned_step"][row] = P - 1; mgr.tick()           # prefill → free text
+    assert len(allowed(row)) > V // 2
+
+    ref = xgr.GrammarMatcher(mgr._compiler.compile_structural_tag(stag))
+    rb = xgr.allocate_token_bitmask(1, V); ref.fill_next_token_bitmask(rb, index=0)
+    assert B["token_bitmask"][row, 0].item() == rb[0, 0].item()
+
+    # Generate the trigger+begin; token k lands at tokens[row, P+k].
+    begin = "<function=get_weather>"
+    for k, ch in enumerate(begin):
+        B["tokens"][row, P + k] = idx[ch]
+    for s in range(P, P + len(begin)):
+        B["pinned_step"][row] = s; mgr.tick()
+    assert [vocab[i] for i in allowed(row)] == ['{']
+    mgr.release(0); assert int(B["constrained_flag"][0]) == 0
+
+
+# ── CUDA kernel correctness ────────────────────────────────────────────────
 
 _CU_SRC = r"""
 #include <cuda_bf16.h>
@@ -139,10 +128,10 @@ typedef __nv_bfloat16 bfloat16;
 #include "apply_token_bitmask_sm100.cuh"
 
 __global__ void probe(void const* in, void* out, int32_t* bm, int32_t* seq,
-                      int32_t* flag, int* rid, int* step,
-                      int v, int w, int n) {
-  kernel::apply_token_bitmask_sm100_kernel<bfloat16, 8>(
-      in, out, bm, seq, flag, rid, step, v, w, n);
+                      int32_t* flag, int* rid, int* step, int* qo,
+                      int v, int w, int nreq) {
+  kernel::apply_token_bitmask_sm100_kernel<bfloat16, 4>(
+      in, out, bm, seq, flag, rid, step, qo, v, w, nreq);
 }
 
 #define CK(x) do{ cudaError_t e=(x); if(e){ \
@@ -150,60 +139,46 @@ __global__ void probe(void const* in, void* out, int32_t* bm, int32_t* seq,
   return 2; } }while(0)
 
 int main() {
-  const int batch = 3, vocab = 40, words = (vocab + 31) / 32, n_req = 4;
-  std::vector<int> rid = {0, 1, -1};       // row0, row1, idle
-  std::vector<int> step(n_req, 5);
-  std::vector<int32_t> seq(n_req, 5);      // mask already published for step 5
-  std::vector<int32_t> bm(n_req * words, 0);
-  // row 0: even tokens allowed; row 1: tokens < 10 allowed
+  // BATCH=4 logits rows; 2 decode requests (1 token each) on rows 5,6;
+  // qo_indptr=[0,1,2] -> req b's next-token logits are row b. Rows 2,3 unused.
+  const int BATCH = 4, vocab = 40, words = (vocab + 31) / 32, n_req = 8;
+  const int num_requests = 2;
+  std::vector<int> rid = {5, 6}, qo = {0, 1, 2}, step(n_req, 5);
+  std::vector<int32_t> seq(n_req, 5), bm(n_req * words, 0);
   for (int t = 0; t < vocab; t++) {
-    if (t % 2 == 0) bm[0 * words + t / 32] |= (1 << (t % 32));
-    if (t < 10)     bm[1 * words + t / 32] |= (1 << (t % 32));
+    if (t % 2 == 0) bm[5 * words + t / 32] |= (1 << (t % 32)); // row5: even
+    if (t < 10)     bm[6 * words + t / 32] |= (1 << (t % 32)); // row6: t<10
   }
-  std::vector<float> hin(batch * vocab, 1.0f);
-  std::vector<bfloat16> hin_bf(batch * vocab);
-  for (size_t i = 0; i < hin.size(); i++) hin_bf[i] = __float2bfloat16(hin[i]);
+  std::vector<bfloat16> hin(BATCH * vocab), hout(BATCH * vocab);
+  for (auto &x : hin) x = __float2bfloat16(1.0f);
 
-  bfloat16 *d_in, *d_out; int32_t *d_bm, *d_seq, *d_flag; int *d_rid, *d_step;
-  CK(cudaMalloc(&d_in,  batch * vocab * sizeof(bfloat16)));
-  CK(cudaMalloc(&d_out, batch * vocab * sizeof(bfloat16)));
-  CK(cudaMalloc(&d_bm,  bm.size() * sizeof(int32_t)));
-  CK(cudaMalloc(&d_seq, n_req * sizeof(int32_t)));
-  CK(cudaMalloc(&d_flag, sizeof(int32_t)));
-  CK(cudaMalloc(&d_rid, batch * sizeof(int)));
-  CK(cudaMalloc(&d_step, n_req * sizeof(int)));
-  CK(cudaMemcpy(d_in, hin_bf.data(), hin_bf.size()*sizeof(bfloat16), cudaMemcpyHostToDevice));
-  CK(cudaMemcpy(d_bm, bm.data(), bm.size()*sizeof(int32_t), cudaMemcpyHostToDevice));
-  CK(cudaMemcpy(d_seq, seq.data(), n_req*sizeof(int32_t), cudaMemcpyHostToDevice));
-  CK(cudaMemcpy(d_rid, rid.data(), batch*sizeof(int), cudaMemcpyHostToDevice));
-  CK(cudaMemcpy(d_step, step.data(), n_req*sizeof(int), cudaMemcpyHostToDevice));
+  bfloat16 *d_in, *d_out; int32_t *d_bm, *d_seq, *d_flag; int *d_rid, *d_step, *d_qo;
+  CK(cudaMalloc(&d_in, BATCH*vocab*2)); CK(cudaMalloc(&d_out, BATCH*vocab*2));
+  CK(cudaMalloc(&d_bm, bm.size()*4)); CK(cudaMalloc(&d_seq, n_req*4));
+  CK(cudaMalloc(&d_flag, 4)); CK(cudaMalloc(&d_rid, num_requests*4));
+  CK(cudaMalloc(&d_step, n_req*4)); CK(cudaMalloc(&d_qo, (num_requests+1)*4));
+  CK(cudaMemcpy(d_in, hin.data(), BATCH*vocab*2, cudaMemcpyHostToDevice));
+  CK(cudaMemcpy(d_bm, bm.data(), bm.size()*4, cudaMemcpyHostToDevice));
+  CK(cudaMemcpy(d_seq, seq.data(), n_req*4, cudaMemcpyHostToDevice));
+  CK(cudaMemcpy(d_rid, rid.data(), num_requests*4, cudaMemcpyHostToDevice));
+  CK(cudaMemcpy(d_step, step.data(), n_req*4, cudaMemcpyHostToDevice));
+  CK(cudaMemcpy(d_qo, qo.data(), (num_requests+1)*4, cudaMemcpyHostToDevice));
 
-  std::vector<bfloat16> hout(batch * vocab);
   for (int fl = 0; fl < 2; fl++) {
-    int32_t flag = fl;
-    CK(cudaMemcpy(d_flag, &flag, sizeof(int32_t), cudaMemcpyHostToDevice));
-    CK(cudaMemset(d_out, 0, batch * vocab * sizeof(bfloat16)));
-    probe<<<1, 256>>>(d_in, d_out, d_bm, d_seq, d_flag, d_rid, d_step,
-                      vocab, words, batch);
-    CK(cudaGetLastError());
-    CK(cudaDeviceSynchronize());
-    CK(cudaMemcpy(hout.data(), d_out, hout.size()*sizeof(bfloat16), cudaMemcpyDeviceToHost));
-
-    for (int b = 0; b < batch; b++) {
-      int row = rid[b];
+    CK(cudaMemcpy(d_flag, &fl, 4, cudaMemcpyHostToDevice));
+    CK(cudaMemset(d_out, 0, BATCH*vocab*2));
+    probe<<<1, 256>>>(d_in, d_out, d_bm, d_seq, d_flag, d_rid, d_step, d_qo,
+                      vocab, words, num_requests);
+    CK(cudaGetLastError()); CK(cudaDeviceSynchronize());
+    CK(cudaMemcpy(hout.data(), d_out, BATCH*vocab*2, cudaMemcpyDeviceToHost));
+    for (int pos = 0; pos < BATCH; pos++) {
+      int row = (pos == 0) ? 5 : (pos == 1) ? 6 : -1;  // pos 2,3 -> plain copy
       for (int t = 0; t < vocab; t++) {
-        float got = __bfloat162float(hout[b * vocab + t]);
-        float want = 1.0f;
-        bool do_mask = (fl == 1) && (row >= 0);
-        if (do_mask) {
-          bool allowed = (bm[row * words + t / 32] >> (t % 32)) & 1;
-          if (!allowed) want = -INFINITY;
-        }
-        bool ok = (std::isinf(want) && std::isinf(got) && got < 0)
-                  || (want == got);
-        if (!ok) {
-          printf("MISMATCH flag=%d b=%d t=%d row=%d got=%f want=%f\n",
-                 fl, b, t, row, got, want);
+        float got = __bfloat162float(hout[pos * vocab + t]), want = 1.0f;
+        if (fl == 1 && row >= 0 && !((bm[row*words + t/32] >> (t%32)) & 1))
+          want = -INFINITY;
+        if (!((std::isinf(want) && std::isinf(got) && got < 0) || want == got)) {
+          printf("MISMATCH fl=%d pos=%d t=%d got=%f want=%f\n", fl, pos, t, got, want);
           return 1;
         }
       }
@@ -225,29 +200,21 @@ def test_apply_token_bitmask_kernel_cuda():
     cc = torch.cuda.get_device_capability(0)
     arch = f"sm_{cc[0]}{cc[1]}a" if cc[0] >= 9 else f"sm_{cc[0]}{cc[1]}"
     with tempfile.TemporaryDirectory() as d:
-        src = os.path.join(d, "check.cu")
-        binp = os.path.join(d, "check")
-        with open(src, "w") as f:
-            f.write(_CU_SRC)
-        compile_cmd = [
-            _nvcc(), "-std=c++17", f"-arch={arch}", src, "-o", binp,
-            "-I", str(KERNEL_DIR),
-        ]
-        cp = subprocess.run(compile_cmd, capture_output=True, text=True)
+        src, binp = os.path.join(d, "check.cu"), os.path.join(d, "check")
+        open(src, "w").write(_CU_SRC)
+        cp = subprocess.run([_nvcc(), "-std=c++17", f"-arch={arch}", src, "-o",
+                             binp, "-I", str(KERNEL_DIR)],
+                            capture_output=True, text=True)
         assert cp.returncode == 0, f"nvcc failed:\n{cp.stderr}"
         rp = subprocess.run([binp], capture_output=True, text=True)
-        assert rp.returncode == 0, f"kernel test failed:\n{rp.stdout}\n{rp.stderr}"
-        assert "KERNEL OK" in rp.stdout
+        assert rp.returncode == 0 and "KERNEL OK" in rp.stdout, rp.stdout + rp.stderr
 
 
 if __name__ == "__main__":
-    print("[host] StructuredGenerationManager ...", flush=True)
-    test_structured_manager_host()
-    print("  PASS")
-    if torch.cuda.is_available() and _nvcc() is not None:
-        print("[cuda] apply_token_bitmask kernel ...", flush=True)
-        test_apply_token_bitmask_kernel_cuda()
-        print("  PASS")
+    test_structured_manager_host(); print("[host] base          PASS")
+    test_structured_manager_structural_tag(); print("[host] structural    PASS")
+    if torch.cuda.is_available() and _nvcc():
+        test_apply_token_bitmask_kernel_cuda(); print("[cuda] kernel        PASS")
     else:
         print("[cuda] skipped (no GPU/nvcc)")
     print("ALL PASS")


### PR DESCRIPTION
# Structured / Constrained decoding for MPK (xgrammar)

## Summary

Constrain a request's output to a grammar — JSON schema, regex, EBNF, or tool-calling structural tags — with the token masking applied **inside the running megakernel** via [xgrammar](https://github.com/mlc-ai/xgrammar). The grammar runs on the CPU, overlapped with the GPU forward pass; a runtime flag gates the masking task, so switching between constrained and unconstrained decode is a flag flip (no recompile) and unconstrained requests are unaffected. Only `online_pinned` mode.

## How to use

```python
from mirage.engine import ModelRunner, RunnerConfig

cfg = RunnerConfig(model="Qwen/Qwen3-8B",
                   vocab_size=153600,            # the model's PADDED logit width
                   enable_constrained_decoding=True,
                   do_sample=True)
runner = ModelRunner(cfg)                        # xgrammar auto-initialized
rt = runner.runtime

rt.set_request_grammar(rid, json_schema=schema)  # or ebnf= / regex= / none ⇒ builtin JSON
rt.submit(rid, prompt_token_ids)                 # grammar auto-released on completion
```

Tool calling — build a structural tag from a registry of tool JSON files:

```python
from mirage.mpk import create_tools
tools = create_tools("path/to/tools")            # a dir of *.json, or a list of JSON strings
rt.set_request_grammar(rid, triggered_tags=tools)      # free text + interleaved calls
#   ...tags_with_separator=tools (tool-only) | dispatch=tools (many tools)
#   ...add model="qwen_3" to emit the model's native tool-call format
```

`vocab_size` must equal the model's padded logit dim (a mismatch is asserted).
To enable a new model, insert one layer before its argmax/sampling layer:

```python
self.mpk.apply_token_bitmask_layer(logits=self.argmax_in, output=masked,
                                   grid_dim=(1, 1, 1), block_dim=(128, 1, 1))
```

## Demos

```bash
# host only, no GPU — drives the real manager over synthetic logits
python demo/constrained_decoding/demo.py                     # JSON grammar
python demo/constrained_decoding/demo.py --grammar email     # regex

# live
CUDA_VISIBLE_DEVICES=0 python demo/constrained_decoding/demo.py --model Qwen/Qwen3-8B --vocab-size 153600
CUDA_VISIBLE_DEVICES=0 python demo/constrained_decoding/agent_tools.py     # single-turn tool call

# coding agent (optimize top-k python implementation)
python demo/coding_agent_large/run.py --scripted                             # no GPU/model
CUDA_VISIBLE_DEVICES=0 python demo/coding_agent_large/run.py  # live, Qwen3-14B
```

## Architecture

Top to bottom, one decode step:

1. **Grammar** — `rt.set_request_grammar(rid, ...)` compiles the source (JSON schema / EBNF / regex / structural tag) with xgrammar's `GrammarCompiler` (cached) into a per-request `GrammarMatcher`. Tool structural tags are built from a registry by `structured_tools` (`create_tools` → `build_*`).

2. **Host** — `StructuredGenerationManager` (`structured.py`) owns all xgrammar state. Each step, `tick()` — driven by `OnlinePinnedRuntime`'s background drain loop — reads the last sampled token, `matcher.accept_token(...)`,
   `matcher.fill_next_token_bitmask(...)`, then publishes `mask_seq` (bitmask written first). This runs overlapped with the GPU forward pass, so the mask is ready by the time the tail masking task runs.

3. **Transport** — three pinned (page-locked) buffers carry the mask CPU→GPU, indexed by buffer row: `token_bitmask` `[n_req, ceil(vocab/32)]` (bit *j* set ⇒ token *j* allowed), `mask_seq` `[n_req]` (decode step the row's mask is
   valid for), `constrained_flag` `[1]` (global on/off).

4. **Device** — `apply_token_bitmask` (task 279, `apply_token_bitmask_sm100.cuh`) is compiled once into the static graph between `lm_head` and argmax/sampling. 
    - `flag == 0` → plain `logits → output` copy.
    - `flag == 1` → per active request, `ld.acquire.sys`-spin until `mask_seq[row] >= step`, then `output[v] = allowed(v) ? logits[v] : -inf`. The rendezvous reuses MPK's existing system-scope acquire/release; a distinct output keeps the producer/consumer wiring unambiguous.

5. **Sampling** — argmax / Gumbel-max sampling consumes the masked logits.

6. **Lifecycle** — `ModelRunner` calls `init_xgrammar` when the flag is set; the runtime auto-releases a request's grammar on completion, clearing the global flag once none remain.
