### PR TITLE
fix: add MoE residual on every rank when it is a TP partial sum

### DIFF
--- a/python/mirage/mpk/models/deepseek_v3/builder.py
+++ b/python/mirage/mpk/models/deepseek_v3/builder.py
@@ -1143,6 +1143,11 @@ class DeepSeekV3Builder(GraphBuilder):
                          residual=None)
 
         # Final: moe_output = sum(routed_experts * weights) + shared_residual
+        # shared_residual is the shared expert's down_proj output, which is
+        # row-parallel: each rank holds a partial sum that the allreduce on
+        # moe_output is meant to add up. The skip connection is applied
+        # separately after that allreduce, so this residual must be added on
+        # every rank rather than only on rank 0.
         self.mpk.moe_mul_sum_add_layer(
             input=moe_down_out,
             weight=moe_topk_weights,
@@ -1150,6 +1155,7 @@ class DeepSeekV3Builder(GraphBuilder):
             output=moe_output,
             grid_dim=(self.max_num_batched_tokens, 1, 1),
             block_dim=(128, 1, 1),
+            add_residual_once=False,
         )
         self.mlp_out = moe_output
 
@@ -1631,10 +1637,13 @@ class DeepSeekV3Builder(GraphBuilder):
                          grid_dim=(self.hidden_size // 64, 1, 1),
                          block_dim=(128, 1, 1), residual=_mtp_resid)
 
+        # shared_residual is a row-parallel partial (see _build_moe_mlp); every
+        # rank must add its own so the following allreduce sums them.
         self.mpk.moe_mul_sum_add_layer(
             input=moe_down_out, weight=moe_topk_weights,
             residual=shared_residual, output=moe_output,
-            grid_dim=(mbt, 1, 1), block_dim=(128, 1, 1))
+            grid_dim=(mbt, 1, 1), block_dim=(128, 1, 1),
+            add_residual_once=False)
         self.mlp_out = moe_output
 
     def _build_mtp_layer(self, state_dict: dict):

--- a/python/mirage/mpk/persistent_kernel.py
+++ b/python/mirage/mpk/persistent_kernel.py
@@ -2051,6 +2051,7 @@ class PersistentKernel:
         output: DTensor,
         grid_dim: tuple,
         block_dim: tuple,
+        add_residual_once: bool = True,
     ):
         # Currently assume that input/output
         assert input.num_dims == 3  # (batch_size, num_experts_per_tok, hidden_size)
@@ -2065,16 +2066,22 @@ class PersistentKernel:
         self.kn_graph.customized([input, weight, residual, output], tb_graph)
 
         # Under tensor parallelism the MoE output is row-parallel and followed by
-        # an allreduce. The residual must be added on exactly one rank, otherwise
-        # the allreduce sums it world_size times (double-counted residual). Mirror
-        # the rank-0-only guard used by linear_with_residual_layer; the SM100
-        # kernel skips the residual add when its pointer is null (params[0]==0).
-        params = []
+        # an allreduce, so how the residual combines with it depends on what the
+        # caller passed:
+        #   add_residual_once=True  - the residual holds the same value on every
+        #       rank (a skip connection). Exactly one rank may add it, or the
+        #       allreduce counts it world_size times (double-counted residual).
+        #   add_residual_once=False - the residual is a per-rank partial that the
+        #       allreduce is meant to sum, such as a row-parallel shared-expert
+        #       output. Every rank must add the partial it was given, or the
+        #       other ranks' contributions are dropped.
+        # The SM100 kernel skips the residual add when its pointer is null
+        # (params[0]==0).
         enable_residual = 1
-        if self.world_size > 1 and self.mpi_rank != 0:
+        if add_residual_once and self.world_size > 1 and self.mpi_rank != 0:
             enable_residual = 0
