### PR TITLE
fix(argmax): bound the reduction to the real vocab size

### DIFF
--- a/demo/qwen3/demo.py
+++ b/demo/qwen3/demo.py
@@ -267,7 +267,7 @@ if __name__ == "__main__":
             (
                 model.lm_head.weight,
                 torch.full(
-                    (153600 - model.config.vocab_size, hidden_size), -1e4, device="cuda"
+                    (153600 - model.config.vocab_size, hidden_size), 0, device="cuda"
                 ),
             ),
             0,

--- a/demo/qwen3/demo.py
+++ b/demo/qwen3/demo.py
@@ -754,6 +754,7 @@ if __name__ == "__main__":
             output=(argmax_part_value, argmax_part_index),
             grid_dim=argmax_partial_grid_dim,
             block_dim=(128, 1, 1),
+            vocab_size=model.config.vocab_size,
         )
         mpk.argmax_reduce_layer(
             input=(argmax_part_value, argmax_part_index),

--- a/demo/qwen3/demo_30B_A3B.py
+++ b/demo/qwen3/demo_30B_A3B.py
@@ -222,7 +222,7 @@ if __name__ == "__main__":
             (
                 model.lm_head.weight,
                 torch.full(
-                    (153600 - model.config.vocab_size, hidden_size), -1e4, device="cuda"
+                    (153600 - model.config.vocab_size, hidden_size), 0, device="cuda"
                 ),
             ),
             0,

--- a/demo/qwen3/demo_30B_A3B.py
+++ b/demo/qwen3/demo_30B_A3B.py
@@ -700,6 +700,7 @@ if __name__ == "__main__":
             output=(argmax_part_value, argmax_part_index),
             grid_dim=argmax_partial_grid_dim,
             block_dim=(256, 1, 1),
+            vocab_size=model.config.vocab_size,
         )
         mpk.argmax_reduce_layer(
             input=(argmax_part_value, argmax_part_index),

--- a/demo/qwen3/demo_30B_A3B_eagle3.py
+++ b/demo/qwen3/demo_30B_A3B_eagle3.py
@@ -236,7 +236,7 @@ if __name__ == "__main__":
             (
                 model.lm_head.weight,
                 torch.full(
-                    (153600 - model.config.vocab_size, hidden_size), -1e4, device="cuda"
+                    (153600 - model.config.vocab_size, hidden_size), 0, device="cuda"
                 ),
             ),
             0,

--- a/demo/qwen3/demo_30B_A3B_eagle3.py
+++ b/demo/qwen3/demo_30B_A3B_eagle3.py
@@ -769,6 +769,7 @@ if __name__ == "__main__":
             output=(argmax_part_value, argmax_part_index),
             grid_dim=argmax_partial_grid_dim,
             block_dim=(256, 1, 1),
+            vocab_size=model.config.vocab_size,
         )
         mpk.argmax_reduce_layer(
             input=(argmax_part_value, argmax_part_index),

--- a/demo/qwen3/demo_30B_A3B_hopper.py
+++ b/demo/qwen3/demo_30B_A3B_hopper.py
@@ -229,7 +229,7 @@ if __name__ == "__main__":
             (
                 model.lm_head.weight,
                 torch.full(
-                    (153600 - model.config.vocab_size, hidden_size), -1e4, device="cuda"
+                    (153600 - model.config.vocab_size, hidden_size), 0, device="cuda"
                 ),
             ),
             0,

--- a/demo/qwen3/demo_30B_A3B_hopper.py
+++ b/demo/qwen3/demo_30B_A3B_hopper.py
@@ -732,6 +732,7 @@ if __name__ == "__main__":
             output=(argmax_part_value, argmax_part_index),
             grid_dim=argmax_partial_grid_dim,
             block_dim=(256, 1, 1),
+            vocab_size=model.config.vocab_size,
         )
         mpk.argmax_reduce_layer(
             input=(argmax_part_value, argmax_part_index),

--- a/demo/qwen3/demo_chat.py
+++ b/demo/qwen3/demo_chat.py
@@ -179,7 +179,7 @@ def build_mirage_graph(model, world_size, rank, args, tokens_tensor, step_tensor
     mpk.rmsnorm_linear_layer(input=x, weight_norm=w_final_norm, weight_linear=w_lm_head, output=argmax_in, grid_dim=(96, 1, 1), block_dim=(128, 1, 1))
 
     # Argmax
-    mpk.argmax_partial_layer(input=argmax_in, output=(argmax_part_value, argmax_part_index), grid_dim=(96, 1, 1), block_dim=(128, 1, 1))
+    mpk.argmax_partial_layer(input=argmax_in, output=(argmax_part_value, argmax_part_index), grid_dim=(96, 1, 1), block_dim=(128, 1, 1), vocab_size=model.config.vocab_size)
     mpk.argmax_reduce_layer(input=(argmax_part_value, argmax_part_index), output=argmax_out, grid_dim=(1, 1, 1), block_dim=(128, 1, 1))
 
     mpk.compile()

--- a/demo/qwen3/demo_chat.py
+++ b/demo/qwen3/demo_chat.py
@@ -62,7 +62,7 @@ def build_mirage_graph(model, world_size, rank, args, tokens_tensor, step_tensor
         (
             model.lm_head.weight,
             torch.full(
-                (153600 - model.config.vocab_size, hidden_size), -1e4, device="cuda"
+                (153600 - model.config.vocab_size, hidden_size), 0, device="cuda"
             ),
         ),
         0,

--- a/demo/qwen3/demo_debug.py
+++ b/demo/qwen3/demo_debug.py
@@ -177,7 +177,7 @@ if __name__ == "__main__":
             (
                 model.lm_head.weight,
                 torch.full(
-                    (153600 - model.config.vocab_size, hidden_size), -1e4, device="cuda"
+                    (153600 - model.config.vocab_size, hidden_size), 0, device="cuda"
                 ),
             ),
             0,

--- a/demo/qwen3/demo_hopper.py
+++ b/demo/qwen3/demo_hopper.py
@@ -638,6 +638,7 @@ if __name__ == "__main__":
             output=(argmax_part_value, argmax_part_index),
             grid_dim=argmax_partial_grid_dim,
             block_dim=(256, 1, 1),
+            vocab_size=model.config.vocab_size,
         )
         mpk.argmax_reduce_layer(
             input=(argmax_part_value, argmax_part_index),

--- a/demo/qwen3/demo_hopper.py
+++ b/demo/qwen3/demo_hopper.py
@@ -202,7 +202,7 @@ if __name__ == "__main__":
             (
                 model.lm_head.weight,
                 torch.full(
-                    (153600 - model.config.vocab_size, hidden_size), -1e4, device="cuda"
+                    (153600 - model.config.vocab_size, hidden_size), 0, device="cuda"
                 ),
             ),
             0,

--- a/demo/qwen3/demo_kernel_reuse.py
+++ b/demo/qwen3/demo_kernel_reuse.py
@@ -501,7 +501,7 @@ def main():
     hidden_size = model.config.hidden_size
     lm_head_weight = torch.cat(
         (model.lm_head.weight,
-         torch.full((153600 - model.config.vocab_size, hidden_size), -1e4, device="cuda")),
+         torch.full((153600 - model.config.vocab_size, hidden_size), 0, device="cuda")),
         0,
     )
     

--- a/demo/qwen3/demo_kernel_reuse.py
+++ b/demo/qwen3/demo_kernel_reuse.py
@@ -391,6 +391,7 @@ def build_mpk_graph(
         output=(argmax_part_value, argmax_part_index),
         grid_dim=argmax_partial_grid_dim,
         block_dim=(128, 1, 1),
+        vocab_size=model.config.vocab_size,
     )
     mpk.argmax_reduce_layer(
         input=(argmax_part_value, argmax_part_index),

--- a/demo/qwen3/demo_sampling.py
+++ b/demo/qwen3/demo_sampling.py
@@ -195,7 +195,7 @@ if __name__ == "__main__":
             (
                 model.lm_head.weight,
                 torch.full(
-                    (153600 - model.config.vocab_size, hidden_size), -1e4, device="cuda"
+                    (153600 - model.config.vocab_size, hidden_size), 0, device="cuda"
                 ),
             ),
             0,

--- a/include/mirage/persistent_kernel/tasks/ampere/argmax.cuh
+++ b/include/mirage/persistent_kernel/tasks/ampere/argmax.cuh
@@ -68,17 +68,25 @@ __device__ __forceinline__ void block_reduce_max_idx(T &val, long long &idx) {
   }
 }
 
-template <typename T, int BATCH_SIZE, int CHUNK_SIZE, int NUM_PARTIAL_TASKS>
+template <typename T,
+          int BATCH_SIZE,
+          int CHUNK_SIZE,
+          int NUM_PARTIAL_TASKS,
+          int VOCAB_SIZE = CHUNK_SIZE *NUM_PARTIAL_TASKS>
 __device__ __forceinline__ void
     argmax_partial_kernel(void const *__restrict__ input_ptr,
                           void *__restrict__ output_val_ptr,
                           void *__restrict__ output_idx_ptr,
-                          int num_active_tokens) {
+                          int num_active_tokens,
+                          int chunk_start = 0) {
   T const *__restrict__ input = static_cast<T const *>(input_ptr);
   T *__restrict__ output_val = static_cast<T *>(output_val_ptr);
   long long *__restrict__ output_idx = static_cast<long long *>(output_idx_ptr);
 
   int tidx = threadIdx.x;
+  // Positions at/after VOCAB_SIZE are lm_head padding rows; keep them out of
+  // the reduction so a padding logit can never win the argmax.
+  int const valid_len = min(CHUNK_SIZE, VOCAB_SIZE - chunk_start);
 
 // TODO: try vectorize
 #pragma unroll
@@ -86,7 +94,7 @@ __device__ __forceinline__ void
     T local_max = T(-inf);
     long long local_idx = -1;
 #pragma unroll
-    for (int i = tidx; i < CHUNK_SIZE; i += NUM_THREADS) {
+    for (int i = tidx; i < valid_len; i += NUM_THREADS) {
       T val = input[i + batch_idx * CHUNK_SIZE * NUM_PARTIAL_TASKS];
       if (val > local_max) {
         local_max = val;

--- a/include/mirage/persistent_kernel/tasks/blackwell/argmax_sm100.cuh
+++ b/include/mirage/persistent_kernel/tasks/blackwell/argmax_sm100.cuh
@@ -75,17 +75,25 @@ __device__ __forceinline__ void block_reduce_max_idx_sm100(T &val,
   }
 }
 
-template <typename T, int BATCH_SIZE, int CHUNK_SIZE, int NUM_PARTIAL_TASKS>
+template <typename T,
+          int BATCH_SIZE,
+          int CHUNK_SIZE,
+          int NUM_PARTIAL_TASKS,
+          int VOCAB_SIZE = CHUNK_SIZE *NUM_PARTIAL_TASKS>
 __device__ __forceinline__ void
     argmax_partial_sm100_kernel(void const *__restrict__ input_ptr,
                                 void *__restrict__ output_val_ptr,
                                 void *__restrict__ output_idx_ptr,
-                                int num_active_tokens) {
+                                int num_active_tokens,
+                                int chunk_start = 0) {
   T const *__restrict__ input = static_cast<T const *>(input_ptr);
   T *__restrict__ output_val = static_cast<T *>(output_val_ptr);
   long long *__restrict__ output_idx = static_cast<long long *>(output_idx_ptr);
 
   int tidx = threadIdx.x;
+  // Positions at/after VOCAB_SIZE are lm_head padding rows; keep them out of
+  // the reduction so a padding logit can never win the argmax.
+  int const valid_len = min(CHUNK_SIZE, VOCAB_SIZE - chunk_start);
 
   if (tidx < NUM_THREADS) {
 
@@ -95,7 +103,7 @@ __device__ __forceinline__ void
       T local_max = T(-inf);
       long long local_idx = -1;
 #pragma unroll
-      for (int i = tidx; i < CHUNK_SIZE; i += NUM_THREADS) {
+      for (int i = tidx; i < valid_len; i += NUM_THREADS) {
         T val = input[i + batch_idx * CHUNK_SIZE * NUM_PARTIAL_TASKS];
         if (val > local_max) {
           local_max = val;

--- a/python/mirage/mpk/models/qwen3/builder.py
+++ b/python/mirage/mpk/models/qwen3/builder.py
@@ -622,6 +622,7 @@ class Qwen3Builder(GraphBuilder):
                 output=(self.argmax_part_value, self.argmax_part_index),
                 grid_dim=argmax_partial_grid_dim,
                 block_dim=(128, 1, 1),
+                vocab_size=self.vocab_size,
             )
             self.mpk.argmax_reduce_layer(
                 input=(self.argmax_part_value, self.argmax_part_index),

--- a/python/mirage/mpk/persistent_kernel.py
+++ b/python/mirage/mpk/persistent_kernel.py
@@ -2374,6 +2374,7 @@ class PersistentKernel:
         output: tuple[DTensor, DTensor],
         grid_dim: tuple,
         block_dim: tuple,
+        vocab_size: int = None,
     ):
         # Currently assume that input/output
         assert input.num_dims == 2  # (batch_size, vocab_size)
@@ -2383,15 +2384,18 @@ class PersistentKernel:
         assert output_index.num_dims == 2  # (batch_size, num_tasks)
         num_tasks = grid_dim[0]
         self.argmax_partial_output_size = input.dim(1) // num_tasks
+        # vocab_size: real vocab size when input.dim(1) is padded (e.g. the
+        # lm_head padded to 153600); positions at/after it never win argmax.
+        params = [num_tasks] if vocab_size is None else [num_tasks, vocab_size]
         tb_graph = TBGraph(CyTBGraph(grid_dim, block_dim, 1, 64))
         tb_graph.new_input(input, (1, 0, -1), -1, True)
         tb_graph.new_input(output_value, (1, 0, -1), -1, True)
         tb_graph.new_input(output_index, (1, 0, -1), -1, True)
         self.kn_graph.customized([input, output_value, output_index], tb_graph)
         if self.target_cc == 100 or self.target_cc == 90:
-            self.kn_graph.register_task(tb_graph, "argmax_partial_sm100", [num_tasks])
+            self.kn_graph.register_task(tb_graph, "argmax_partial_sm100", params)
         else:
-            self.kn_graph.register_task(tb_graph, "argmax_partial", [num_tasks])
+            self.kn_graph.register_task(tb_graph, "argmax_partial", params)
 
     def argmax_reduce_layer(
         self,

--- a/src/kernel/runtime.cc
+++ b/src/kernel/runtime.cc
@@ -342,6 +342,11 @@ void register_mugraph(
               // the request dimension
               task.task_metadata.request_id = bid.x;
             }
+            // Argmax partial tasks: grid_dim.x partitions the vocab dimension
+            if (task_type == TASK_ARGMAX_PARTIAL ||
+                task_type == TASK_ARGMAX_PARTIAL_SM100) {
+              task.task_metadata.task_offset = bid.x;
+            }
             // Set expert_offset for MoE tasks
             if (task_type == TASK_MOE_W13_LINEAR_SM100 ||
                 task_type == TASK_MOE_W2_LINEAR_SM100 ||

--- a/src/kernel/task_register.cc
+++ b/src/kernel/task_register.cc
@@ -920,7 +920,9 @@ int TaskRegister::register_linear_task(threadblock::Graph const &bgraph,
 int TaskRegister::register_argmax_partial_task(threadblock::Graph const &bgraph,
                                                std::vector<int> const &params) {
   // params[0]: num_partial_tasks
-  assert(params.size() == 1);
+  // params[1] (optional): real vocab size; positions at/after it are lm_head
+  // padding rows and are excluded from the argmax
+  assert(params.size() == 1 || params.size() == 2);
   std::vector<tb::TBInputOp *> input_ops;
   std::vector<tb::TBInputOp *> output_ops;
   int num_inputs = 1;
@@ -940,16 +942,21 @@ int TaskRegister::register_argmax_partial_task(threadblock::Graph const &bgraph,
   int num_elements = input_ops[0]->output_tensors[0].dim[1];
   int num_partial_tasks = params[0];
 
+  int vocab_size =
+      params.size() == 2 ? params[1] : num_elements * num_partial_tasks;
+
   mirage::transpiler::CodeKeeper code;
   code.inc_indent();
-  code.e("kernel::argmax_partial_kernel<bfloat16, $, $, $>(",
+  code.e("kernel::argmax_partial_kernel<bfloat16, $, $, $, $>(",
          batch_size,
          num_elements,
-         num_partial_tasks);
+         num_partial_tasks,
+         vocab_size);
   code.e("    task_desc->input_ptrs[0],");
   code.e("    task_desc->output_ptrs[0],");
   code.e("    task_desc->output_ptrs[1],");
-  code.e("    runtime_config.qo_indptr_buffer[MPK_MAX_NUM_BATCHED_REQUESTS]);");
+  code.e("    runtime_config.qo_indptr_buffer[MPK_MAX_NUM_BATCHED_REQUESTS],");
+  code.e("    task_desc->task_metadata.task_offset * $);", num_elements);
   return register_task_variant(TASK_ARGMAX_PARTIAL, code.to_string());
 }
 
@@ -2388,7 +2395,9 @@ int TaskRegister::register_paged_attention_sm100_task(
 int TaskRegister::register_argmax_partial_sm100_task(
     threadblock::Graph const &bgraph, std::vector<int> const &params) {
   // params[0]: num_partial_tasks
-  assert(params.size() == 1);
+  // params[1] (optional): real vocab size; positions at/after it are lm_head
+  // padding rows and are excluded from the argmax
+  assert(params.size() == 1 || params.size() == 2);
   std::vector<tb::TBInputOp *> input_ops;
   std::vector<tb::TBInputOp *> output_ops;
   int num_inputs = 1;
@@ -2408,16 +2417,21 @@ int TaskRegister::register_argmax_partial_sm100_task(
   int num_elements = input_ops[0]->output_tensors[0].dim[1];
   int num_partial_tasks = params[0];
 
+  int vocab_size =
+      params.size() == 2 ? params[1] : num_elements * num_partial_tasks;
+
   mirage::transpiler::CodeKeeper code;
   code.inc_indent();
-  code.e("kernel::argmax_partial_sm100_kernel<bfloat16, $, $, $>(",
+  code.e("kernel::argmax_partial_sm100_kernel<bfloat16, $, $, $, $>(",
          batch_size,
          num_elements,
-         num_partial_tasks);
+         num_partial_tasks,
+         vocab_size);
   code.e("    task_desc->input_ptrs[0],");
   code.e("    task_desc->output_ptrs[0],");
   code.e("    task_desc->output_ptrs[1],");
-  code.e("    runtime_config.qo_indptr_buffer[MPK_MAX_NUM_BATCHED_REQUESTS]);");
+  code.e("    runtime_config.qo_indptr_buffer[MPK_MAX_NUM_BATCHED_REQUESTS],");
+  code.e("    task_desc->task_metadata.task_offset * $);", num_elements);
   return register_task_variant(TASK_ARGMAX_PARTIAL_SM100, code.to_string());
 }
 

--- a/tests/runtime_python/test_mode/test_argmax_vocab_bound_testmode.py
+++ b/tests/runtime_python/test_mode/test_argmax_vocab_bound_testmode.py
@@ -1,0 +1,95 @@
+"""Argmax over an lm_head padded past the real vocab.
+
+Qwen3 demos pad the lm_head from 151936 to 153600 rows so the partial-task
+grid divides evenly. The pad rows produce logits the model never trained
+(0 for zero-padded weights), so argmax_partial must ignore positions at or
+after ``vocab_size`` — otherwise a pad row wins whenever every real logit is
+negative (#751/#752), and any non-zero weight padding is worse (#755).
+
+Every real logit here is strictly negative while the pad region holds 0.0,
+so an unbounded argmax would return a pad index (>= VOCAB) for every row.
+"""
+
+import os
+import sys
+
+import torch
+
+import mirage
+from mirage.mpk.persistent_kernel import PersistentKernel
+
+BATCH = 4
+PADDED = 153600
+VOCAB = 151936
+NUM_TASKS = 96  # PADDED divides evenly; chunk = 1600
+CHUNK = PADDED // NUM_TASKS
+# One winner per row: an in-chunk position, the chunk-94 boundary cases
+# (150400 starts the chunk that straddles VOCAB; 151935 is the last real
+# position), and a mid-vocab position.
+WINNERS = [5, 150400, 151935, 77777]
+
+
+def main():
+    torch.manual_seed(0)
+    device, dtype = "cuda", torch.bfloat16
+
+    num_workers, num_schedulers = mirage.get_configurations_from_gpu(0)
+    params = PersistentKernel.get_default_init_parameters()
+    qo_indptr = torch.zeros(BATCH + 1, dtype=torch.int32, device=device)
+    qo_indptr[BATCH] = BATCH
+    params.update(test_mode=True, num_workers=num_workers,
+                  num_local_schedulers=num_schedulers,
+                  max_num_batched_tokens=BATCH, max_num_batched_requests=BATCH,
+                  meta_tensors={"qo_indptr_buffer": qo_indptr})
+    pk = PersistentKernel(**params)
+
+    logits = -torch.rand(BATCH, PADDED, dtype=dtype, device=device) - 0.5
+    logits[:, VOCAB:] = 0.0  # zero-padded lm_head rows
+    for row, idx in enumerate(WINNERS):
+        logits[row, idx] = -0.25  # unique real max, still below the padding
+
+    part_val = torch.zeros(BATCH, NUM_TASKS, dtype=dtype, device=device)
+    part_idx = torch.zeros(BATCH, NUM_TASKS, dtype=torch.int64, device=device)
+    out = torch.zeros(BATCH, 1, dtype=torch.int64, device=device)
+
+    d_val = pk.attach_input(part_val, name="part_val")
+    d_idx = pk.attach_input(part_idx, name="part_idx")
+    pk.argmax_partial_layer(
+        input=pk.attach_input(logits, name="logits"),
+        output=(d_val, d_idx),
+        grid_dim=(NUM_TASKS, 1, 1), block_dim=(128, 1, 1),
+        vocab_size=VOCAB)
+    pk.argmax_reduce_layer(
+        input=(d_val, d_idx),
+        output=pk.attach_input(out, name="argmax_out"),
+        grid_dim=(1, 1, 1), block_dim=(128, 1, 1))
+
+    print("Compiling test kernel...")
+    pk.compile(output_dir=os.path.dirname(os.path.abspath(__file__)))
+    print("Running test kernel...")
+    pk()
+    torch.cuda.synchronize()
+
+    ref = logits[:, :VOCAB].float().argmax(dim=-1).cpu()
+    got = out.squeeze(1).cpu()
+    ok = True
+    for row in range(BATCH):
+        pad_beats_real = logits[row, VOCAB:].max() > logits[row, :VOCAB].max()
+        status = "ok" if got[row] == ref[row] else "FAILED"
+        print(f"[row {row}] expected {ref[row].item()} got {got[row].item()} "
+              f"(pad region max beats real max: {pad_beats_real}) {status}")
+        if not pad_beats_real:
+            print(f"[row {row}] FAILED: case is not adversarial")
+            ok = False
+        if got[row].item() >= VOCAB:
+            print(f"[row {row}] FAILED: returned a padding-row token id")
+            ok = False
+        if got[row] != ref[row] or ref[row].item() != WINNERS[row]:
+            ok = False
+
+    print("PASSED" if ok else "FAILED")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Revert #755, which makes `mpk-qwen-ci` fail deterministically.
- Fix the underlying bug in the argmax task instead: reduce only over positions below the real vocab size.
- Add a test-mode regression test for the padded-lm_head case.

## Why #755 cannot work

The Qwen3 demos pad `lm_head` from `vocab_size` to 153600 rows so the partial-task grid divides evenly. `argmax_partial` reduced over the whole padded width, so a padding row could win and emit a token id `>= vocab_size` (#751 #752).

#755 tried to fix this by filling the padding **weight rows** with `-1e4`. But a padding logit is `dot(x, w_pad)`, linear in the hidden state, so a constant fill flips sign with the hidden state:

```
padding logit = dot(x, [-1e4, ..., -1e4]) = -1e4 * sum(x)
```

Whenever `sum(x) < 0` — roughly half of all decode steps — that is a huge **positive** value and argmax always picks a padding row. This is far more frequent than the all-negative-logits case #755 set out to fix. No constant weight row can give an always-negative logit, so the fix does not belong in the weight padding.

## The fix

Bound the reduction itself. `argmax_partial_kernel` / `argmax_partial_sm100_kernel` take a `VOCAB_SIZE` template argument and each task its own `chunk_start`, then reduce over `min(CHUNK_SIZE, VOCAB_SIZE - chunk_start)`. Positions at or after `vocab_size` never enter the reduction, so no padding value can win regardless of what the pad rows hold.

- `chunk_start` comes from `task_desc->task_metadata.task_offset * num_elements`, with `task_offset = bid.x` (the vocab-partitioning grid dimension) set in `runtime.cc`.
- `argmax_partial_layer(..., vocab_size=...)` passes the real vocab size as an optional `params[1]`.
- Both the template argument and the chunk offset default to the previous behaviour, so callers that do not pass `vocab_size` (llama3, deepseek_v3, glm4_moe, gpt_oss, dflash, inkling, eagle3, and the test wrapper) are unaffected.

## Validation

Run locally on a B200 with Qwen3-8B.

Differential test of #755, before vs after, same CI steps:

| | before #755 (`aa3ac171`) | at #755 (`176042f5`) |
|---|---|---|
| Torch vs MPK token comparison | pass | **fail** at position 0: `torch=151667`, `mpk=151968`; 63 of 100 MPK tokens are padding-row ids |

This matches the upstream CI history: green at `b5d01ab0`, failing from `33f35d12` onward, still failing at `cd91162b`.

With this PR, both `mpk-qwen-ci` steps pass:

- `tests/ci-tests/run_ci_tests_qwen3.sh`: `1 passed`, torch and MPK identical over the first 50 tokens, 4.03 ms/token, 7.23x over torch.
- Batch perf `r=1/2/4/8`: 225.5 / 450.1 / 896.2 / 1760.3 tokens/s, matching the pre-#755 baseline (227 / 453 / 821 / 1770) within noise, so the bound costs nothing.

New test `tests/runtime_python/test_mode/test_argmax_vocab_bound_testmode.py` builds logits where every real logit is negative and the pad region holds 0.0, covering an in-chunk winner, a chunk that straddles `vocab_size`, the last real position (151935), and a mid-vocab winner. It returns padding-row ids without the bound and the correct ids with it, and asserts each case is actually adversarial so it cannot silently degrade into a test that always passes.

## Note

`demo_sampling.py`'s `sampling_sm100_layer` is a separate token-selection path that still reduces over the padded width, so the same padding issue applies there. Left for a follow-up to keep this PR to one topic.

Fixes #751 #752

🤖 Generated with [Claude Code](https://claude.com/claude-code)