### PR TITLE
fix(serving): make online request lifecycle race-free

### DIFF
--- a/include/mirage/persistent_kernel/persistent_kernel.cuh
+++ b/include/mirage/persistent_kernel/persistent_kernel.cuh
@@ -471,6 +471,18 @@ __device__ __forceinline__ bool
   int free_row_top = *config.free_row_top;
   int const ring_mask = MPK_PINNED_RING_CAPACITY - 1;
 
+  // Reclaim rows only after the CPU has copied their completed output and
+  // release-stored -1 to pinned_step. The owner mapping stays stable for the
+  // full CPU read, so a completion can never refer to a reused row.
+  for (int row = 0; row < MPK_MAX_NUM_BATCHED_REQUESTS; row++) {
+    int32_t owner = ld_acquire_sys_i32(&config.pinned_rid_at_row[row]);
+    int32_t progress = ld_acquire_sys_i32(&config.pinned_step[row]);
+    if (owner >= 0 && progress == -1) {
+      st_release_sys_i32(&config.pinned_rid_at_row[row], -1);
+      config.free_rows[free_row_top++] = row;
+    }
+  }
+
   // ── Step 1: finalize previous batch ────────────────────────────────────────
   for (int i = 0; i < MPK_MAX_NUM_BATCHED_REQUESTS; i++) {
     int16_t row = config.request_ids[i];
@@ -512,15 +524,17 @@ __device__ __forceinline__ bool
       // Write completion entry so CPU background thread can collect the
       // output. Reports the original rid (not the buffer row).
       int comp_slot = gpu_comp_tail & ring_mask;
+      while (ld_acquire_sys_i32(&config.pinned_comp_ready[comp_slot]) != 0) {
+        __nanosleep(100);
+      }
       config.pinned_comp_request_id[comp_slot] = (int32_t)rid;
       config.pinned_comp_buffer_row[comp_slot] = (int32_t)row;
       config.pinned_comp_final_step[comp_slot] = (int32_t)(step + num_tokens);
       st_release_sys_i32(&config.pinned_comp_ready[comp_slot], 1);
       gpu_comp_tail++;
 
-      // Free the buffer row back to the pool.
-      config.free_rows[free_row_top++] = (int)row;
-      config.pinned_rid_at_row[row] = (int32_t)-1;
+      // Retain the row and owner until the CPU acknowledges its completed
+      // read through pinned_step[row] = -1.
       // Mark batch slot as empty.
       config.request_ids[i] = -1;
       config.request_rids[i] = -1;
@@ -618,8 +632,10 @@ __device__ __forceinline__ bool
     }
     config.prompt_length[row] = prompt_len;
     config.step[row] = initial_step;
-    // Let CPU discover which row this rid is on by scanning pinned_rid_at_row.
-    config.pinned_rid_at_row[row] = (int32_t)new_rid;
+    // Reset progress before release-publishing the owner. An observer that
+    // finds new_rid must not see progress or tokens from the prior lease.
+    st_release_sys_i32(&config.pinned_step[row], initial_step);
+    st_release_sys_i32(&config.pinned_rid_at_row[row], new_rid);
 
     // Clear the ring slot so CPU can reuse it.
     st_release_sys_i32(&config.pinned_req_ready[req_slot], 0);
@@ -1520,11 +1536,12 @@ extern "C" void
       static_cast<int32_t *>(meta_tensors[18]);
   global_runtime_config.pinned_shutdown =
       static_cast<int32_t volatile *>(meta_tensors[19]);
-  global_runtime_config.pinned_step = static_cast<int32_t *>(meta_tensors[20]);
+  global_runtime_config.pinned_step =
+      static_cast<int32_t volatile *>(meta_tensors[20]);
   global_runtime_config.pinned_inbox_tokens =
       static_cast<int64_t *>(meta_tensors[21]);
   global_runtime_config.pinned_rid_at_row =
-      static_cast<int32_t *>(meta_tensors[22]);
+      static_cast<int32_t volatile *>(meta_tensors[22]);
 #endif
   global_runtime_config.num_workers = num_workers;
   global_runtime_config.num_local_schedulers = num_local_schedulers;
@@ -1857,6 +1874,17 @@ extern "C" void launch_persistent_kernel(cudaStream_t default_stream) {
     }
     printf("Finished Launch Persistent Kernel\n");
   }
