### PR TITLE
fix: use next_iter_len for Ampere K/V prefetch (#698)

### DIFF
--- a/include/mirage/persistent_kernel/tasks/ampere/multitoken_paged_attention_32_64.cuh
+++ b/include/mirage/persistent_kernel/tasks/ampere/multitoken_paged_attention_32_64.cuh
@@ -322,9 +322,11 @@ __device__ __forceinline__ void multitoken_paged_attention_task_impl_32_64(
                             : 0;
     if (next_iter_len > 0) {
       int page_idx = page_indices[cp_finished_seq_len / PAGE_SIZE];
+      // Prefetch bound must be next_iter_len (tile being loaded), not
+      // curr_iter_len (tile being consumed). Same bug as #698 / #692.
 #pragma unroll
       for (int chunk_idx = threadIdx.x;
-           chunk_idx < curr_iter_len * HEAD_DIM_COPY_ITER;
+           chunk_idx < next_iter_len * HEAD_DIM_COPY_ITER;
            chunk_idx += NUM_THREADS) {
         int dst_row = chunk_idx / HEAD_DIM_COPY_ITER;
         int col = (chunk_idx % HEAD_DIM_COPY_ITER) * CP_CHUNK_SIZE;

--- a/include/mirage/persistent_kernel/tasks/ampere/multitoken_paged_attention_32_64_split_kv.cuh
+++ b/include/mirage/persistent_kernel/tasks/ampere/multitoken_paged_attention_32_64_split_kv.cuh
@@ -382,9 +382,11 @@ __device__ __forceinline__ void
       int page_idx =
           page_indices[(cp_finished_seq_len + kv_cache_offset) / PAGE_SIZE];
 
+      // Prefetch bound must be next_iter_len (tile being loaded), not
+      // curr_iter_len (tile being consumed). Same bug as #698 / #692.
 #pragma unroll
       for (int chunk_idx = threadIdx.x;
-           chunk_idx < curr_iter_len * HEAD_DIM_COPY_ITER;
+           chunk_idx < next_iter_len * HEAD_DIM_COPY_ITER;
            chunk_idx += NUM_THREADS) {
         int dst_row = chunk_idx / HEAD_DIM_COPY_ITER;
         int col = (chunk_idx % HEAD_DIM_COPY_ITER) * CP_CHUNK_SIZE;

--- a/include/mirage/persistent_kernel/tasks/ampere/multitoken_paged_attention_4_16.cuh
+++ b/include/mirage/persistent_kernel/tasks/ampere/multitoken_paged_attention_4_16.cuh
@@ -309,9 +309,11 @@ __device__ __forceinline__ void multitoken_paged_attention_task_impl_4_16(
                             : 0;
     if (next_iter_len > 0) {
       int page_idx = page_indices[cp_finished_seq_len / PAGE_SIZE];
+      // Prefetch bound must be next_iter_len (tile being loaded), not
+      // curr_iter_len (tile being consumed). Same bug as #698 / #692.
 #pragma unroll
       for (int chunk_idx = threadIdx.x;
-           chunk_idx < curr_iter_len * HEAD_DIM / CP_CHUNK_SIZE;
+           chunk_idx < next_iter_len * HEAD_DIM / CP_CHUNK_SIZE;
            chunk_idx += NUM_THREADS) {
         int dst_row = chunk_idx / (HEAD_DIM / CP_CHUNK_SIZE);
         int col = (chunk_idx % (HEAD_DIM / CP_CHUNK_SIZE)) * CP_CHUNK_SIZE;

--- a/include/mirage/persistent_kernel/tasks/ampere/multitoken_paged_attention_4_16_split_kv.cuh
+++ b/include/mirage/persistent_kernel/tasks/ampere/multitoken_paged_attention_4_16_split_kv.cuh
@@ -339,9 +339,11 @@ __device__ __forceinline__ void
     if (next_iter_len > 0) {
       int page_idx =
           page_indices[(cp_finished_seq_len + kv_cache_offset) / PAGE_SIZE];
+      // Prefetch bound must be next_iter_len (tile being loaded), not
+      // curr_iter_len (tile being consumed). Same bug as #698 / #692.
 #pragma unroll
       for (int chunk_idx = threadIdx.x;
-           chunk_idx < curr_iter_len * HEAD_DIM / CP_CHUNK_SIZE;
+           chunk_idx < next_iter_len * HEAD_DIM / CP_CHUNK_SIZE;
            chunk_idx += NUM_THREADS) {
         int dst_row = chunk_idx / (HEAD_DIM / CP_CHUNK_SIZE);
         int col = (chunk_idx % (HEAD_DIM / CP_CHUNK_SIZE)) * CP_CHUNK_SIZE;

--- a/include/mirage/persistent_kernel/tasks/blackwell/attention_sm100.cuh
+++ b/include/mirage/persistent_kernel/tasks/blackwell/attention_sm100.cuh
@@ -315,11 +315,9 @@ __device__ __forceinline__ void multitoken_paged_attention_sm100_task_impl(
                               : 0;
       if (next_iter_len > 0) {
         int page_idx = page_indices[cp_finished_seq_len / PAGE_SIZE];
-        // FIX: loop bound was `curr_iter_len` (stale first-iter value); should
-        // be `next_iter_len` (the tile being loaded). The original OOB-read
-        // QKV input for `dst_row >= next_iter_len`, which lands in
-        // unmapped memory at higher mbt values → illegal access. See plan
-        // /home/letianr/.claude/plans/mpk-eagle3-k-greater-than-1-chain-flow.md
+        // Prefetch bound must be next_iter_len (tile being loaded), not
+        // curr_iter_len (tile being consumed). Using the stale first-iter
+        // length OOBs into QKV when next_iter_len < curr_iter_len (#698/#692).
 #pragma unroll
         for (int chunk_idx = threadIdx.x;
              chunk_idx < next_iter_len * HEAD_DIM / CP_CHUNK_SIZE;


### PR DESCRIPTION
SM100 already used the correct next_iter_len bound after #692, but the four Ampere multitoken paged-attention kernels still sized the next-tile K/V prefetch with curr_iter_len (the tile being consumed) instead of next_iter_len (the tile being loaded). This PR applies that same fix.

Linked Issues:
- Issue #698 

Issues closed by this PR:
- Closes #698 