-        params.append(enable_residual)
-        self.kn_graph.register_task(tb_graph, "moe_mul_sum_add_sm100", params)
+        self.kn_graph.register_task(
+            tb_graph, "moe_mul_sum_add_sm100", [enable_residual])
 
     def splitk_linear_layer(
         self,

--- a/tests/runtime_python/test_mode/test_moe_residual_rank_guard_testmode.py
+++ b/tests/runtime_python/test_mode/test_moe_residual_rank_guard_testmode.py
@@ -1,0 +1,189 @@
+"""
+Test: moe_mul_sum_add_layer residual handling under tensor parallelism.
+
+Under TP the MoE output is row-parallel and followed by an allreduce, so the
+correct way to combine the residual depends on what the caller passed:
+
+  add_residual_once=True  (default) - the residual is the same on every rank,
+      e.g. a skip connection. Exactly one rank may add it, otherwise the
+      allreduce counts it world_size times. This is the PR #722 fix.
+
+  add_residual_once=False - the residual is a per-rank partial that the
+      allreduce is meant to sum, e.g. DeepSeek V3's row-parallel shared-expert
+      output. Every rank must add its own, otherwise the other ranks'
+      contributions are silently dropped.
+
+Two test functions:
+  1. test_rank_guard_flags:  which residual-enable flag reaches the task for a
+     matrix of (world_size, mpi_rank, add_residual_once). Registration only, so
+     it runs on a single GPU without MPI/NVSHMEM.
+  2. test_mul_sum_add_numerics: world_size=1 end-to-end compile+run against a
+     PyTorch reference. moe_mul_sum_add_layer previously had no test_mode
+     coverage at all.
+
+Run:
+    python tests/runtime_python/test_mode/test_moe_residual_rank_guard_testmode.py
+"""
+
+import torch
+import sys
+import os
+
+import mirage
+from mirage.mpk.persistent_kernel import PersistentKernel
+
+
+BATCH_SIZE = 1
+HIDDEN_SIZE = 4096
+NUM_TOPK = 8
+
+
+def _make_pk(world_size=1, mpi_rank=0):
+    num_workers, num_schedulers = mirage.get_configurations_from_gpu(0)
+    params = PersistentKernel.get_default_init_parameters()
+    params.update(
+        test_mode=True,
+        num_workers=num_workers,
+        num_local_schedulers=num_schedulers,
+        mpi_rank=mpi_rank,
+        world_size=world_size,
+        max_num_batched_tokens=BATCH_SIZE,
+        max_num_batched_requests=BATCH_SIZE,
+    )
+    return PersistentKernel(**params)
+
+
+def _attach_moe_tensors(pk, device="cuda"):
+    """Attach the tensors moe_mul_sum_add_layer expects, returning DTensors."""
+    x = torch.randn(BATCH_SIZE, NUM_TOPK, HIDDEN_SIZE,
+                    dtype=torch.bfloat16, device=device) * 0.1
+    w = torch.rand(BATCH_SIZE, NUM_TOPK, dtype=torch.float32, device=device)
+    res = torch.randn(BATCH_SIZE, HIDDEN_SIZE,
+                      dtype=torch.bfloat16, device=device) * 0.1
+    out = torch.zeros(BATCH_SIZE, HIDDEN_SIZE,
+                      dtype=torch.bfloat16, device=device)
+    return (
+        pk.attach_input(x, name="moe_in"),
+        pk.attach_input(w, name="moe_topk_weight"),
+        pk.attach_input(res, name="moe_residual"),
+        pk.attach_input(out, name="moe_out"),
+        (x, w, res, out),
+    )
+
+
+def _registered_residual_flag(world_size, mpi_rank, add_residual_once):
+    """Register the layer and report the residual-enable flag it passed down.
+
+    The SM100 kernel skips the residual add when params[0] == 0, so this flag
+    is exactly what decides whether this rank contributes its residual.
+    """
+    pk = _make_pk(world_size=world_size, mpi_rank=mpi_rank)
+    x_dt, w_dt, res_dt, out_dt, _ = _attach_moe_tensors(pk)
+
+    captured = {}
+    original = pk.kn_graph.register_task
+
+    def spy(bgraph, task_type, params=None):
+        captured["task_type"] = task_type
+        captured["params"] = params
+        return original(bgraph, task_type, params)
+
+    pk.kn_graph.register_task = spy
+    pk.moe_mul_sum_add_layer(
+        input=x_dt, weight=w_dt, residual=res_dt, output=out_dt,
+        grid_dim=(BATCH_SIZE, HIDDEN_SIZE // 256, 1),
+        block_dim=(256, 1, 1),
+        add_residual_once=add_residual_once,
+    )
+
+    assert captured["task_type"] == "moe_mul_sum_add_sm100"
+    return captured["params"][0]
+
+
+def test_rank_guard_flags():
+    print(f"\n{'='*70}")
+    print("Test: residual-enable flag by (world_size, rank, add_residual_once)")
+
+    # (world_size, mpi_rank, add_residual_once, expected_flag, why)
+    cases = [
+        (1, 0, True,  1, "single GPU always adds the residual"),
+        (1, 0, False, 1, "single GPU always adds the residual"),
+        (2, 0, True,  1, "replicated residual: rank 0 adds it"),
+        (2, 1, True,  0, "replicated residual: other ranks must not (PR #722)"),
+        (2, 0, False, 1, "partial residual: every rank adds its own"),
+        (2, 1, False, 1, "partial residual: every rank adds its own"),
+        (4, 3, True,  0, "replicated residual: only rank 0 adds it"),
+        (4, 3, False, 1, "partial residual: every rank adds its own"),
+    ]
+
+    ok = True
+    for world_size, rank, once, expected, why in cases:
+        got = _registered_residual_flag(world_size, rank, once)
+        status = "ok " if got == expected else "FAIL"
+        if got != expected:
+            ok = False
+        print(f"  [{status}] world_size={world_size} rank={rank} "
+              f"add_residual_once={str(once):5} -> flag={got} "
+              f"(expected {expected}: {why})")
+
+    if not ok:
+        print("\nFAILED: residual-enable flag did not match expectations")
+        sys.exit(1)
+    print("\nPASSED: residual rank guard applies only to replicated residuals")
+
+
+def test_mul_sum_add_numerics():
+    print(f"\n{'='*70}")
+    print("Test: moe_mul_sum_add_layer numerics (world_size=1, compile+run)")
+    print(f"  B={BATCH_SIZE}, H={HIDDEN_SIZE}, topk={NUM_TOPK}")
+
+    torch.manual_seed(42)
+    pk = _make_pk(world_size=1, mpi_rank=0)
+    x_dt, w_dt, res_dt, out_dt, (x, w, res, out) = _attach_moe_tensors(pk)
+
+    pk.moe_mul_sum_add_layer(
+        input=x_dt, weight=w_dt, residual=res_dt, output=out_dt,
+        grid_dim=(BATCH_SIZE, HIDDEN_SIZE // 256, 1),
+        block_dim=(256, 1, 1),
+    )
+
+    print("Compiling...")
+    pk.compile(output_dir=os.path.dirname(__file__))
+    print("Running...")
+    pk()
+    torch.cuda.synchronize()
+
+    ref = (x.float() * w.unsqueeze(-1)).sum(dim=1) + res.float()
+    ref = ref.to(torch.bfloat16)
+
+    print(f"\nOutput[0, :8]:    {out[0, :8]}")
+    print(f"Reference[0, :8]: {ref[0, :8]}")
+
+    max_abs = (out.float() - ref.float()).abs().max().item()
+    max_rel = max_abs / max(ref.float().abs().max().item(), 1e-6)
+    print(f"\nMax absolute diff: {max_abs:.6f}")
+    print(f"Max relative err:  {max_rel:.6f}")
+
+    if max_rel >= 0.05:
+        print(f"\nFAILED: max relative error {max_rel:.4f} exceeds 5% tolerance")
+        pk.finalize()
+        sys.exit(1)
+
+    # The residual must appear exactly once: subtracting it must leave the
+    # weighted expert sum on its own.
+    weighted_only = (x.float() * w.unsqueeze(-1)).sum(dim=1)
+    residual_delta = (out.float() - weighted_only - res.float()).abs().max().item()
+    if residual_delta > 0.5:
+        print(f"\nFAILED: residual not added exactly once (delta {residual_delta:.4f})")
+        pk.finalize()
+        sys.exit(1)
+
+    print("\nPASSED: moe_mul_sum_add matches reference, residual added once")
+    pk.finalize()
+
+
+if __name__ == "__main__":
+    test_rank_guard_flags()
+    test_mul_sum_add_numerics()
+    print(f"\n{'='*70}")
+    print("All MoE residual rank-guard tests PASSED!")


### PR DESCRIPTION
Problem:
moe_mul_sum_add_layer has added the residual on rank 0 only since PR #722. That is correct when the residual is a skip connection replicated across ranks, since the allreduce that follows the row-parallel MoE output would otherwise count it world_size times.

DeepSeek V3 passes something different. shared_residual is the shared expert's down_proj output, and because moe_intermediate_size is sharded, that projection is row-parallel, so each rank holds a partial sum the allreduce is meant to add up. DeepSeek applies its skip connection separately via elementwise_add after the allreduce. Under the rank-0 guard, every non-zero rank's shared-expert partial was being dropped.

Fix:
Give the layer an explicit add_residual_once flag so each call states which kind of residual it passes, and set it to False at DeepSeek's two call sites. The default is True, so Qwen3 and every other caller keep the #722 behaviour unchanged.

Test added:
test_moe_residual_rank_guard_testmode.py checks the resulting flag across 8 combinations of (world_size, rank, add_residual_once) and adds a single-GPU numerics check against PyTorch. moe_mul_sum_add_layer had no test_mode coverage before.