### PR TITLE
Add SM120 support

### DIFF
--- a/include/mirage/persistent_kernel/runtime_header.h
+++ b/include/mirage/persistent_kernel/runtime_header.h
@@ -34,7 +34,12 @@ constexpr int WORKER_RESERVED_STATIC_SHARED_MEMORY_SIZE = 3 * 1024;
 
 #if defined(MODE_ONLINE_NOTOKEN) || defined(MODE_MULTI_TURN)
 // Have to be smaller for vllm compatibility, or program will stuck
-#if MPK_TARGET_CC >= 90
+#if MPK_TARGET_CC == 120
+// Consumer/workstation Blackwell (SM120, e.g. RTX Pro 6000): ~99KB max
+// dynamic smem per block, unlike datacenter Hopper/Blackwell's ~220KB.
+constexpr int MAX_DYNAMIC_SHARED_MEMORY_SIZE =
+    99 * 1024 - WORKER_RESERVED_STATIC_SHARED_MEMORY_SIZE;
+#elif MPK_TARGET_CC >= 90
 constexpr int MAX_DYNAMIC_SHARED_MEMORY_SIZE =
     220 * 1024 - WORKER_RESERVED_STATIC_SHARED_MEMORY_SIZE;
 #elif MPK_TARGET_CC >= 86
@@ -48,7 +53,12 @@ constexpr int MAX_DYNAMIC_SHARED_MEMORY_SIZE =
     163 * 1024 - WORKER_RESERVED_STATIC_SHARED_MEMORY_SIZE;
 #endif
 #else
-#if MPK_TARGET_CC >= 90
+#if MPK_TARGET_CC == 120
+// Consumer/workstation Blackwell (SM120, e.g. RTX Pro 6000): ~99KB max
+// dynamic smem per block, unlike datacenter Hopper/Blackwell's ~207-220KB.
+constexpr int MAX_DYNAMIC_SHARED_MEMORY_SIZE =
+    99 * 1024 - WORKER_RESERVED_STATIC_SHARED_MEMORY_SIZE;
+#elif MPK_TARGET_CC >= 90
 // B200: 228KB total smem. PR 651 MLA reduce adds ~16KB static smem
 // (la_smem[MAX_SK*128]). Reduce dynamic budget to stay under total limit.
 constexpr int MAX_DYNAMIC_SHARED_MEMORY_SIZE =

