### PR TITLE
Support Qwen3-32B: fix split-K linear grid for non-dividing K dims

### DIFF
--- a/demo/qwen3/demo.py
+++ b/demo/qwen3/demo.py
@@ -8,6 +8,7 @@ import os, json
 
 from models.qwen3_shard_loader import Qwen3ShardLoader
 from mirage.mpk.base_dynamic_shard_loader import ShardType
+from mirage.mpk.models.utils import grid_for_splitk_linear_layer
 
 
 mapping = {
@@ -608,7 +609,7 @@ if __name__ == "__main__":
                     input=attn_out,
                     weight=w,
                     output=attn_proj_out,
-                    grid_dim=(hidden_size // 128, 128 * 128 // hidden_size, 1),
+                    grid_dim=grid_for_splitk_linear_layer(hidden_size, w.dim(1)),
                     block_dim=(256, 1, 1),
                 )
             else:
@@ -688,7 +689,7 @@ if __name__ == "__main__":
                     input=silu_mul_out,
                     weight=w,
                     output=mlp_out,
-                    grid_dim=(hidden_size // 128, 128 * 128 // hidden_size, 1),
+                    grid_dim=grid_for_splitk_linear_layer(hidden_size, w.dim(1)),
                     block_dim=(256, 1, 1),
                 )
             else:

--- a/python/mirage/mpk/models/qwen3/builder.py
+++ b/python/mirage/mpk/models/qwen3/builder.py
@@ -1,7 +1,7 @@
 from safetensors.torch import load_model
 import torch
 
-from ..utils import grid_for_rmsnorm_linear_layer, shuffle_tensors, inplace_shuffle_tensors
+from ..utils import grid_for_rmsnorm_linear_layer, grid_for_splitk_linear_layer, shuffle_tensors, inplace_shuffle_tensors
 from ..graph_builder import GraphBuilder, MirageModelConfig
 from ...persistent_kernel import PersistentKernel
 from ...model_registry import register_model_builder
@@ -9,7 +9,7 @@ from ....core import bfloat16, int64
 
 from typing import Optional
 
-@register_model_builder("Qwen3", "Qwen/Qwen3-8B", "Qwen/Qwen3-1.7B", "Qwen/Qwen3-14B", "Qwen/Qwen3-0.6B", "Qwen/Qwen3.5-0.8B", "Qwen3.5-0.8B")
+@register_model_builder("Qwen3", "Qwen/Qwen3-8B", "Qwen/Qwen3-1.7B", "Qwen/Qwen3-14B", "Qwen/Qwen3-32B", "Qwen/Qwen3-0.6B", "Qwen/Qwen3.5-0.8B", "Qwen3.5-0.8B")
 class Qwen3Builder(GraphBuilder):
     def __init__(self, mpk: PersistentKernel, weights: Optional[dict] = None):
         super().__init__(mpk, weights)
@@ -382,7 +382,7 @@ class Qwen3Builder(GraphBuilder):
                     input=self.attn_out,
                     weight=self.w,
                     output=self.attn_proj_out,
-                    grid_dim=(self.hidden_size // 128, 128 * 128 // self.hidden_size, 1),
+                    grid_dim=grid_for_splitk_linear_layer(self.hidden_size, self.w.dim(1)),
                     block_dim=(256, 1, 1),
                 )
             else:
@@ -497,7 +497,7 @@ class Qwen3Builder(GraphBuilder):
                     input=self.silu_mul_out,
                     weight=self.w,
                     output=self.mlp_out,
-                    grid_dim=(self.hidden_size // 128, 128 * 128 // self.hidden_size, 1),
+                    grid_dim=grid_for_splitk_linear_layer(self.hidden_size, self.w.dim(1)),
                     block_dim=(256, 1, 1),
                 )
             else:

--- a/python/mirage/mpk/models/utils.py
+++ b/python/mirage/mpk/models/utils.py
@@ -13,7 +13,26 @@ def grid_for_rmsnorm_linear_layer(size):
         return 96
     elif size % 64 == 0:
         return 64
-    
+
+def grid_for_splitk_linear_layer(output_size, reduction_size):
+    """Grid for the split-K linear task (SM100).
+
+    x tiles the output in MMA_M=128 rows; y is the number of K splits. Each
+    split becomes a task whose input/weight slice starts reduction_size//y
+    elements into the K dim, so that size must keep TMA 16B alignment and
+    match the kernel's 64-element K tiles: y must divide reduction_size and
+    reduction_size//y must be a multiple of 64. The previous fixed
+    y = 128*128//output_size broke models where it does not divide the K dim
+    (e.g. Qwen3-32B o_proj: 8192 / 3), producing misaligned TMA descriptors.
+    """
+    max_splits = max(1, (128 * 128) // output_size)
+    splits = 1
+    for s in range(max_splits, 0, -1):
+        if reduction_size % s == 0 and (reduction_size // s) % 64 == 0:
+            splits = s
+            break
+    return (output_size // 128, splits, 1)
+
 # Return the largest factor of m that is less than or equal to n
 # This is used to determine the grid size
 def max_factor_leq_n(m: int, n: int) -> int:


### PR DESCRIPTION
Fixes #700.

Two changes:

1. Register `Qwen/Qwen3-32B` in the Qwen3 builder.
2. Fix the SM100 split-K linear grid that blocked it: the split count was `128 * 128 // hidden_size`, which for hidden 5120 gives 3 — dividing neither o_proj K (8192) nor down_proj K (25600). The ceil-split slices then start at non-16B-aligned offsets (8533 × 2B), so every `TASK_SPLITK_LINEAR_SM100` TMA descriptor fails (`Error in tile TMA descriptor creation: invalid argument`) and the megakernel dies with an illegal instruction. 8B only worked because 4 splits divide its K dims cleanly; 14B has the same broken 3-split math.

`grid_for_splitk_linear_layer(output_size, reduction_size)` now picks the largest split count ≤ the old heuristic that divides K into 64-element multiples (16B TMA alignment + the kernel's bK=64 tiles). Grids are unchanged for 0.6B/1.7B/8B; 14B/32B get 2 splits instead of 3.

**Verified on B200 (sm_100a):** `demo.py --model Qwen/Qwen3-32B --use-mirage` went from TMA errors + crash to coherent output, 15.27 ms/token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)