+}
+
+extern "C" cudaError_t wait_persistent_kernel() {
+  if (!global_runtime_config.split_worker_scheduler) {
+    return cudaSuccess;
+  }
+  cudaError_t worker_err =
+      cudaStreamSynchronize(global_runtime_config.worker_stream);
+  cudaError_t scheduler_err =
+      cudaStreamSynchronize(global_runtime_config.scheduler_stream);
+  return worker_err != cudaSuccess ? worker_err : scheduler_err;
 }
 
 extern "C" void finalize_persistent_kernel() {

--- a/include/mirage/persistent_kernel/runtime_header.h
+++ b/include/mirage/persistent_kernel/runtime_header.h
@@ -401,9 +401,10 @@ struct RuntimeConfig {
   // CPU→GPU shutdown signal: CPU writes 1 to request kernel termination.
   // GPU polls with ld.acquire.sys when the batch is empty.
   int32_t volatile *pinned_shutdown; // 0=running, 1=shutdown requested
-  // Per-request step progress: GPU writes after each decode step so CPU can
-  // poll for streaming output without touching GPU memory.
-  int32_t *pinned_step; // [total_inflight], pinned, indexed by buffer row
+  // Per-row progress and release handshake. GPU publishes a nonnegative decode
+  // step. After it reads completed output, CPU stores -1 to release the row.
+  int32_t volatile
+      *pinned_step; // [total_inflight], pinned, indexed by buffer row
   // Pinned inbox: CPU writes prompt tokens here before submitting a request
   // via the ring buffer. GPU copies from inbox to the allocated buffer row.
   int64_t *pinned_inbox_tokens; // [MPK_PINNED_RING_CAPACITY * max_seq_length],
@@ -411,7 +412,7 @@ struct RuntimeConfig {
   // Pinned rid→row mapping: GPU writes pinned_rid_at_row[row] = rid when
   // allocating a buffer row so CPU can discover which row its request is
   // on by scanning rows, then poll pinned_step[row] for per-step streaming.
-  int32_t *pinned_rid_at_row; // [total_inflight], pinned
+  int32_t volatile *pinned_rid_at_row; // [total_inflight], pinned
   // Running queue rid tracking: request_rids[i] stores the original rid
   // for active batch slot i (GPU device memory).
   int *request_rids; // [MPK_MAX_NUM_BATCHED_REQUESTS]

--- a/python/mirage/engine/llm_engine.py
+++ b/python/mirage/engine/llm_engine.py
@@ -18,8 +18,8 @@ class _StreamingMonitor:
     """Single background thread that monitors all active streaming sessions.
 
     Replaces the per-request polling thread (Thread B) with one shared daemon
-    that drains completions, polls step progress, and enqueues tokens for
-    every registered session.  This eliminates the thread explosion that
+    that polls completion state and step progress, then enqueues tokens for
+    every registered session. This eliminates the thread explosion that
     causes GIL contention under concurrent load.
     """
 
@@ -45,35 +45,45 @@ class _StreamingMonitor:
             }
         return q
 
+    def unregister(self, rid: int) -> None:
+        """Remove a session whose request could not be published."""
+        with self._lock:
+            self._sessions.pop(rid, None)
+
     def _run(self) -> None:
         while not self._stop.is_set():
             try:
-                # Drain completions and flush waiting queue.
-                self._runtime.drain_completions()
-
                 with self._lock:
                     for rid, s in list(self._sessions.items()):
+                        released = False
                         try:
+                            # Completion is authoritative and may arrive before
+                            # the monitor observes the transient row mapping.
+                            completion = self._runtime.get_completion(rid)
+                            if completion is not None:
+                                row, final_step = completion
+                                try:
+                                    self._yield_remaining(s, row, final_step)
+                                finally:
+                                    released = self._runtime.release_request(rid)
+                                if not released:
+                                    raise RuntimeError(
+                                        f"missing completion for rid={rid}")
+                                del self._sessions[rid]
+                                continue
+
                             # Phase 1 — discover buffer row.
                             if s['row'] == -1:
                                 row = self._runtime.find_row_for_rid(rid)
                                 if row >= 0:
                                     s['row'] = row
                                 elif time.monotonic() > s['deadline']:
+                                    self._runtime.abandon_request(rid)
                                     s['q'].put(("__timeout__", True))
                                     del self._sessions[rid]
                                 continue
 
                             row = s['row']
-
-                            # Check completion via runtime bookkeeping.
-                            with self._runtime._lock:
-                                if rid in self._runtime._completions:
-                                    _, final_step = self._runtime._completions[rid]
-                                    self._yield_remaining(s, row, final_step)
-                                    self._runtime.release_request(rid)
-                                    del self._sessions[rid]
-                                    continue
 
                             # Phase 2 — poll step progress, read only new tokens.
                             current_step = self._runtime.get_current_step_at_row(row)
@@ -87,12 +97,17 @@ class _StreamingMonitor:
 
                             # Check timeout.
                             if time.monotonic() > s['deadline']:
+                                self._runtime.abandon_request(rid)
                                 s['q'].put(("__timeout__", True))
                                 del self._sessions[rid]
 
                         except Exception:
-                            s['q'].put(("__error__", True))
-                            del self._sessions[rid]
+                            try:
+                                if not released:
+                                    self._runtime.abandon_request(rid)
+                            finally:
+                                s['q'].put(("__error__", True))
+                                del self._sessions[rid]
 
             except Exception:
                 pass
@@ -115,6 +130,25 @@ class _StreamingMonitor:
 
     def shutdown(self) -> None:
         self._stop.set()
+        self._thread.join()
+        with self._lock:
+            sessions = list(self._sessions.items())
+            self._sessions.clear()
+        cleanup_error: Exception | None = None
+        for rid, session in sessions:
+            # The GPU has no per-request cancellation. Mark each request so
+            # the runtime releases its row if a completion arrives later, and
+            # always wake the user-facing generator.
+            try:
+                self._runtime.abandon_request(rid)
+            except Exception as exc:
+                if cleanup_error is None:
+                    cleanup_error = exc
+            finally:
+                session['q'].put(("__closed__", True))
+        if cleanup_error is not None:
+            raise RuntimeError(
+                "failed to abandon a streaming request") from cleanup_error
 
 
 class LLMEngine:
@@ -145,14 +179,16 @@ class LLMEngine:
         self._submit_lock = threading.RLock()
 
         # Shared streaming monitor — replaces per-request polling threads.
-        self._monitor = _StreamingMonitor(self.runtime, self.tokenizer_manager)
+        self._monitor: _StreamingMonitor
 
         # Background kernel bookkeeping.
         self._kernel_launched: threading.Event = threading.Event()
         self._kernel_thread: threading.Thread | None = None
+        self._closed = False
 
         # Launch MPK kernels
         self._ensure_kernel_running()
+        self._monitor = _StreamingMonitor(self.runtime, self.tokenizer_manager)
 
     # ── Public API ────────────────────────────────────────────────────────
 
@@ -184,25 +220,39 @@ class LLMEngine:
         token_ids = self.tokenizer_manager.tokenize(prompt, use_template)
         prompt_len = len(token_ids)
 
-        rid = self._next_rid
-        self._next_rid += 1
-
         t = torch.tensor(token_ids, dtype=torch.int64)
+        stream_queue: queue.Queue | None = None
         with self._submit_lock:
-            self.runtime.submit(rid, t)
+            if self._closed:
+                raise RuntimeError("LLMEngine is closed")
+            rid = self._next_rid
+            self._next_rid += 1
+            if stream:
+                stream_queue = self._monitor.register(
+                    rid, prompt_len, timeout)
+            try:
+                self.runtime.submit(rid, t)
+            except Exception:
+                if stream:
+                    self._monitor.unregister(rid)
+                raise
 
         if stream:
-            return self._submit_stream(rid, prompt_len, timeout, poll_interval)
+            assert stream_queue is not None
+            return self._submit_stream(rid, stream_queue)
         else:
             buffer_row, final_step = self.runtime.wait_for_request(
                 rid, timeout, poll_interval)
-            full_tokens = self.runtime.read_tokens_at_row(buffer_row, final_step)
-            output_ids = full_tokens[prompt_len:].tolist()
-            self.runtime.release_request(rid)
-            return {
-                "text": self.tokenizer_manager.decode(output_ids),
-                "token_ids": output_ids,
-            }
+            try:
+                full_tokens = self.runtime.read_tokens_at_row(
+                    buffer_row, final_step)
+                output_ids = full_tokens[prompt_len:].tolist()
+                return {
+                    "text": self.tokenizer_manager.decode(output_ids),
+                    "token_ids": output_ids,
+                }
+            finally:
+                self.runtime.release_request(rid)
 
     # ── Internal ──────────────────────────────────────────────────────────
 
@@ -214,6 +264,7 @@ class LLMEngine:
             if self._kernel_launched.is_set():
                 return
             self.runtime.reset()
+            self.runtime.start()
             self._kernel_thread = threading.Thread(
                 target=self.model_runner, daemon=True)
             self._kernel_thread.start()
@@ -222,9 +273,7 @@ class LLMEngine:
     def _submit_stream(
         self,
         rid: int,
-        prompt_len: int,
-        timeout: float,
-        poll_interval: float,
+        q: queue.Queue,
     ):
         """Generator: yield ``(text, is_final)`` as tokens are decoded.
 
@@ -232,8 +281,6 @@ class LLMEngine:
         spawning a dedicated polling thread, so the number of polling
         threads stays constant regardless of concurrent request count.
         """
-        q = self._monitor.register(rid, prompt_len, timeout)
-
         def generator():
             while True:
                 try:
@@ -246,6 +293,9 @@ class LLMEngine:
                 if text == "__error__":
                     raise RuntimeError(
                         f"stream error for rid={rid}")
+                if text == "__closed__":
+                    raise RuntimeError(
+                        f"engine closed while streaming rid={rid}")
                 yield (text, is_final)
                 if is_final:
                     break
@@ -254,5 +304,20 @@ class LLMEngine:
 
     def close(self) -> None:
         """Signal the GPU kernel to shut down at the next idle cycle."""
-        self._monitor.shutdown()
-        self.runtime.shutdown()
+        with self._submit_lock:
+            if self._closed:
+                return
+            self._closed = True
+        monitor_error: Exception | None = None
+        try:
+            self._monitor.shutdown()
+        except Exception as exc:
+            monitor_error = exc
+        try:
+            self.runtime.request_shutdown()
+            if self._kernel_thread is not None:
+                self._kernel_thread.join()
+        finally:
+            self.runtime.stop()
+        if monitor_error is not None:
+            raise monitor_error

--- a/python/mirage/engine/model_runner.py
+++ b/python/mirage/engine/model_runner.py
@@ -101,14 +101,16 @@ class ModelRunner:
     # ── Execution ─────────────────────────────────────────────────────────────
 
     def __call__(self) -> None:
-        """Launch the MPK persistent kernel.
+        """Launch the MPK kernel and block until runtime shutdown completes.
 
-        Blocks until all requests submitted to the ring buffer have been
-        processed.  Intended to run in a background thread so the main thread
-        can concurrently submit requests and poll completions via
-        :attr:`runtime`.
+        Intended to run in a background thread so the main thread can submit
+        requests and poll completions through :attr:`runtime`.
         """
         self.mpk()
+        # The split worker/scheduler launch is asynchronous. Keep this Python
+        # thread alive until both GPU streams exit so LLMEngine.close() can
+        # safely join it before stopping completion draining or freeing state.
+        self.mpk.persistent_kernel.wait()
 
     # ── Private helpers ───────────────────────────────────────────────────────
 

--- a/python/mirage/mpk/online_pinned_runtime.py
+++ b/python/mirage/mpk/online_pinned_runtime.py
@@ -26,9 +26,9 @@ Usage::
 """
 
 import collections
-import time
 import threading
-from typing import Deque, Dict, List, Optional, Tuple
+import time
+from typing import Deque, Dict, List, Tuple
 
 import torch
 
@@ -64,9 +64,9 @@ class OnlinePinnedRuntime:
         self._cpu_req_ack   = 0  # last slot known to be consumed by GPU
         self._cpu_comp_head = 0
 
-        # CPU-side waiting queue: holds (rid, token_ids) tuples that couldn't
-        # be written to the ring because it was full.
-        self._waiting: Deque[Tuple[int, torch.Tensor]] = collections.deque()
+        # CPU-side waiting queue: holds (rid, token_ids, initial_step) tuples
+        # that could not be written to the ring because it was full.
+        self._waiting: Deque[Tuple[int, torch.Tensor, int]] = collections.deque()
         self._waiting_lock = threading.Lock()
 
         # Dedicated stream for HtoD / DtoH copies.
@@ -81,13 +81,14 @@ class OnlinePinnedRuntime:
 
         # Completion tracking: rid → (buffer_row, final_step)
         self._completions: Dict[int, Tuple[int, int]] = {}
+        self._abandoned: set[int] = set()
         self._lock = threading.RLock()
 
-        # Persistent drain thread — ensures completions are drained and waiting
-        # requests are flushed even when no streaming threads are alive.
+        # The drain thread starts only after reset() has initialized all shared
+        # state. Starting it here races reset() and can corrupt ring cursors.
         self._drain_stop = threading.Event()
-        self._drain_thread = threading.Thread(target=self._drain_loop, daemon=True)
-        self._drain_thread.start()
+        self._drain_thread: threading.Thread | None = None
+        self._drain_error: Exception | None = None
 
     # ── Public API ────────────────────────────────────────────────────────
 
@@ -109,29 +110,20 @@ class OnlinePinnedRuntime:
         True if the request was written to the ring, False if enqueued to
         the CPU waiting deque.
         """
-        prompt_len = token_ids.shape[0]
+        self._raise_drain_error()
 
-        # Atomically claim the next ring slot.  Must be serialised with
-        # flush_waiting() so the two paths never grab the same slot.
+        # Keep the producer lock until ready=1 is published. Otherwise a
+        # flusher can reserve a later slot and leave a permanent hole in the
+        # ordered request ring.
         with self._ring_lock:
             slot = self._cpu_req_tail & self._mask
-            if self._req_ready[slot].item() != 0:
+            if self._load_i32_acquire(self._req_ready, slot) != 0:
                 # Ring full — enqueue to CPU-side waiting.
                 with self._waiting_lock:
                     self._waiting.append((rid, token_ids.clone(), initial_step))
                 return False
-            self._cpu_req_tail += 1  # reserve slot
-
-        # Copy prompt tokens to this slot's inbox.
-        with torch.cuda.stream(self._write_stream):
-            self._inbox_tokens[slot, :prompt_len].copy_(token_ids, non_blocking=True)
-        self._write_stream.synchronize()
-
-        # Publish ring entry.
-        self._req_request_id[slot]   = rid
-        self._req_prompt_len[slot]   = prompt_len
-        self._req_initial_step[slot] = initial_step
-        self._req_ready[slot] = 1
+            self._publish_request_locked(slot, rid, token_ids, initial_step)
+            self._cpu_req_tail += 1
         return True
 
     def flush_waiting(self) -> int:
@@ -141,34 +133,42 @@ class OnlinePinnedRuntime:
         Called from :meth:`drain_completions` so waiting requests are
         gradually fed into the ring as slots free up.
         """
-        # Reserve ring slot first (serialised with submit), then pop from
-        # the waiting deque.  This ordering prevents a lost request if the
-        # ring is full: we never remove a request from waiting unless we
-        # have a guaranteed ring slot.
         with self._ring_lock:
             slot = self._cpu_req_tail & self._mask
-            if self._req_ready[slot].item() != 0:
+            if self._load_i32_acquire(self._req_ready, slot) != 0:
                 return 0  # ring still full
-            self._cpu_req_tail += 1  # reserve slot
+            with self._waiting_lock:
+                if not self._waiting:
+                    return 0
+                request = self._waiting.popleft()
 
-        with self._waiting_lock:
-            if not self._waiting:
-                # Rare: submit() drained the deque between our check and now.
-                # Put the reserved slot back.
-                with self._ring_lock:
-                    self._cpu_req_tail -= 1
-                return 0
-            rid, token_ids, initial_step = self._waiting.popleft()
+            rid, token_ids, initial_step = request
+            try:
+                self._publish_request_locked(slot, rid, token_ids, initial_step)
+            except Exception:
+                with self._waiting_lock:
+                    self._waiting.appendleft(request)
+                raise
+            self._cpu_req_tail += 1
+        return 1
 
+    def _publish_request_locked(
+        self,
+        slot: int,
+        rid: int,
+        token_ids: torch.Tensor,
+        initial_step: int,
+    ) -> None:
+        """Copy and publish one request while ``_ring_lock`` is held."""
         prompt_len = token_ids.shape[0]
         with torch.cuda.stream(self._write_stream):
-            self._inbox_tokens[slot, :prompt_len].copy_(token_ids, non_blocking=True)
+            self._inbox_tokens[slot, :prompt_len].copy_(
+                token_ids, non_blocking=True)
         self._write_stream.synchronize()
-        self._req_request_id[slot]   = rid
-        self._req_prompt_len[slot]   = prompt_len
+        self._req_request_id[slot] = rid
+        self._req_prompt_len[slot] = prompt_len
         self._req_initial_step[slot] = initial_step
-        self._req_ready[slot] = 1
-        return 1
+        self._store_i32_release(self._req_ready, slot, 1)
 
     def drain_completions(self) -> List[Tuple[int, int, int]]:
         """Non-blocking poll: collect all newly completed requests.
@@ -176,18 +176,25 @@ class OnlinePinnedRuntime:
         Returns a list of ``(rid, buffer_row, final_step)`` tuples for
         requests that have finished since the last call.
         """
+        self._raise_drain_error()
         finished = []
         while True:
             with self._lock:
                 slot = self._cpu_comp_head & self._mask
-                if self._comp_ready[slot].item() == 0:
+                if self._load_i32_acquire(self._comp_ready, slot) == 0:
                     break
                 rid         = int(self._comp_request_id[slot].item())
                 buffer_row  = int(self._comp_buffer_row[slot].item())
                 final_step  = int(self._comp_final_step[slot].item())
-                self._comp_ready[slot] = 0
+                if rid in self._abandoned:
+                    self._release_row_locked(rid, buffer_row)
+                    self._abandoned.remove(rid)
+                else:
+                    self._completions[rid] = (buffer_row, final_step)
+                # Do not make the slot reusable until completion bookkeeping
+                # and any abandoned-row release both succeed.
+                self._store_i32_release(self._comp_ready, slot, 0)
                 self._cpu_comp_head += 1
-                self._completions[rid] = (buffer_row, final_step)
             finished.append((rid, buffer_row, final_step))
 
         # Flush all waiting requests while ring slots are free.
@@ -196,14 +203,15 @@ class OnlinePinnedRuntime:
         return finished
 
     def _drain_loop(self) -> None:
-        """Persistent background loop that drains completions and flushes
-        waiting requests, ensuring forward progress even when all per-request
-        streaming threads have exited."""
+        """Drain completions and flush queued requests in the background."""
         while not self._drain_stop.is_set():
             try:
                 self.drain_completions()
-            except Exception:
-                pass
+            except Exception as exc:
+                with self._lock:
+                    self._drain_error = exc
+                self._drain_stop.set()
+                break
             self._drain_stop.wait(0.0002)
 
     def wait_for_request(
@@ -224,6 +232,7 @@ class OnlinePinnedRuntime:
                 if rid in self._completions:
                     return self._completions[rid]
             if time.monotonic() > deadline:
+                self.abandon_request(rid)
                 raise TimeoutError(
                     f"wait_for_request timed out for rid={rid}"
                 )
@@ -249,14 +258,47 @@ class OnlinePinnedRuntime:
         self._write_stream.synchronize()
         return result
 
-    def release_request(self, rid: int) -> None:
-        """Remove a completed request from the completion bookkeeping."""
+    def get_completion(self, rid: int) -> Tuple[int, int] | None:
+        """Return the completion for *rid*, if the GPU has published it."""
         with self._lock:
-            self._completions.pop(rid, None)
+            self._raise_drain_error_locked()
+            return self._completions.get(rid)
+
+    def release_request(self, rid: int) -> bool:
+        """Acknowledge that the CPU finished reading a completed row."""
+        with self._lock:
+            completion = self._completions.get(rid)
+            if completion is None:
+                return False
+            buffer_row, _ = completion
+            self._release_row_locked(rid, buffer_row)
+            del self._completions[rid]
+            return True
+
+    def abandon_request(self, rid: int) -> None:
+        """Release *rid* when it completes without retaining its output."""
+        with self._lock:
+            completion = self._completions.get(rid)
+            if completion is None:
+                self._abandoned.add(rid)
+                return
+            buffer_row, _ = completion
+            self._release_row_locked(rid, buffer_row)
+            del self._completions[rid]
+
+    def _release_row_locked(self, rid: int, buffer_row: int) -> None:
+        owner = self._load_i32_acquire(self._pinned_rid_at_row, buffer_row)
+        if owner != rid:
+            raise RuntimeError(
+                f"row {buffer_row} belongs to rid={owner}, expected rid={rid}"
+            )
+        # -1 is a phase-disjoint CPU release acknowledgement. The GPU keeps
+        # the owner mapping and row stable until it observes this value.
+        self._store_i32_release(self._pinned_step, buffer_row, -1)
 
     def get_current_step_at_row(self, buffer_row: int) -> int:
         """Return the latest decode step written by the GPU for *buffer_row*."""
-        return int(self._pinned_step[buffer_row].item())
+        return self._load_i32_acquire(self._pinned_step, buffer_row)
 
     def find_row_for_rid(self, rid: int) -> int:
         """Scan ``pinned_rid_at_row`` to find which buffer row holds *rid*.
@@ -264,7 +306,7 @@ class OnlinePinnedRuntime:
         Returns the row index, or -1 if the GPU hasn't assigned a row yet.
         """
         for r in range(self._total_inflight):
-            if int(self._pinned_rid_at_row[r].item()) == rid:
+            if self._load_i32_acquire(self._pinned_rid_at_row, r) == rid:
                 return r
         return -1
 
@@ -274,22 +316,69 @@ class OnlinePinnedRuntime:
         with self._waiting_lock:
             return len(self._waiting)
 
-    def shutdown(self) -> None:
-        """Signal the GPU persistent kernel to terminate."""
-        self._shutdown[0] = 1
+    def request_shutdown(self) -> None:
+        """Signal the GPU persistent kernel to terminate when it is idle."""
+        self._store_i32_release(self._shutdown, 0, 1)
+
+    def stop(self) -> None:
+        """Stop the completion drainer after the GPU kernel has exited."""
         self._drain_stop.set()
+        if self._drain_thread is not None:
+            self._drain_thread.join()
+
+    def shutdown(self) -> None:
+        """Signal the GPU kernel and stop the completion drainer."""
+        self.request_shutdown()
+        self.stop()
+
+    def start(self) -> None:
+        """Start the background completion drainer after shared state is reset."""
+        if self._drain_thread is not None and self._drain_thread.is_alive():
+            return
+        self._raise_drain_error()
+        self._drain_stop.clear()
+        self._drain_thread = threading.Thread(
+            target=self._drain_loop, daemon=True)
+        self._drain_thread.start()
 
     def reset(self) -> None:
         """Clear completion bookkeeping and ring state for a new session."""
-        self._cpu_req_tail    = 0
-        self._cpu_req_ack     = 0
-        self._cpu_comp_head   = 0
-        self._shutdown[0]     = 0
+        if self._drain_thread is not None and self._drain_thread.is_alive():
+            raise RuntimeError("cannot reset a running online runtime")
+
+        with self._ring_lock:
+            self._cpu_req_tail = 0
+            self._cpu_req_ack = 0
+            with self._waiting_lock:
+                self._waiting.clear()
+            self._req_ready.zero_()
+            self._req_request_id.zero_()
+
         with self._lock:
+            self._cpu_comp_head = 0
             self._completions.clear()
-        with self._waiting_lock:
-            self._waiting.clear()
-        self._comp_ready.zero_()
-        self._req_ready.zero_()
-        self._req_request_id.zero_()
+            self._abandoned.clear()
+            self._drain_error = None
+            self._comp_ready.zero_()
+
+        self._shutdown.zero_()
+        self._pinned_step.zero_()
         self._pinned_rid_at_row.fill_(-1)
+
+    def _load_i32_acquire(self, tensor: torch.Tensor, index: int) -> int:
+        return int(self._mpk.persistent_kernel.load_i32_acquire(
+            tensor.data_ptr(), index))
+
+    def _store_i32_release(
+        self, tensor: torch.Tensor, index: int, value: int,
+    ) -> None:
+        self._mpk.persistent_kernel.store_i32_release(
+            tensor.data_ptr(), index, value)
+
+    def _raise_drain_error(self) -> None:
+        with self._lock:
+            self._raise_drain_error_locked()
+
+    def _raise_drain_error_locked(self) -> None:
+        if self._drain_error is not None:
+            raise RuntimeError("completion drainer failed") from self._drain_error

--- a/python/mirage/mpk/persistent_kernel.py
+++ b/python/mirage/mpk/persistent_kernel.py
@@ -3170,12 +3170,10 @@ class PersistentKernel:
         self.init_func = getattr(mod, "init_func")
         self.launch_func = getattr(mod, "launch_func")
         self.init_request_func = getattr(mod, "init_request_func")
-        if self.mode == "online_pinned":
-            self.wait_func = getattr(mod, "wait_func")
+        self.wait_func = getattr(mod, "wait_func")
         self.finalize_func = getattr(mod, "finalize_func")
-        if self.mode == "online_pinned":
-            self.load_i32_acquire = getattr(mod, "load_i32_acquire")
-            self.store_i32_release = getattr(mod, "store_i32_release")
+        self.load_i32_acquire = getattr(mod, "load_i32_acquire")
+        self.store_i32_release = getattr(mod, "store_i32_release")
         
         # Prepare meta tensors
         meta_tensors = list()

--- a/python/mirage/mpk/persistent_kernel.py
+++ b/python/mirage/mpk/persistent_kernel.py
@@ -20,6 +20,7 @@ from typing import Optional
 
 HARD_CODE = """
 #include <Python.h>
+#include <cstdint>
 #include <cuda_runtime.h>
 #include <string>
 #include <vector>
@@ -114,9 +115,52 @@ static PyObject *launch_func(PyObject *self, PyObject *args) {
   Py_RETURN_NONE;
 }
 
+static PyObject *wait_func(PyObject *self, PyObject *args) {
+  cudaError_t err;
+  Py_BEGIN_ALLOW_THREADS
+  err = wait_persistent_kernel();
+  Py_END_ALLOW_THREADS
+  if (err != cudaSuccess) {
+    PyErr_Format(PyExc_RuntimeError,
+                 "persistent kernel failed: %s",
+                 cudaGetErrorString(err));
+    return NULL;
+  }
+  Py_RETURN_NONE;
+}
+
 static PyObject *finalize_func(PyObject *self, PyObject *args) {
   finalize_persistent_kernel();
 
+  Py_RETURN_NONE;
+}
+
+static PyObject *load_i32_acquire(PyObject *self, PyObject *args) {
+  PyObject *py_ptr;
+  Py_ssize_t index;
+  if (!PyArg_ParseTuple(args, "On", &py_ptr, &index)) {
+    return NULL;
+  }
+  auto *ptr = static_cast<int32_t *>(PyLong_AsVoidPtr(py_ptr));
+  if (PyErr_Occurred()) {
+    return NULL;
+  }
+  int32_t value = __atomic_load_n(ptr + index, __ATOMIC_ACQUIRE);
+  return PyLong_FromLong(value);
+}
+
+static PyObject *store_i32_release(PyObject *self, PyObject *args) {
+  PyObject *py_ptr;
+  Py_ssize_t index;
+  int value;
+  if (!PyArg_ParseTuple(args, "Oni", &py_ptr, &index, &value)) {
+    return NULL;
+  }
+  auto *ptr = static_cast<int32_t *>(PyLong_AsVoidPtr(py_ptr));
+  if (PyErr_Occurred()) {
+    return NULL;
+  }
+  __atomic_store_n(ptr + index, static_cast<int32_t>(value), __ATOMIC_RELEASE);
   Py_RETURN_NONE;
 }
 
@@ -124,7 +168,10 @@ static PyMethodDef ModuleMethods[] = {
   {"init_func", init_func, METH_VARARGS, "initialize persistent kernel"},
   {"init_request_func", init_request_func, METH_VARARGS, "initialize request resources"},
   {"launch_func", launch_func, METH_VARARGS, "launch persistent kernel"},
+  {"wait_func", wait_func, METH_NOARGS, "wait for persistent kernel"},
   {"finalize_func", finalize_func, METH_VARARGS, "finalize persistent kernel"},
+  {"load_i32_acquire", load_i32_acquire, METH_VARARGS, "acquire-load int32"},
+  {"store_i32_release", store_i32_release, METH_VARARGS, "release-store int32"},
   {NULL, NULL, 0, NULL} // sentinel
 };
 
@@ -2997,7 +3044,10 @@ class PersistentKernel:
         spec.loader.exec_module(mod)
         self.init_func = getattr(mod, "init_func")
         self.launch_func = getattr(mod, "launch_func")
+        self.wait_func = getattr(mod, "wait_func")
         self.finalize_func = getattr(mod, "finalize_func")
+        self.load_i32_acquire = getattr(mod, "load_i32_acquire")
+        self.store_i32_release = getattr(mod, "store_i32_release")
         print("Finished megakernel compilation...")
 
         expected_order = [
@@ -3120,7 +3170,12 @@ class PersistentKernel:
         self.init_func = getattr(mod, "init_func")
         self.launch_func = getattr(mod, "launch_func")
         self.init_request_func = getattr(mod, "init_request_func")
+        if self.mode == "online_pinned":
+            self.wait_func = getattr(mod, "wait_func")
         self.finalize_func = getattr(mod, "finalize_func")
+        if self.mode == "online_pinned":
+            self.load_i32_acquire = getattr(mod, "load_i32_acquire")
+            self.store_i32_release = getattr(mod, "store_i32_release")
         
         # Prepare meta tensors
         meta_tensors = list()
@@ -3214,6 +3269,10 @@ class PersistentKernel:
     def __del__(self):
         if not self.__finalized__:
             self.finalize()
+
+    def wait(self) -> None:
+        """Block until both persistent GPU streams have exited."""
+        self.wait_func()
 
     def finalize(self):
         assert not self.__finalized__


### PR DESCRIPTION
## Summary

- Keep completed token rows leased until the CPU finishes copying each response.
- Use system-scope acquire/release operations for CPU/GPU handshake fields.
- Publish request-ring entries without cursor holes or completion-slot overwrite.
- Register streams before request publication, release timed-out requests, and wait for both persistent GPU streams during shutdown.

CI regression coverage is split into #756.

## Root cause

The GPU returned a completed row to the free pool before the CPU copied the response. A later request could overwrite that row while the first caller was reading it. This caused stale or cross-request chat output. Reused rows also retained stale progress state.

The CPU producer could also advance its request cursor before it published the ready flag. A concurrent flush could then publish behind an empty slot, and the GPU would stop at that permanent ring hole. Streaming registration also happened after request publication, so a fast completion could be missed.

## Validation

The six runtime-file blobs are identical to the combined revision tested on a Catalyst B200. With the functional harness from #756 applied:

- Sequential requests passed 12/12.
- Concurrent requests passed 12/12.
- HTTP status, exact response markers, cross-request isolation, streaming completion, metrics, and clean shutdown passed.
- Python compilation and `git diff --check` passed.

## Scope

- One runtime commit.
- Six runtime files.
- 365 additions and 121 deletions.
- No CI workflow or test-file changes.