--- a/include/mirage/persistent_kernel/tasks/hopper/utils.cuh
+++ b/include/mirage/persistent_kernel/tasks/hopper/utils.cuh
@@ -28,7 +28,13 @@ static __device__ __forceinline__ void wg_decrease_regs() {
 // sync inside a warp group
 template <int GROUP_THREADS>
 static __device__ __forceinline__ void wg_sync(uint32_t barrier_id) {
-#if defined(MIRAGE_GRACE_HOPPER) || defined(MIRAGE_GRACE_BLACKWELL)
+// bar.sync with a named barrier is portable PTX (sm_70+); SM120 (consumer
+// Blackwell) builds have no warp-group specialization but still reach this
+// helper through shared code paths, so route them to the portable form
+// instead of the brkpt fallback (which is only meant to catch genuinely
+// unsupported architectures at runtime).
+#if defined(MIRAGE_GRACE_HOPPER) || defined(MIRAGE_GRACE_BLACKWELL) ||        \
+    (defined(MPK_TARGET_CC) && MPK_TARGET_CC == 120)
   asm volatile("bar.sync %0, %1;\n" ::"r"(barrier_id), "n"(GROUP_THREADS));
 #elif defined(__CUDA_ARCH__)
   asm volatile("brkpt;\n" ::);

--- a/python/mirage/mpk/persistent_kernel.py
+++ b/python/mirage/mpk/persistent_kernel.py
@@ -663,7 +663,11 @@ class PersistentKernel:
         tb_graph.new_input(weight, (-1, -1, -1), 0, True)
         tb_graph.new_input(output, (0, -1, -1), 1, True)
         self.kn_graph.customized([input, weight, output], tb_graph)
-        self.kn_graph.register_task(tb_graph, "rmsnorm_hopper" if self.target_cc >= 90 else "rmsnorm")
+        # SM120 (consumer Blackwell) has no TMA/WGMMA and uses the ampere
+        # task set, not the Hopper-specific kernel.
+        self.kn_graph.register_task(
+            tb_graph,
+            "rmsnorm_hopper" if 90 <= self.target_cc < 120 else "rmsnorm")
 
     def rmsnorm_linear_layer(
         self,
@@ -1884,7 +1888,9 @@ class PersistentKernel:
                 # self.kn_graph.register_task(tb_graph, "linear_cutlass_hopper")
             else:
                 self.kn_graph.register_task(tb_graph, "linear_swapAB_hopper")
-        elif self.target_cc >= 80 and self.target_cc < 90:
+        elif (self.target_cc >= 80 and self.target_cc < 90) or self.target_cc == 120:
+            # SM120 (consumer/workstation Blackwell): no tcgen05/WGMMA, use
+            # the ampere task set.
             self.kn_graph.register_task(tb_graph, "linear")
         else:
             assert False, f"Unsupported compute capability: {self.target_cc}"
@@ -1923,7 +1929,9 @@ class PersistentKernel:
                 self.kn_graph.register_task(tb_graph, "linear_swapAB_with_residual_hopper", params)
             else:
                 self.kn_graph.register_task(tb_graph, "linear_swapAB_with_residual_hopper", params)
-        elif self.target_cc >= 80 and self.target_cc < 90:
+        elif (self.target_cc >= 80 and self.target_cc < 90) or self.target_cc == 120:
+            # SM120 (consumer/workstation Blackwell): no tcgen05/WGMMA, use
+            # the ampere task set.
             self.kn_graph.register_task(tb_graph, "linear_with_residual")
         else:
             assert False, f"Unsupported compute capability: {self.target_cc}"


### PR DESCRIPTION
## Summary

Adds an SM120 path so MPK runs on consumer/workstation Blackwell (e.g. RTX Pro 6000, cc120). Previously MPK had no SM120 support:

- `linear_layer` / `linear_with_residual_layer` hit `assert False, "Unsupported compute capability: 120"`.
- The shared-memory ladder misclassified SM120 into the `>= 90` (Hopper/datacenter-Blackwell) bucket and requested ~207–220KB of dynamic smem, but SM120 only has ~99KB usable per block. This over-request is the root cause of the persistent-kernel scheduler hangs seen on this hardware.

## Changes

- **`runtime_header.h`**: add an explicit `MPK_TARGET_CC == 120` rung (99KB) ahead of the `>= 90` check in both shared-memory ladders.
- **`hopper/utils.cuh`**: `wg_sync` now emits portable `bar.sync` PTX for SM120 instead of falling through to the `brkpt` trap.
- **`persistent_kernel.py`**: `rmsnorm_layer` bounds the Hopper kernel dispatch to `90 <= cc < 120` (previously any `cc >= 90` incorrectly picked the Hopper-specific TMA/WGMMA kernel); `linear_layer` / `linear_with_residual_layer` route SM120 to the ampere task set (no TMA/WGMMA required there).

All SM120 gates use exact `== 120` rather than `>= 120`, so a future higher compute capability still falls through to the loud `assert False` / correct datacenter rung instead of silently reusing the SM120-specific path.

## Test results

Verified on real **RTX Pro 6000 (Blackwell Workstation, cc120)** hardware. Both tests previously failed/hung on this GPU. Compiled with `-DMPK_TARGET_CC=120`; the megakernel now requests `smem size: 98304` (96KB, under the ~99KB limit — the fix that resolves the hang).

**`test_diamond_fork_join_testmode.py`**
```
[MPK INIT] Total tasks: 1546, Total events: 5
diff A = 0.00390625, B = 0.0009765625, C = 0.0009765625, D = 0.001953125
PASSED: diamond_fork_join test_mode produces correct output
```

**`test_qwen3_mlp_testmode.py`** (three stages, bf16 tolerance)
```
Test: Gate+Up linear only (dense Qwen3 MLP)
  Max absolute diff: 0.007812
  PASSED: gate+up linear layer produces correct output

Test: Gate+Up linear + SiLU-Mul
  Max absolute diff: 0.015625
  PASSED: gate+up + silu_mul produces correct output

Test: Full MLP pipeline (gate+up → silu_mul → down+residual)
  B=8, hidden=4096, intermediate=2048
  Max absolute diff: 0.015625
  PASSED: full MLP pipeline produces correct output
```

## Out of scope

No ampere/generic fallback kernel exists to route these to (would need new kernel work): MoE layers, FP8 group GEMM, split-KV attention — all Hopper/datacenter-Blackwell-only today.
